### PR TITLE
fix: resolve sub tone issue in tom drum

### DIFF
--- a/lib/src/tom.rs
+++ b/lib/src/tom.rs
@@ -101,7 +101,7 @@ impl TomDrum {
         self.tonal_oscillator.set_adsr(ADSRConfig::new(
             0.001,                    // Very fast attack
             config.decay_time * 0.9,  // Main decay
-            0.1,                      // Low sustain for drum character
+            0.0,                      // No sustain - drums should decay to silence
             config.decay_time * 0.3,  // Medium release
         ));
 


### PR DESCRIPTION
Fixes #42

This PR resolves the sub tone issue in the tom drum where the tonal oscillator continued playing after the envelope completed.

## Root Cause
The tom drum's tonal oscillator had a sustain level of 0.1 (10%) which meant it continued playing at low volume indefinitely until explicitly released.

## Changes
- Set tom drum tonal oscillator sustain to 0.0 instead of 0.1
- This ensures drum sounds naturally decay to silence without requiring explicit release calls
- Matches the fix pattern previously applied to snare drum

Note: Kick drum was already properly configured with sustain levels of 0.0.

Generated with [Claude Code](https://claude.ai/code)