### PR TITLE
Expose limiter threshold parameter via FFI

### DIFF
--- a/src/effects/limiter.rs
+++ b/src/effects/limiter.rs
@@ -39,6 +39,16 @@ impl SoftLimiter {
             inv_threshold: 1.0 / threshold,
         }
     }
+
+    pub fn set_threshold(&mut self, threshold: f32) {
+        let threshold = threshold.clamp(0.001, 1.0);
+        self.threshold = threshold;
+        self.inv_threshold = 1.0 / threshold;
+    }
+
+    pub fn get_threshold(&self) -> f32 {
+        self.threshold
+    }
 }
 
 impl Effect for SoftLimiter {

--- a/src/effects/limiter.rs
+++ b/src/effects/limiter.rs
@@ -41,6 +41,9 @@ impl SoftLimiter {
     }
 
     pub fn set_threshold(&mut self, threshold: f32) {
+        if !threshold.is_finite() {
+            return;
+        }
         let threshold = threshold.clamp(0.001, 1.0);
         self.threshold = threshold;
         self.inv_threshold = 1.0 / threshold;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1033,6 +1033,13 @@ pub const EFFECT_COMPRESSOR: u32 = 3;
 pub const EFFECT_TILT_FILTER: u32 = 4;
 /// Global effect: Limiter (soft limiter, protects output from clipping)
 pub const EFFECT_LIMITER: u32 = 5;
+
+// =============================================================================
+// Limiter parameter indices (must match Swift LimiterParam enum)
+// =============================================================================
+
+/// Limiter parameter: threshold (0.001-1.0)
+pub const LIMITER_PARAM_THRESHOLD: u32 = 0;
 /// Global effect: Spring reverb
 pub const EFFECT_REVERB: u32 = 6;
 /// Total number of global effects
@@ -2193,6 +2200,8 @@ pub unsafe extern "C" fn gooey_engine_load_bass_preset(engine: *mut GooeyEngine,
 ///   - COMPRESSOR_PARAM_ATTACK (2): 0.1-100.0 ms
 ///   - COMPRESSOR_PARAM_RELEASE (3): 5.0-1000.0 ms
 ///   - COMPRESSOR_PARAM_MIX (4): 0.0-1.0
+/// - EFFECT_LIMITER (5):
+///   - LIMITER_PARAM_THRESHOLD (0): 0.001-1.0
 ///
 /// # Safety
 /// `engine` must be a valid pointer returned by `gooey_engine_new`
@@ -2249,6 +2258,10 @@ pub unsafe extern "C" fn gooey_engine_set_global_effect_param(
             REVERB_PARAM_DECAY => engine.reverb.set_decay(value),
             REVERB_PARAM_MIX => engine.reverb.set_mix(value),
             REVERB_PARAM_DAMPING => engine.reverb.set_damping(value),
+            _ => {} // Unknown parameter, ignore
+        },
+        EFFECT_LIMITER => match param {
+            LIMITER_PARAM_THRESHOLD => engine.limiter.set_threshold(value),
             _ => {} // Unknown parameter, ignore
         },
         _ => {} // Unknown effect, ignore
@@ -2317,6 +2330,10 @@ pub unsafe extern "C" fn gooey_engine_get_global_effect_param(
             REVERB_PARAM_DECAY => engine.reverb.get_decay(),
             REVERB_PARAM_MIX => engine.reverb.get_mix(),
             REVERB_PARAM_DAMPING => engine.reverb.get_damping(),
+            _ => -1.0, // Unknown parameter
+        },
+        EFFECT_LIMITER => match param {
+            LIMITER_PARAM_THRESHOLD => engine.limiter.get_threshold(),
             _ => -1.0, // Unknown parameter
         },
         _ => -1.0, // Unknown effect


### PR DESCRIPTION
## Summary
- Add `set_threshold` / `get_threshold` methods to `SoftLimiter` (clamped to 0.001–1.0)
- Add `LIMITER_PARAM_THRESHOLD` constant and wire it into the FFI set/get param functions
- The threshold was hardcoded to 1.0 where `tanh` saturation has negligible effect, making the limiter toggle inaudible

## Test plan
- [x] `cargo build` passes
- [x] All 161 tests pass
- [x] `cargo fmt --check` clean
- [ ] Verify in iOS UI that adjusting limiter threshold produces audible difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)