### PR TITLE
Add frequency and waveform controls

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -82,5 +82,38 @@ pub mod web {
         pub fn get_instrument_volume(&self, index: usize) -> f32 {
             self.stage.get_instrument_volume(index)
         }
+
+        #[wasm_bindgen]
+        pub fn set_instrument_frequency(&mut self, index: usize, frequency_hz: f32) {
+            self.stage.set_instrument_frequency(index, frequency_hz);
+        }
+
+        #[wasm_bindgen]
+        pub fn get_instrument_frequency(&self, index: usize) -> f32 {
+            self.stage.get_instrument_frequency(index)
+        }
+
+        #[wasm_bindgen]
+        pub fn set_instrument_waveform(&mut self, index: usize, waveform_type: u32) {
+            let waveform = match waveform_type {
+                0 => crate::waveform::Waveform::Sine,
+                1 => crate::waveform::Waveform::Square,
+                2 => crate::waveform::Waveform::Saw,
+                3 => crate::waveform::Waveform::Triangle,
+                _ => crate::waveform::Waveform::Sine, // Default to sine for invalid values
+            };
+            self.stage.set_instrument_waveform(index, waveform);
+        }
+
+        #[wasm_bindgen]
+        pub fn get_instrument_waveform(&self, index: usize) -> u32 {
+            let waveform = self.stage.get_instrument_waveform(index);
+            match waveform {
+                crate::waveform::Waveform::Sine => 0,
+                crate::waveform::Waveform::Square => 1,
+                crate::waveform::Waveform::Saw => 2,
+                crate::waveform::Waveform::Triangle => 3,
+            }
+        }
     }
 } 

--- a/lib/src/stage.rs
+++ b/lib/src/stage.rs
@@ -56,6 +56,34 @@ impl Stage {
         }
     }
 
+    pub fn set_instrument_frequency(&mut self, index: usize, frequency_hz: f32) {
+        if let Some(instrument) = self.instruments.get_mut(index) {
+            instrument.frequency_hz = frequency_hz;
+        }
+    }
+
+    pub fn get_instrument_frequency(&self, index: usize) -> f32 {
+        if let Some(instrument) = self.instruments.get(index) {
+            instrument.frequency_hz
+        } else {
+            0.0
+        }
+    }
+
+    pub fn set_instrument_waveform(&mut self, index: usize, waveform: crate::waveform::Waveform) {
+        if let Some(instrument) = self.instruments.get_mut(index) {
+            instrument.waveform = waveform;
+        }
+    }
+
+    pub fn get_instrument_waveform(&self, index: usize) -> crate::waveform::Waveform {
+        if let Some(instrument) = self.instruments.get(index) {
+            instrument.waveform
+        } else {
+            crate::waveform::Waveform::Sine
+        }
+    }
+
     /// Set the limiter threshold (typically 0.0 to 1.0)
     pub fn set_limiter_threshold(&mut self, threshold: f32) {
         self.limiter.threshold = threshold;

--- a/lib/src/waveform.rs
+++ b/lib/src/waveform.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, Clone, Copy)]
 pub enum Waveform {
     Sine,
     Square,


### PR DESCRIPTION
Adds controls to modify the waveform type and frequency of each instrument on the stage.

## Changes
- Added frequency and waveform setter/getter methods to Stage
- Updated WASM bindings to expose new controls
- Added frequency sliders (50-2000Hz) and waveform dropdowns to UI
- Reorganized instrument controls into individual panels

Closes #12

Generated with [Claude Code](https://claude.ai/code)