### PR TITLE
Allow users to reorder the global effects chain

### DIFF
--- a/src/effects/reverb.rs
+++ b/src/effects/reverb.rs
@@ -123,6 +123,18 @@ impl SpringReverbEffect {
     pub fn get_damping(&self) -> f32 {
         f32::from_bits(self.damping_target.load(Ordering::Relaxed))
     }
+
+    /// Reset reverb state (clear allpass buffers and feedback path)
+    pub fn reset(&self) {
+        // SAFETY: Called from main thread when reverb is not processing
+        let state = unsafe { &mut *self.state.get() };
+        for ap in state.allpasses.iter_mut() {
+            ap.buffer.fill(0.0);
+            ap.index = 0;
+        }
+        state.feedback_sample = 0.0;
+        state.damping_filter_state = 0.0;
+    }
 }
 
 impl Effect for SpringReverbEffect {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -507,7 +507,9 @@ pub struct GooeyEngine {
     // Per-channel sequencers (sample-accurate, synchronized)
     sequencers: [Sequencer; NUM_INSTRUMENTS],
 
-    /// Global effects (applied in order: saturation -> lowpass filter -> tilt filter -> delay -> compressor -> reverb -> limiter)
+    /// Global effects. Applied in the order described by `effect_order`,
+    /// followed by the limiter which is always last.
+    /// Default order: saturation -> lowpass filter -> tilt filter -> delay -> compressor -> reverb -> limiter.
     delay: DelayEffect,
     delay_enabled: bool,
     lowpass_filter: LowpassFilterEffect,
@@ -523,6 +525,10 @@ pub struct GooeyEngine {
     reverb_enabled: bool,
     limiter: SoftLimiter,
     limiter_enabled: bool,
+
+    /// Order in which the reorderable effects are applied. Stores `EFFECT_*`
+    /// IDs (excluding `EFFECT_LIMITER`, which is pinned at the end of the chain).
+    effect_order: [u32; REORDERABLE_EFFECT_COUNT as usize],
 
     // Engine state
     sample_rate: f32,
@@ -660,6 +666,7 @@ impl GooeyEngine {
             reverb_enabled: false,
             limiter: SoftLimiter::new(1.0),
             limiter_enabled: true,
+            effect_order: DEFAULT_EFFECT_ORDER,
             sample_rate,
             bpm,
             swing: 0.5,
@@ -840,37 +847,38 @@ impl GooeyEngine {
             // Mix in poly synth output
             output += self.poly_synth.tick(self.current_time);
 
-            // Apply global effects chain
-            if self.saturation_enabled {
-                output = self.saturation.process(output);
-            }
-            if self.lowpass_filter_enabled {
-                output = self.lowpass_filter.process(output);
-            }
-            if self.tilt_filter_enabled {
-                output = self.tilt_filter.process(output);
-            }
-            if self.delay_enabled {
-                output = self.delay.process(output);
+            // Apply global effects chain (order is user-configurable; limiter is always last)
+            for &effect_id in &self.effect_order {
+                match effect_id {
+                    EFFECT_SATURATION if self.saturation_enabled => {
+                        output = self.saturation.process(output);
+                    }
+                    EFFECT_LOWPASS_FILTER if self.lowpass_filter_enabled => {
+                        output = self.lowpass_filter.process(output);
+                    }
+                    EFFECT_TILT_FILTER if self.tilt_filter_enabled => {
+                        output = self.tilt_filter.process(output);
+                    }
+                    EFFECT_DELAY if self.delay_enabled => {
+                        output = self.delay.process(output);
+                    }
+                    EFFECT_COMPRESSOR if self.compressor_enabled => {
+                        let sc = self.compressor_sidechain as usize;
+                        output = if sc < NUM_INSTRUMENTS {
+                            self.compressor
+                                .process_with_sidechain(output, channel_outs[sc])
+                        } else {
+                            self.compressor.process(output)
+                        };
+                    }
+                    EFFECT_REVERB if self.reverb_enabled => {
+                        output = self.reverb.process(output);
+                    }
+                    _ => {}
+                }
             }
 
-            // Compressor (if enabled), with optional sidechain from individual channel
-            if self.compressor_enabled {
-                let sc = self.compressor_sidechain as usize;
-                output = if sc < NUM_INSTRUMENTS {
-                    self.compressor
-                        .process_with_sidechain(output, channel_outs[sc])
-                } else {
-                    self.compressor.process(output)
-                };
-            }
-
-            // Reverb (if enabled)
-            if self.reverb_enabled {
-                output = self.reverb.process(output);
-            }
-
-            // Limiter (protects output from clipping)
+            // Limiter (always last; protects output from clipping)
             if self.limiter_enabled {
                 *sample = self.limiter.process(output);
             } else {
@@ -905,6 +913,19 @@ impl GooeyEngine {
         if idx < NUM_INSTRUMENTS {
             self.blenders[idx].blend_and_apply(&mut self.channels[idx], x, y);
         }
+    }
+
+    /// Clear internal state of all reorderable effects so a new chain order
+    /// does not inherit stale buffers/envelopes from the previous routing.
+    /// Limiter is intentionally skipped — keeping its gain-reduction state
+    /// stable avoids transients on the protective output stage.
+    fn reset_effect_states(&self) {
+        self.saturation.reset();
+        self.lowpass_filter.reset();
+        self.tilt_filter.reset();
+        self.delay.reset();
+        self.compressor.reset();
+        self.reverb.reset();
     }
 
     /// Apply LFO modulation to a channel's instrument parameter by index
@@ -1044,6 +1065,21 @@ pub const LIMITER_PARAM_THRESHOLD: u32 = 0;
 pub const EFFECT_REVERB: u32 = 6;
 /// Total number of global effects
 pub const EFFECT_COUNT: u32 = 7;
+
+/// Number of reorderable effects in the chain. Excludes the limiter,
+/// which is pinned at the end of the chain (output-protection stage).
+pub const REORDERABLE_EFFECT_COUNT: u32 = 6;
+
+/// Default order for the reorderable effects, matching the historical
+/// hardcoded chain (saturation -> lowpass -> tilt -> delay -> compressor -> reverb).
+const DEFAULT_EFFECT_ORDER: [u32; REORDERABLE_EFFECT_COUNT as usize] = [
+    EFFECT_SATURATION,
+    EFFECT_LOWPASS_FILTER,
+    EFFECT_TILT_FILTER,
+    EFFECT_DELAY,
+    EFFECT_COMPRESSOR,
+    EFFECT_REVERB,
+];
 
 // =============================================================================
 // Lowpass filter parameter indices (must match Swift FilterParam enum)
@@ -3392,6 +3428,166 @@ pub extern "C" fn gooey_engine_instrument_count() -> u32 {
 #[no_mangle]
 pub extern "C" fn gooey_engine_global_effect_count() -> u32 {
     EFFECT_COUNT
+}
+
+// =============================================================================
+// Effect chain reordering
+// =============================================================================
+
+/// Get the number of reorderable effects in the chain.
+///
+/// The limiter is excluded — it is always pinned at the end of the chain
+/// as a protective output stage. Only the other effects can be reordered.
+#[no_mangle]
+pub extern "C" fn gooey_engine_reorderable_effect_count() -> u32 {
+    REORDERABLE_EFFECT_COUNT
+}
+
+/// Returns true iff `id` is a valid reorderable effect ID
+/// (any `EFFECT_*` constant except `EFFECT_LIMITER`).
+fn is_reorderable_effect(id: u32) -> bool {
+    matches!(
+        id,
+        EFFECT_LOWPASS_FILTER
+            | EFFECT_DELAY
+            | EFFECT_SATURATION
+            | EFFECT_COMPRESSOR
+            | EFFECT_TILT_FILTER
+            | EFFECT_REVERB
+    )
+}
+
+/// Set the full effect-chain order in one call.
+///
+/// `ids` must point to exactly `REORDERABLE_EFFECT_COUNT` u32 values, each a
+/// distinct reorderable effect ID (any of `EFFECT_LOWPASS_FILTER`,
+/// `EFFECT_DELAY`, `EFFECT_SATURATION`, `EFFECT_COMPRESSOR`,
+/// `EFFECT_TILT_FILTER`, `EFFECT_REVERB`). `EFFECT_LIMITER` is pinned at the
+/// end of the chain and must not appear in `ids`.
+///
+/// On success, the chain order is replaced and the internal state of every
+/// reorderable effect is reset (delay buffer, reverb tail, compressor envelope,
+/// filter poles) so a stale routing does not bleed into the new one.
+///
+/// Returns `true` on success. Returns `false` (leaving the chain unchanged) if
+/// `len != REORDERABLE_EFFECT_COUNT`, any ID is not reorderable, or any ID
+/// appears more than once.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`. `ids` must
+/// point to at least `len` u32 values. Caller must ensure the engine is not
+/// concurrently mutated from another thread.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_set_effect_order(
+    engine: *mut GooeyEngine,
+    ids: *const u32,
+    len: u32,
+) -> bool {
+    if engine.is_null() || ids.is_null() {
+        return false;
+    }
+    if len != REORDERABLE_EFFECT_COUNT {
+        return false;
+    }
+
+    let slice = std::slice::from_raw_parts(ids, len as usize);
+    let mut new_order = [0u32; REORDERABLE_EFFECT_COUNT as usize];
+    for (i, &id) in slice.iter().enumerate() {
+        if !is_reorderable_effect(id) {
+            return false;
+        }
+        if slice[..i].contains(&id) {
+            return false;
+        }
+        new_order[i] = id;
+    }
+
+    let engine = &mut *engine;
+    engine.effect_order = new_order;
+    engine.reset_effect_states();
+    true
+}
+
+/// Move a single effect to `new_position` (0-indexed within the reorderable
+/// section of the chain). Other effects shift to fill the gap, preserving
+/// their relative order.
+///
+/// On success, internal state of every reorderable effect is reset (see
+/// `gooey_engine_set_effect_order` for rationale).
+///
+/// Returns `false` (leaving the chain unchanged) if `effect_id` is not
+/// reorderable (e.g. `EFFECT_LIMITER`) or `new_position >=
+/// REORDERABLE_EFFECT_COUNT`.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`. Caller
+/// must ensure the engine is not concurrently mutated from another thread.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_move_effect(
+    engine: *mut GooeyEngine,
+    effect_id: u32,
+    new_position: u32,
+) -> bool {
+    if engine.is_null() {
+        return false;
+    }
+    if !is_reorderable_effect(effect_id) {
+        return false;
+    }
+    if new_position >= REORDERABLE_EFFECT_COUNT {
+        return false;
+    }
+
+    let engine = &mut *engine;
+    let Some(current_pos) = engine.effect_order.iter().position(|&id| id == effect_id) else {
+        return false;
+    };
+    let new_pos = new_position as usize;
+    if current_pos == new_pos {
+        return true;
+    }
+
+    if new_pos > current_pos {
+        // Shift left: elements (current_pos+1 ..= new_pos) move down by one.
+        for i in current_pos..new_pos {
+            engine.effect_order[i] = engine.effect_order[i + 1];
+        }
+    } else {
+        // Shift right: elements (new_pos .. current_pos) move up by one.
+        for i in (new_pos..current_pos).rev() {
+            engine.effect_order[i + 1] = engine.effect_order[i];
+        }
+    }
+    engine.effect_order[new_pos] = effect_id;
+    engine.reset_effect_states();
+    true
+}
+
+/// Read the current effect-chain order. Writes up to `max_len` IDs into
+/// `out_ids` in chain order (position 0 first, the limiter — always pinned
+/// last — is not written).
+///
+/// Returns the number of IDs written, which equals `REORDERABLE_EFFECT_COUNT`
+/// when `max_len` is large enough, or `max_len` otherwise. Returns `0` if
+/// `engine` or `out_ids` is null.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`. `out_ids`
+/// must point to a buffer of at least `max_len` u32 values.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_get_effect_order(
+    engine: *const GooeyEngine,
+    out_ids: *mut u32,
+    max_len: u32,
+) -> u32 {
+    if engine.is_null() || out_ids.is_null() || max_len == 0 {
+        return 0;
+    }
+    let engine = &*engine;
+    let n = (max_len as usize).min(engine.effect_order.len());
+    let dst = std::slice::from_raw_parts_mut(out_ids, n);
+    dst.copy_from_slice(&engine.effect_order[..n]);
+    n as u32
 }
 
 // =============================================================================

--- a/tests/effect_order.rs
+++ b/tests/effect_order.rs
@@ -1,0 +1,289 @@
+//! Integration tests for the reorderable global-effects chain.
+
+use gooey::ffi::*;
+
+const N: usize = REORDERABLE_EFFECT_COUNT as usize;
+
+fn read_order(engine: *mut GooeyEngine) -> [u32; N] {
+    let mut out = [0u32; N];
+    let written = unsafe { gooey_engine_get_effect_order(engine, out.as_mut_ptr(), N as u32) };
+    assert_eq!(written, REORDERABLE_EFFECT_COUNT);
+    out
+}
+
+#[test]
+fn default_order_matches_legacy_chain() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+
+        let order = read_order(engine);
+        assert_eq!(
+            order,
+            [
+                EFFECT_SATURATION,
+                EFFECT_LOWPASS_FILTER,
+                EFFECT_TILT_FILTER,
+                EFFECT_DELAY,
+                EFFECT_COMPRESSOR,
+                EFFECT_REVERB,
+            ]
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn reorderable_count_is_six() {
+    assert_eq!(gooey_engine_reorderable_effect_count(), 6);
+}
+
+#[test]
+fn bulk_set_then_get_round_trips() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+
+        let new_order = [
+            EFFECT_REVERB,
+            EFFECT_DELAY,
+            EFFECT_COMPRESSOR,
+            EFFECT_SATURATION,
+            EFFECT_TILT_FILTER,
+            EFFECT_LOWPASS_FILTER,
+        ];
+        let ok = gooey_engine_set_effect_order(engine, new_order.as_ptr(), N as u32);
+        assert!(ok);
+        assert_eq!(read_order(engine), new_order);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn move_effect_to_front_shifts_others_right() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+
+        // Move REVERB (last) to position 0; others should shift right preserving order.
+        let ok = gooey_engine_move_effect(engine, EFFECT_REVERB, 0);
+        assert!(ok);
+        assert_eq!(
+            read_order(engine),
+            [
+                EFFECT_REVERB,
+                EFFECT_SATURATION,
+                EFFECT_LOWPASS_FILTER,
+                EFFECT_TILT_FILTER,
+                EFFECT_DELAY,
+                EFFECT_COMPRESSOR,
+            ]
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn move_effect_to_back_shifts_others_left() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+
+        // Move SATURATION (first) to last reorderable position.
+        let ok = gooey_engine_move_effect(engine, EFFECT_SATURATION, N as u32 - 1);
+        assert!(ok);
+        assert_eq!(
+            read_order(engine),
+            [
+                EFFECT_LOWPASS_FILTER,
+                EFFECT_TILT_FILTER,
+                EFFECT_DELAY,
+                EFFECT_COMPRESSOR,
+                EFFECT_REVERB,
+                EFFECT_SATURATION,
+            ]
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn move_effect_to_same_position_is_noop() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+        let before = read_order(engine);
+
+        let ok = gooey_engine_move_effect(engine, EFFECT_DELAY, 3);
+        assert!(ok);
+        assert_eq!(read_order(engine), before);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn limiter_cannot_be_set_in_order() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+        let before = read_order(engine);
+
+        // Replace REVERB with LIMITER — must be rejected.
+        let bad = [
+            EFFECT_SATURATION,
+            EFFECT_LOWPASS_FILTER,
+            EFFECT_TILT_FILTER,
+            EFFECT_DELAY,
+            EFFECT_COMPRESSOR,
+            EFFECT_LIMITER,
+        ];
+        let ok = gooey_engine_set_effect_order(engine, bad.as_ptr(), N as u32);
+        assert!(!ok, "LIMITER must not be accepted in chain order");
+        assert_eq!(
+            read_order(engine),
+            before,
+            "order must be unchanged on reject"
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn limiter_cannot_be_moved() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+        let before = read_order(engine);
+
+        let ok = gooey_engine_move_effect(engine, EFFECT_LIMITER, 0);
+        assert!(!ok);
+        assert_eq!(read_order(engine), before);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn duplicate_ids_rejected() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+        let before = read_order(engine);
+
+        let bad = [
+            EFFECT_SATURATION,
+            EFFECT_SATURATION,
+            EFFECT_TILT_FILTER,
+            EFFECT_DELAY,
+            EFFECT_COMPRESSOR,
+            EFFECT_REVERB,
+        ];
+        let ok = gooey_engine_set_effect_order(engine, bad.as_ptr(), N as u32);
+        assert!(!ok);
+        assert_eq!(read_order(engine), before);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn wrong_length_rejected() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+        let before = read_order(engine);
+
+        let short = [EFFECT_SATURATION, EFFECT_DELAY];
+        let ok = gooey_engine_set_effect_order(engine, short.as_ptr(), short.len() as u32);
+        assert!(!ok);
+        assert_eq!(read_order(engine), before);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn unknown_id_rejected() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+        let before = read_order(engine);
+
+        let bad = [
+            EFFECT_SATURATION,
+            EFFECT_LOWPASS_FILTER,
+            EFFECT_TILT_FILTER,
+            EFFECT_DELAY,
+            EFFECT_COMPRESSOR,
+            999, // not a real effect
+        ];
+        let ok = gooey_engine_set_effect_order(engine, bad.as_ptr(), N as u32);
+        assert!(!ok);
+        assert_eq!(read_order(engine), before);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn reordering_changes_audio_output() {
+    // Saturation→delay vs delay→saturation should produce different output for the
+    // same input. Tests that the dispatch loop actually honors `effect_order`.
+    unsafe fn render_with_order(order: &[u32; N]) -> Vec<f32> {
+        let engine = gooey_engine_new(44100.0);
+
+        // Enable just saturation + delay; both with strong, audible settings.
+        gooey_engine_set_global_effect_enabled(engine, EFFECT_SATURATION, true);
+        gooey_engine_set_global_effect_enabled(engine, EFFECT_DELAY, true);
+        gooey_engine_set_global_effect_enabled(engine, EFFECT_LIMITER, false);
+
+        // Heavy distortion so its position relative to delay matters.
+        gooey_engine_set_global_effect_param(
+            engine,
+            EFFECT_SATURATION,
+            SATURATION_PARAM_DRIVE,
+            1.0,
+        );
+        gooey_engine_set_global_effect_param(engine, EFFECT_SATURATION, SATURATION_PARAM_MIX, 1.0);
+
+        // Audible delay with strong feedback.
+        gooey_engine_set_global_effect_param(engine, EFFECT_DELAY, DELAY_PARAM_FEEDBACK, 0.7);
+        gooey_engine_set_global_effect_param(engine, EFFECT_DELAY, DELAY_PARAM_MIX, 0.8);
+
+        let ok = gooey_engine_set_effect_order(engine, order.as_ptr(), N as u32);
+        assert!(ok);
+
+        gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
+        let mut buffer = vec![0.0f32; 16_384];
+        gooey_engine_render(engine, buffer.as_mut_ptr(), buffer.len() as u32);
+
+        gooey_engine_free(engine);
+        buffer
+    }
+
+    let order_a = [
+        EFFECT_SATURATION,
+        EFFECT_DELAY,
+        EFFECT_LOWPASS_FILTER,
+        EFFECT_TILT_FILTER,
+        EFFECT_COMPRESSOR,
+        EFFECT_REVERB,
+    ];
+    let order_b = [
+        EFFECT_DELAY,
+        EFFECT_SATURATION,
+        EFFECT_LOWPASS_FILTER,
+        EFFECT_TILT_FILTER,
+        EFFECT_COMPRESSOR,
+        EFFECT_REVERB,
+    ];
+
+    let buf_a = unsafe { render_with_order(&order_a) };
+    let buf_b = unsafe { render_with_order(&order_b) };
+
+    let max_diff = buf_a
+        .iter()
+        .zip(buf_b.iter())
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f32, f32::max);
+    assert!(
+        max_diff > 1e-4,
+        "Reordering saturation and delay should change the output (max diff = {max_diff})"
+    );
+}


### PR DESCRIPTION
## Summary
- User testing showed effect order materially changes sound design (e.g. distortion-before-delay vs delay-before-distortion). Adds FFI APIs to reorder the six non-limiter global effects at runtime.
- New APIs: `gooey_engine_set_effect_order` (bulk), `gooey_engine_move_effect` (single), `gooey_engine_get_effect_order` (read), `gooey_engine_reorderable_effect_count`. Limiter stays pinned at the end as the protective output stage; reorder operations reset internal state on all reorderable effects to avoid stale buffers/envelopes bleeding into the new routing.
- Adds `reset()` to the spring reverb (other effects already had one) and 12 new integration tests covering default order, round-trip, single moves in both directions, all validation rejection paths (limiter, duplicates, wrong length, unknown id), and an audible-difference smoke test.

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo build --example kick --features native,crossterm\` clean
- [x] \`cargo test\` — 257 tests pass (12 new in tests/effect_order.rs)
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --lib --tests --all-features\` — zero new warnings in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)