### PR TITLE
Apply hi-hat attack/decay LFO modulation mid-note

### DIFF
--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -676,8 +676,9 @@ fn resolve_parameter_alias(kind: Option<InstrumentKind>, parameter: &str) -> Str
             // exposed as LFO targets (they were baked at trigger time and
             // never re-read). Migrate them all to `tuning`, which provides
             // live kick pitch modulation.
-            "pitch_drop" | "pitch_env_amt" | "pitch_env_crv" | "pitch_ratio"
-            | "tuning_offset" => "tuning".to_string(),
+            "pitch_drop" | "pitch_env_amt" | "pitch_env_crv" | "pitch_ratio" | "tuning_offset" => {
+                "tuning".to_string()
+            }
             "osc_decay" => "oscillator_decay".to_string(),
             "phase_mod_amt" => "phase_mod_amount".to_string(),
             "noise_res" => "noise_resonance".to_string(),

--- a/src/instruments/hihat2.rs
+++ b/src/instruments/hihat2.rs
@@ -457,6 +457,11 @@ impl HiHat2 {
             return 0.0;
         }
 
+        self.envelope
+            .set_segment_duration_ms(0, self.params.attack_ms());
+        self.envelope
+            .set_segment_duration_ms(1, self.params.decay_ms());
+
         let pitch_hz = self.params.pitch_hz() * tuning_to_multiplier(self.params.tuning.get());
         let mod_freq = pitch_hz * 0.1;
         self.mod_osc.set_frequency(mod_freq);

--- a/src/max_curve.rs
+++ b/src/max_curve.rs
@@ -112,6 +112,13 @@ impl MaxCurveEnvelope {
         self.initial_value = value;
     }
 
+    /// Update the duration (in ms) of a specific segment.
+    pub fn set_segment_duration_ms(&mut self, index: usize, duration_ms: f32) {
+        if let Some(seg) = self.segments.get_mut(index) {
+            seg.duration_secs = (duration_ms / 1000.0).max(0.0);
+        }
+    }
+
     /// Trigger the envelope at the given time
     pub fn trigger(&mut self, time: f64) {
         self.is_active = true;

--- a/tests/dsl.rs
+++ b/tests/dsl.rs
@@ -61,7 +61,12 @@ fn lfo_hz_rate_and_offset_syntax() {
 fn legacy_kick_pitch_aliases_migrate_to_tuning() {
     // Programs written against the old kick pitch LFO targets must keep
     // building. All four historical pitch aliases now resolve to `tuning`.
-    for alias in ["pitch_drop", "pitch_env_amt", "pitch_env_crv", "pitch_ratio"] {
+    for alias in [
+        "pitch_drop",
+        "pitch_env_amt",
+        "pitch_env_crv",
+        "pitch_ratio",
+    ] {
         let src = format!("inst kick kick\nlfo 1bar kick.{} amt=1\n", alias);
         let program = Program::parse(&src).expect("parse");
         let engine = program

--- a/tests/lfo_modulation.rs
+++ b/tests/lfo_modulation.rs
@@ -289,71 +289,85 @@ fn audio_kick_pitch_targets_no_longer_modulatable() {
 }
 
 // ---------------------------------------------------------------------------
-// Trigger-time pickup tests for envelopes that can't be live-updated.
-//
-// HiHat2 uses MaxCurveEnvelope which has no live-update API, so attack/decay
-// modulation is intentionally trigger-time only. Tom2 stores decay as a plain
-// f32 and rebuilds its MaxCurveEnvelope at each trigger, so the same applies.
-// What we verify here is that the *next* trigger picks up the LFO-modulated
-// value, which is the documented contract for these instruments.
+// HiHat2 attack/decay LFO modulation. Like kick/snare, hihat now re-applies
+// MaxCurveEnvelope segment durations every tick so modulation is audible
+// both at trigger time and mid-note.
 // ---------------------------------------------------------------------------
 
-#[test]
-fn audio_hihat_attack_pickup_at_next_trigger() {
-    // Two identical hihat instances triggered with attack at -1 vs +1 should
-    // differ. The smoother for `attack` is read at trigger time.
-    fn render_hihat(attack_mod: f32) -> Vec<f32> {
-        let mut h = HiHat2::new(SR);
-        h.apply_modulation("attack", attack_mod).unwrap();
-        for _ in 0..2048 {
-            h.tick(0.0);
-        }
-        let mut out = Vec::with_capacity(RENDER_SAMPLES);
-        h.apply_modulation("attack", attack_mod).unwrap();
-        h.trigger_with_velocity(0.0, 1.0);
-        for i in 0..RENDER_SAMPLES {
-            h.apply_modulation("attack", attack_mod).unwrap();
-            let t = i as f64 / SR as f64;
-            out.push(h.tick(t));
-        }
-        out
+fn render_hihat_with_mod(param: &str, mod_value: f32) -> Vec<f32> {
+    let mut h = HiHat2::new(SR);
+    h.apply_modulation(param, mod_value).unwrap();
+    for _ in 0..2048 {
+        h.tick(0.0);
     }
+    h.trigger_with_velocity(0.0, 1.0);
+    let mut out = Vec::with_capacity(RENDER_SAMPLES);
+    for i in 0..RENDER_SAMPLES {
+        h.apply_modulation(param, mod_value).unwrap();
+        let t = i as f64 / SR as f64;
+        out.push(h.tick(t));
+    }
+    out
+}
 
-    let short = render_hihat(-1.0);
-    let long = render_hihat(1.0);
+#[test]
+fn audio_hihat_attack_lfo_changes_output() {
+    let short = render_hihat_with_mod("attack", -1.0);
+    let long = render_hihat_with_mod("attack", 1.0);
     let diff = mean_abs_diff(&short, &long);
     assert!(
         diff > DIFF_THRESHOLD,
-        "hihat attack LFO produced no audible change at next trigger (mean abs diff = {})",
+        "hihat attack LFO produced no audible change (mean abs diff = {})",
         diff
     );
 }
 
 #[test]
-fn audio_hihat_decay_pickup_at_next_trigger() {
-    fn render_hihat(decay_mod: f32) -> Vec<f32> {
+fn audio_hihat_decay_lfo_changes_output() {
+    let short = render_hihat_with_mod("decay", -1.0);
+    let long = render_hihat_with_mod("decay", 1.0);
+    let diff = mean_abs_diff(&short, &long);
+    assert!(
+        diff > DIFF_THRESHOLD,
+        "hihat decay LFO produced no audible change (mean abs diff = {})",
+        diff
+    );
+}
+
+#[test]
+fn audio_hihat_decay_lfo_changes_output_mid_note() {
+    // Specifically verify the fix: trigger first with no modulation, then
+    // start modulating decay only after the note is in flight. Output must
+    // diverge from a baseline that triggers identically with no modulation.
+    fn render(decay_mod_after_trigger: f32) -> Vec<f32> {
         let mut h = HiHat2::new(SR);
-        h.apply_modulation("decay", decay_mod).unwrap();
         for _ in 0..2048 {
             h.tick(0.0);
         }
-        let mut out = Vec::with_capacity(RENDER_SAMPLES);
-        h.apply_modulation("decay", decay_mod).unwrap();
         h.trigger_with_velocity(0.0, 1.0);
-        for i in 0..RENDER_SAMPLES {
-            h.apply_modulation("decay", decay_mod).unwrap();
+        // First few samples with no mod so trigger-time attack/decay match.
+        let mut out = Vec::with_capacity(RENDER_SAMPLES);
+        for i in 0..16 {
+            let t = i as f64 / SR as f64;
+            out.push(h.tick(t));
+        }
+        h.apply_modulation("decay", decay_mod_after_trigger)
+            .unwrap();
+        for i in 16..RENDER_SAMPLES {
+            h.apply_modulation("decay", decay_mod_after_trigger)
+                .unwrap();
             let t = i as f64 / SR as f64;
             out.push(h.tick(t));
         }
         out
     }
 
-    let short = render_hihat(-1.0);
-    let long = render_hihat(1.0);
-    let diff = mean_abs_diff(&short, &long);
+    let baseline = render(0.0);
+    let modulated = render(1.0);
+    let diff = mean_abs_diff(&baseline, &modulated);
     assert!(
         diff > DIFF_THRESHOLD,
-        "hihat decay LFO produced no audible change at next trigger (mean abs diff = {})",
+        "hihat decay LFO had no mid-note effect (mean abs diff = {})",
         diff
     );
 }


### PR DESCRIPTION
## Summary
- HiHat2 baked attack/decay into a `MaxCurveEnvelope` at trigger time and never re-read them, so LFO modulation of those params was silently inert (while pitch/tone/volume worked).
- Added `MaxCurveEnvelope::set_segment_duration_ms` and call it every tick from `HiHat2::tick`, mirroring how Kick/Snare keep their envelopes in sync with smoothed params.
- Replaced the trigger-time-only hihat tests with three audio-difference tests, including one that triggers first and applies modulation only after the note is in flight.
- Two unrelated whitespace-only fmt fixes in `src/dsl.rs` / `tests/dsl.rs` came along to satisfy `cargo fmt --all -- --check`.

## Test plan
- [x] `cargo build`
- [x] `cargo build --example kick --features native,crossterm`
- [x] `cargo test` (245 tests pass, including new `audio_hihat_attack_lfo_changes_output`, `audio_hihat_decay_lfo_changes_output`, `audio_hihat_decay_lfo_changes_output_mid_note`)
- [x] `cargo fmt --all -- --check`
- [ ] Audible check: route an LFO to hi-hat decay and confirm the tail length now modulates over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)