### PR TITLE
feat: add volume control for instruments

### DIFF
--- a/debug-ui/app/wasm-test.tsx
+++ b/debug-ui/app/wasm-test.tsx
@@ -9,6 +9,7 @@ export default function WasmTest() {
   const [isLoaded, setIsLoaded] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [volumes, setVolumes] = useState([1.0, 1.0, 1.0, 1.0]); // Volume for each instrument
 
   async function loadWasm() {
     setIsLoading(true);
@@ -137,6 +138,20 @@ export default function WasmTest() {
     }
   }
 
+  function handleVolumeChange(index: number, volume: number) {
+    if (!stageRef.current) return;
+    
+    // Update the WASM stage
+    stageRef.current.set_instrument_volume(index, volume);
+    
+    // Update local state for UI
+    setVolumes(prev => {
+      const newVolumes = [...prev];
+      newVolumes[index] = volume;
+      return newVolumes;
+    });
+  }
+
   return (
     <div className="p-8 max-w-lg mx-auto">
       <h1 className="text-2xl font-bold mb-6">WASM Stage API Test</h1>
@@ -202,6 +217,37 @@ export default function WasmTest() {
               🥽 Cymbal (600Hz)
             </button>
           </div>
+          
+          <div className="mt-6">
+            <h4 className="font-semibold mb-3 text-center">Volume Controls</h4>
+            <div className="space-y-3">
+              {[
+                { name: '🥁 Bass Drum', color: 'red' },
+                { name: '🥁 Snare', color: 'orange' },
+                { name: '🔔 Hi-hat', color: 'yellow' },
+                { name: '🥽 Cymbal', color: 'cyan' }
+              ].map((instrument, index) => (
+                <div key={index} className="flex items-center space-x-3">
+                  <label className="w-24 text-sm font-medium truncate" title={instrument.name}>
+                    {instrument.name}
+                  </label>
+                  <input
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.01"
+                    value={volumes[index]}
+                    onChange={(e) => handleVolumeChange(index, parseFloat(e.target.value))}
+                    disabled={!isLoaded}
+                    className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:cursor-not-allowed"
+                  />
+                  <span className="w-10 text-xs font-mono text-right">
+                    {volumes[index].toFixed(2)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
       
@@ -218,7 +264,8 @@ export default function WasmTest() {
           <li>• <strong>Multi-instrument</strong>: Stage contains 4 oscillators at different frequencies</li>
           <li>• <strong>Individual control</strong>: Trigger each instrument separately</li>
           <li>• <strong>Group control</strong>: Trigger all instruments simultaneously</li>
-          <li>• <strong>Audio mixing</strong>: Stage.tick() sums all instrument outputs</li>
+          <li>• <strong>Volume control</strong>: Adjust volume (0.0-1.0) for each instrument with sliders</li>
+          <li>• <strong>Audio mixing</strong>: Stage.tick() sums all instrument outputs with volume applied</li>
         </ul>
       </div>
 
@@ -228,7 +275,8 @@ export default function WasmTest() {
           <li>Click "Load Stage" to initialize the WASM Stage with 4 oscillators</li>
           <li>Click "Start Audio" to begin audio processing</li>
           <li>Use individual instrument buttons to test single oscillators</li>
-          <li>Use "Trigger All" to hear the mixed output of all instruments</li>
+          <li>Adjust volume sliders to control the relative volume of each instrument (0.0-1.0)</li>
+          <li>Use "Trigger All" to hear the mixed output of all instruments with volume applied</li>
         </ol>
       </div>
     </div>

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -72,5 +72,15 @@ pub mod web {
         pub fn trigger_instrument(&mut self, index: usize, time: f32) {
             self.stage.trigger_instrument(index, time);
         }
+
+        #[wasm_bindgen]
+        pub fn set_instrument_volume(&mut self, index: usize, volume: f32) {
+            self.stage.set_instrument_volume(index, volume);
+        }
+
+        #[wasm_bindgen]
+        pub fn get_instrument_volume(&self, index: usize) -> f32 {
+            self.stage.get_instrument_volume(index)
+        }
     }
 } 

--- a/lib/src/oscillator.rs
+++ b/lib/src/oscillator.rs
@@ -7,6 +7,7 @@ pub struct Oscillator {
     pub current_sample_index: f32,
     pub frequency_hz: f32,
     pub envelope: Envelope,
+    pub volume: f32, // Volume from 0.0 to 1.0
 }
 
 impl Oscillator {
@@ -17,6 +18,7 @@ impl Oscillator {
             current_sample_index: 0.0,
             frequency_hz,
             envelope: Envelope::new(),
+            volume: 1.0, // Default to full volume
         }
     }
 
@@ -65,6 +67,10 @@ impl Oscillator {
     pub fn trigger(&mut self, time: f32) {
         self.envelope.trigger(time);
     }
+    
+    pub fn set_volume(&mut self, volume: f32) {
+        self.volume = volume.clamp(0.0, 1.0);
+    }
 
     pub fn tick(&mut self, current_time: f32) -> f32 {
         let raw_output = match self.waveform {
@@ -74,6 +80,6 @@ impl Oscillator {
             Waveform::Triangle => self.triangle_wave(),
         };
         let envelope_amplitude = self.envelope.get_amplitude(current_time);
-        raw_output * envelope_amplitude
+        raw_output * envelope_amplitude * self.volume
     }
 } 

--- a/lib/src/stage.rs
+++ b/lib/src/stage.rs
@@ -38,4 +38,18 @@ impl Stage {
             instrument.trigger(time);
         }
     }
+    
+    pub fn set_instrument_volume(&mut self, index: usize, volume: f32) {
+        if let Some(instrument) = self.instruments.get_mut(index) {
+            instrument.set_volume(volume);
+        }
+    }
+    
+    pub fn get_instrument_volume(&self, index: usize) -> f32 {
+        if let Some(instrument) = self.instruments.get(index) {
+            instrument.volume
+        } else {
+            0.0
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Added volume control (0.0-1.0) for each instrument in the Stage
- Implemented basic summing algorithm with volume applied per instrument
- Added volume slider controls in WASM debug UI

## Test plan
- [ ] Build WASM module: `npm run wasm:build` in debug-ui directory
- [ ] Test volume sliders in debug UI work correctly
- [ ] Verify each instrument volume can be controlled independently
- [ ] Confirm volume settings affect audio output when triggering instruments

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)