### PR TITLE
feat: add enable/disable toggle for individual instruments

### DIFF
--- a/debug-ui/app/wasm-test.tsx
+++ b/debug-ui/app/wasm-test.tsx
@@ -12,6 +12,7 @@ export default function WasmTest() {
   const [volumes, setVolumes] = useState([1.0, 1.0, 1.0, 1.0]); // Volume for each instrument
   const [frequencies, setFrequencies] = useState([200, 300, 440, 600]); // Frequency for each instrument
   const [waveforms, setWaveforms] = useState([1, 1, 1, 1]); // Waveform for each instrument (0=Sine, 1=Square, 2=Saw, 3=Triangle)
+  const [enabled, setEnabled] = useState([true, true, true, true]); // Enabled state for each instrument
   const [adsrValues, setAdsrValues] = useState([
     { attack: 0.01, decay: 0.1, sustain: 0.7, release: 0.3 }, // Bass Drum
     { attack: 0.001, decay: 0.05, sustain: 0.3, release: 0.1 }, // Snare
@@ -211,6 +212,20 @@ export default function WasmTest() {
     });
   }
 
+  function handleEnabledChange(index: number, isEnabled: boolean) {
+    if (!stageRef.current) return;
+    
+    // Update the WASM stage
+    stageRef.current.set_instrument_enabled(index, isEnabled);
+    
+    // Update local state for UI
+    setEnabled(prev => {
+      const newEnabled = [...prev];
+      newEnabled[index] = isEnabled;
+      return newEnabled;
+    });
+  }
+
   function releaseInstrument(index: number, name: string) {
     if (!audioContextRef.current || !stageRef.current) {
       alert('Audio not started yet. Click "Start Audio" first.');
@@ -319,7 +334,20 @@ export default function WasmTest() {
                 { name: '🥽 Cymbal', color: 'cyan' }
               ].map((instrument, index) => (
                 <div key={index} className="p-3 bg-gray-800 rounded-lg border border-gray-700">
-                  <h5 className="font-medium mb-2 text-sm">{instrument.name}</h5>
+                  <div className="flex items-center justify-between mb-2">
+                    <h5 className="font-medium text-sm">{instrument.name}</h5>
+                    <button
+                      onClick={() => handleEnabledChange(index, !enabled[index])}
+                      disabled={!isLoaded}
+                      className={`px-3 py-1 text-xs font-medium rounded transition-colors disabled:cursor-not-allowed ${
+                        enabled[index]
+                          ? 'bg-green-600 text-white hover:bg-green-700 disabled:bg-gray-600'
+                          : 'bg-red-600 text-white hover:bg-red-700 disabled:bg-gray-600'
+                      }`}
+                    >
+                      {enabled[index] ? '🔊 ON' : '🔇 OFF'}
+                    </button>
+                  </div>
                   
                   {/* Volume Control */}
                   <div className="flex items-center space-x-2 mb-2">
@@ -488,6 +516,7 @@ export default function WasmTest() {
           <li>• <strong>Multi-instrument</strong>: Stage contains 4 oscillators with independent controls</li>
           <li>• <strong>Individual control</strong>: Trigger each instrument separately</li>
           <li>• <strong>Group control</strong>: Trigger all instruments simultaneously</li>
+          <li>• <strong>Enable/disable</strong>: Toggle instruments on/off to mute/unmute individual instruments</li>
           <li>• <strong>Volume control</strong>: Adjust volume (0.0-1.0) for each instrument</li>
           <li>• <strong>Frequency control</strong>: Adjust frequency (50-2000Hz) for each instrument</li>
           <li>• <strong>Waveform control</strong>: Select waveform type (Sine, Square, Saw, Triangle) for each instrument</li>
@@ -505,6 +534,7 @@ export default function WasmTest() {
           <li>Use individual instrument buttons to test single oscillators</li>
           <li>Adjust instrument controls for each oscillator:</li>
           <ul className="list-disc list-inside ml-4 text-xs space-y-0.5 text-yellow-200">
+            <li><strong>Enable/Disable:</strong> Click ON/OFF button to mute/unmute individual instruments</li>
             <li><strong>Volume:</strong> Control relative volume of each instrument (0.0-1.0)</li>
             <li><strong>Frequency:</strong> Change the pitch of each instrument (50-2000Hz)</li>
             <li><strong>Waveform:</strong> Select tone quality (Sine, Square, Saw, Triangle)</li>

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -143,5 +143,15 @@ pub mod web {
                 crate::waveform::Waveform::Triangle => 3,
             }
         }
+
+        #[wasm_bindgen]
+        pub fn set_instrument_enabled(&mut self, index: usize, enabled: bool) {
+            self.stage.set_instrument_enabled(index, enabled);
+        }
+
+        #[wasm_bindgen]
+        pub fn is_instrument_enabled(&self, index: usize) -> bool {
+            self.stage.is_instrument_enabled(index)
+        }
     }
 } 

--- a/lib/src/oscillator.rs
+++ b/lib/src/oscillator.rs
@@ -8,6 +8,7 @@ pub struct Oscillator {
     pub frequency_hz: f32,
     pub envelope: Envelope,
     pub volume: f32,
+    pub enabled: bool,
 }
 
 impl Oscillator {
@@ -19,6 +20,7 @@ impl Oscillator {
             frequency_hz,
             envelope: Envelope::new(),
             volume: 1.0,
+            enabled: true,
         }
     }
 
@@ -80,7 +82,18 @@ impl Oscillator {
         self.envelope.set_config(config);
     }
 
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
     pub fn tick(&mut self, current_time: f32) -> f32 {
+        if !self.enabled {
+            return 0.0;
+        }
         let raw_output = match self.waveform {
             Waveform::Sine => self.sine_wave(),
             Waveform::Square => self.square_wave(),

--- a/lib/src/stage.rs
+++ b/lib/src/stage.rs
@@ -103,6 +103,20 @@ impl Stage {
         }
     }
 
+    pub fn set_instrument_enabled(&mut self, index: usize, enabled: bool) {
+        if let Some(instrument) = self.instruments.get_mut(index) {
+            instrument.set_enabled(enabled);
+        }
+    }
+
+    pub fn is_instrument_enabled(&self, index: usize) -> bool {
+        if let Some(instrument) = self.instruments.get(index) {
+            instrument.is_enabled()
+        } else {
+            false
+        }
+    }
+
     /// Set the limiter threshold (typically 0.0 to 1.0)
     pub fn set_limiter_threshold(&mut self, threshold: f32) {
         self.limiter.threshold = threshold;


### PR DESCRIPTION
This PR adds a simple toggle button to enable or disable instruments from making sound, as requested in issue #22.

## Changes:
- Added `enabled` field to Oscillator struct (defaults to true)
- Modified tick() method to return 0.0 when instrument is disabled
- Added set_instrument_enabled() and is_instrument_enabled() methods to Stage
- Added WASM bindings for new enable/disable functionality
- Added toggle buttons in debug-ui with visual state indicators
- Updated documentation to include new enable/disable feature

Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)