### PR TITLE
Add CLI examples for kick, snare, and hihat drums

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,3 +23,15 @@ web-sys = { version = "0.3", optional = true, features = ["AudioContext"] }
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["AudioContext"] }
+
+[[example]]
+name = "kick"
+required-features = ["native"]
+
+[[example]]
+name = "snare"
+required-features = ["native"]
+
+[[example]]
+name = "hihat"
+required-features = ["native"]

--- a/lib/examples/hihat.rs
+++ b/lib/examples/hihat.rs
@@ -1,0 +1,55 @@
+/* CLI example for hi-hat testing.
+Minimal code to start the audio engine and trigger hi-hat hits.
+*/
+
+use std::io::{self, Write};
+
+// Import the platform abstraction and audio engine
+use oscillator::platform::{AudioEngine, AudioOutput, CpalOutput};
+
+// CLI example for hi-hat
+#[cfg(feature = "native")]
+fn main() -> anyhow::Result<()> {
+    // Create the audio engine
+    let audio_engine = AudioEngine::new(44100.0);
+
+    // Create and configure the CPAL output
+    let mut cpal_output = CpalOutput::new();
+    cpal_output.initialize(44100.0)?;
+    cpal_output.create_stream_with_stage(audio_engine.stage(), audio_engine.audio_state())?;
+
+    // Start the audio stream
+    cpal_output.start()?;
+
+    println!("=== Hi-Hat Example ===");
+    println!("Press SPACE to trigger hi-hat, 'q' to quit");
+
+    // Main input loop
+    loop {
+        let mut input = String::new();
+        io::stdout().flush().unwrap();
+        io::stdin().read_line(&mut input).unwrap();
+
+        match input.trim() {
+            " " | "" => {
+                println!("Triggering hi-hat!");
+                let mut stage = audio_engine.stage_mut();
+                stage.trigger_hihat();
+            }
+            "q" => {
+                println!("Quitting...");
+                break;
+            }
+            _ => {
+                println!("Press SPACE to trigger hi-hat, 'q' to quit");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "native"))]
+fn main() {
+    println!("This example is only available with the 'native' feature enabled.");
+}

--- a/lib/examples/kick.rs
+++ b/lib/examples/kick.rs
@@ -1,0 +1,55 @@
+/* CLI example for kick drum testing.
+Minimal code to start the audio engine and trigger kick drum hits.
+*/
+
+use std::io::{self, Write};
+
+// Import the platform abstraction and audio engine
+use oscillator::platform::{AudioEngine, AudioOutput, CpalOutput};
+
+// CLI example for kick drum
+#[cfg(feature = "native")]
+fn main() -> anyhow::Result<()> {
+    // Create the audio engine
+    let audio_engine = AudioEngine::new(44100.0);
+
+    // Create and configure the CPAL output
+    let mut cpal_output = CpalOutput::new();
+    cpal_output.initialize(44100.0)?;
+    cpal_output.create_stream_with_stage(audio_engine.stage(), audio_engine.audio_state())?;
+
+    // Start the audio stream
+    cpal_output.start()?;
+
+    println!("=== Kick Drum Example ===");
+    println!("Press SPACE to trigger kick drum, 'q' to quit");
+
+    // Main input loop
+    loop {
+        let mut input = String::new();
+        io::stdout().flush().unwrap();
+        io::stdin().read_line(&mut input).unwrap();
+
+        match input.trim() {
+            " " | "" => {
+                println!("Triggering kick drum!");
+                let mut stage = audio_engine.stage_mut();
+                stage.trigger_kick();
+            }
+            "q" => {
+                println!("Quitting...");
+                break;
+            }
+            _ => {
+                println!("Press SPACE to trigger kick drum, 'q' to quit");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "native"))]
+fn main() {
+    println!("This example is only available with the 'native' feature enabled.");
+}

--- a/lib/examples/snare.rs
+++ b/lib/examples/snare.rs
@@ -1,0 +1,55 @@
+/* CLI example for snare drum testing.
+Minimal code to start the audio engine and trigger snare drum hits.
+*/
+
+use std::io::{self, Write};
+
+// Import the platform abstraction and audio engine
+use oscillator::platform::{AudioEngine, AudioOutput, CpalOutput};
+
+// CLI example for snare drum
+#[cfg(feature = "native")]
+fn main() -> anyhow::Result<()> {
+    // Create the audio engine
+    let audio_engine = AudioEngine::new(44100.0);
+
+    // Create and configure the CPAL output
+    let mut cpal_output = CpalOutput::new();
+    cpal_output.initialize(44100.0)?;
+    cpal_output.create_stream_with_stage(audio_engine.stage(), audio_engine.audio_state())?;
+
+    // Start the audio stream
+    cpal_output.start()?;
+
+    println!("=== Snare Drum Example ===");
+    println!("Press SPACE to trigger snare drum, 'q' to quit");
+
+    // Main input loop
+    loop {
+        let mut input = String::new();
+        io::stdout().flush().unwrap();
+        io::stdin().read_line(&mut input).unwrap();
+
+        match input.trim() {
+            " " | "" => {
+                println!("Triggering snare drum!");
+                let mut stage = audio_engine.stage_mut();
+                stage.trigger_snare();
+            }
+            "q" => {
+                println!("Quitting...");
+                break;
+            }
+            _ => {
+                println!("Press SPACE to trigger snare drum, 'q' to quit");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "native"))]
+fn main() {
+    println!("This example is only available with the 'native' feature enabled.");
+}


### PR DESCRIPTION
Add CLI examples for individual drum testing

- Add kick.rs example for kick drum testing
- Add snare.rs example for snare drum testing
- Add hihat.rs example for hi-hat testing
- Update Cargo.toml with example configurations
- Each example provides simple SPACE to trigger, 'q' to quit interface

Run with: cargo run --example [kick|snare|hihat] --features native

Closes #78

Generated with [Claude Code](https://claude.ai/code)