### PR TITLE
Expose FFI getters for drum-synth parameters

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -243,6 +243,75 @@ impl ChannelInstrument {
         }
     }
 
+    /// Read the most-recently-set value of a parameter, in the same normalized 0-1
+    /// range used by `set_param`. Returns `f32::NAN` if `param` is not recognized
+    /// for the current variant.
+    ///
+    /// Uses `SmoothedParam::target()` (not `.get()`) so callers see the value they
+    /// set, independent of any in-flight smoothing — appropriate for state recovery.
+    fn get_param(&self, param: u32) -> f32 {
+        match self {
+            Self::Kick(k) => match param {
+                KICK_PARAM_FREQUENCY => k.params.frequency.target(),
+                KICK_PARAM_PUNCH => k.params.punch.target(),
+                KICK_PARAM_SUB => k.params.sub.target(),
+                KICK_PARAM_CLICK => k.params.click.target(),
+                KICK_PARAM_DECAY => k.params.oscillator_decay.target(),
+                KICK_PARAM_PITCH_ENVELOPE => k.params.pitch_envelope_amount.target(),
+                KICK_PARAM_VOLUME => k.params.volume.target(),
+                KICK_PARAM_TUNING => k.params.tuning.target(),
+                _ => f32::NAN,
+            },
+            Self::Snare(s) => match param {
+                SNARE_PARAM_FREQUENCY => s.params.frequency.target(),
+                SNARE_PARAM_DECAY => s.params.decay.target(),
+                SNARE_PARAM_BRIGHTNESS => s.params.brightness.target(),
+                SNARE_PARAM_VOLUME => s.params.volume.target(),
+                SNARE_PARAM_TONAL => s.params.tonal.target(),
+                SNARE_PARAM_NOISE => s.params.noise.target(),
+                SNARE_PARAM_PITCH_DROP => s.params.pitch_drop.target(),
+                SNARE_PARAM_TONAL_DECAY => s.params.tonal_decay.target(),
+                SNARE_PARAM_NOISE_DECAY => s.params.noise_decay.target(),
+                SNARE_PARAM_NOISE_TAIL_DECAY => s.params.noise_tail_decay.target(),
+                SNARE_PARAM_FILTER_CUTOFF => s.params.filter_cutoff.target(),
+                SNARE_PARAM_FILTER_RESONANCE => s.params.filter_resonance.target(),
+                SNARE_PARAM_FILTER_TYPE => s.params.filter_type as f32,
+                SNARE_PARAM_XFADE => s.params.xfade.target(),
+                SNARE_PARAM_PHASE_MOD_AMOUNT => s.params.phase_mod_amount.target(),
+                SNARE_PARAM_OVERDRIVE => s.params.overdrive.target(),
+                SNARE_PARAM_AMP_DECAY => s.params.amp_decay.target(),
+                SNARE_PARAM_AMP_DECAY_CURVE => s.params.amp_decay_curve.target(),
+                SNARE_PARAM_TONAL_DECAY_CURVE => s.params.tonal_decay_curve.target(),
+                SNARE_PARAM_TUNING => s.params.tuning.target(),
+                _ => f32::NAN,
+            },
+            Self::HiHat(h) => match param {
+                HIHAT_PARAM_PITCH => h.params.pitch.target(),
+                HIHAT_PARAM_DECAY => h.params.decay.target(),
+                HIHAT_PARAM_ATTACK => h.params.attack.target(),
+                HIHAT_PARAM_VOLUME => h.params.volume.target(),
+                HIHAT_PARAM_TONE => h.params.tone.target(),
+                HIHAT_PARAM_TUNING => h.params.tuning.target(),
+                _ => f32::NAN,
+            },
+            Self::Tom(t) => match param {
+                // Tom2 stores 0-100 internally; renormalize to 0-1 for the FFI surface.
+                TOM_PARAM_TUNE => t.tune() / 100.0,
+                TOM_PARAM_BEND => t.bend() / 100.0,
+                TOM_PARAM_TONE => t.tone() / 100.0,
+                TOM_PARAM_COLOR => t.color() / 100.0,
+                TOM_PARAM_DECAY => t.decay() / 100.0,
+                TOM_PARAM_MEMBRANE => t.membrane() / 100.0,
+                TOM_PARAM_MEMBRANE_Q => t.membrane_q() / 100.0,
+                TOM_PARAM_VOLUME => t.volume() / 100.0,
+                // Tuning is stored 0-1 directly, mirroring the setter exception.
+                TOM_PARAM_TUNING => t.tuning(),
+                _ => f32::NAN,
+            },
+            Self::Bass(_) => f32::NAN,
+        }
+    }
+
     /// Apply LFO modulation to a parameter. Uses bipolar modulation for smoothed params.
     fn apply_modulation(&mut self, param: u32, value: f32) {
         match self {
@@ -2118,6 +2187,40 @@ pub unsafe extern "C" fn gooey_engine_set_kick_param(
     }
 }
 
+/// Read a kick drum parameter in the same normalized form used by
+/// `gooey_engine_set_kick_param`.
+///
+/// Returns the most-recently-set target value (not the in-flight smoothed sample),
+/// so set→get round-trips exactly. Use this to capture mutations applied by
+/// randomize/mutate flows for snapshot/undo.
+///
+/// # Arguments
+/// * `engine` - Pointer to a GooeyEngine
+/// * `param` - Parameter index (see KICK_PARAM_* constants)
+///
+/// # Returns
+/// The current parameter value, or `f32::NAN` if `engine` is null, the kick
+/// channel is missing, or `param` is unrecognized. Note that
+/// `KICK_PARAM_PITCH_ENVELOPE` reports the value set via the setter; it only
+/// takes audible effect at the next trigger.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_get_kick_param(
+    engine: *const GooeyEngine,
+    param: u32,
+) -> f32 {
+    if engine.is_null() {
+        return f32::NAN;
+    }
+    let engine = &*engine;
+    match engine.find_channel_by_type(INSTRUMENT_KICK) {
+        Some(ch) => engine.channels[ch].get_param(param),
+        None => f32::NAN,
+    }
+}
+
 /// Set a hi-hat parameter
 ///
 /// All parameters are automatically smoothed to prevent clicks/pops.
@@ -2147,6 +2250,37 @@ pub unsafe extern "C" fn gooey_engine_set_hihat_param(
     let engine = &mut *engine;
     if let Some(ch) = engine.find_channel_by_type(INSTRUMENT_HIHAT) {
         engine.channels[ch].set_param(param, value);
+    }
+}
+
+/// Read a hi-hat parameter in the same normalized form used by
+/// `gooey_engine_set_hihat_param`.
+///
+/// Returns the most-recently-set target value (not the in-flight smoothed sample),
+/// so set→get round-trips exactly.
+///
+/// # Arguments
+/// * `engine` - Pointer to a GooeyEngine
+/// * `param` - Parameter index (see HIHAT_PARAM_* constants)
+///
+/// # Returns
+/// The current parameter value, or `f32::NAN` if `engine` is null, the hi-hat
+/// channel is missing, or `param` is unrecognized.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_get_hihat_param(
+    engine: *const GooeyEngine,
+    param: u32,
+) -> f32 {
+    if engine.is_null() {
+        return f32::NAN;
+    }
+    let engine = &*engine;
+    match engine.find_channel_by_type(INSTRUMENT_HIHAT) {
+        Some(ch) => engine.channels[ch].get_param(param),
+        None => f32::NAN,
     }
 }
 
@@ -2197,6 +2331,38 @@ pub unsafe extern "C" fn gooey_engine_set_snare_param(
     }
 }
 
+/// Read a snare drum parameter in the same normalized form used by
+/// `gooey_engine_set_snare_param`.
+///
+/// Returns the most-recently-set target value (not the in-flight smoothed sample),
+/// so set→get round-trips exactly. `SNARE_PARAM_FILTER_TYPE` is reported as the
+/// raw 0-3 enum value cast to `f32`.
+///
+/// # Arguments
+/// * `engine` - Pointer to a GooeyEngine
+/// * `param` - Parameter index (see SNARE_PARAM_* constants)
+///
+/// # Returns
+/// The current parameter value, or `f32::NAN` if `engine` is null, the snare
+/// channel is missing, or `param` is unrecognized.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_get_snare_param(
+    engine: *const GooeyEngine,
+    param: u32,
+) -> f32 {
+    if engine.is_null() {
+        return f32::NAN;
+    }
+    let engine = &*engine;
+    match engine.find_channel_by_type(INSTRUMENT_SNARE) {
+        Some(ch) => engine.channels[ch].get_param(param),
+        None => f32::NAN,
+    }
+}
+
 /// Set a tom drum parameter
 ///
 /// All parameters use normalized 0-1 range. Values are internally scaled
@@ -2230,6 +2396,35 @@ pub unsafe extern "C" fn gooey_engine_set_tom_param(
     let engine = &mut *engine;
     if let Some(ch) = engine.find_channel_by_type(INSTRUMENT_TOM) {
         engine.channels[ch].set_param(param, value);
+    }
+}
+
+/// Read a tom drum parameter in the same normalized form used by
+/// `gooey_engine_set_tom_param`.
+///
+/// Tom2 stores parameters 0-7 internally on a 0-100 scale; the getter
+/// renormalizes back to 0-1 to match the setter contract. `TOM_PARAM_TUNING`
+/// (param 8) is the exception: it's already 0-1 in both directions.
+///
+/// # Arguments
+/// * `engine` - Pointer to a GooeyEngine
+/// * `param` - Parameter index (see TOM_PARAM_* constants)
+///
+/// # Returns
+/// The current parameter value, or `f32::NAN` if `engine` is null, the tom
+/// channel is missing, or `param` is unrecognized.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_get_tom_param(engine: *const GooeyEngine, param: u32) -> f32 {
+    if engine.is_null() {
+        return f32::NAN;
+    }
+    let engine = &*engine;
+    match engine.find_channel_by_type(INSTRUMENT_TOM) {
+        Some(ch) => engine.channels[ch].get_param(param),
+        None => f32::NAN,
     }
 }
 

--- a/tests/param_getters.rs
+++ b/tests/param_getters.rs
@@ -1,0 +1,117 @@
+//! Round-trip tests for the FFI parameter getters used by Swift state recovery.
+
+use gooey::ffi::*;
+
+fn approx_eq(a: f32, b: f32) {
+    assert!(
+        (a - b).abs() < 1e-6,
+        "expected {b}, got {a} (delta {})",
+        (a - b).abs()
+    );
+}
+
+#[test]
+fn kick_param_round_trip() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+
+        gooey_engine_set_kick_param(engine, KICK_PARAM_FREQUENCY, 0.42);
+        gooey_engine_set_kick_param(engine, KICK_PARAM_PUNCH, 0.13);
+        gooey_engine_set_kick_param(engine, KICK_PARAM_PITCH_ENVELOPE, 0.77);
+        gooey_engine_set_kick_param(engine, KICK_PARAM_TUNING, 0.6);
+
+        approx_eq(
+            gooey_engine_get_kick_param(engine, KICK_PARAM_FREQUENCY),
+            0.42,
+        );
+        approx_eq(gooey_engine_get_kick_param(engine, KICK_PARAM_PUNCH), 0.13);
+        approx_eq(
+            gooey_engine_get_kick_param(engine, KICK_PARAM_PITCH_ENVELOPE),
+            0.77,
+        );
+        approx_eq(gooey_engine_get_kick_param(engine, KICK_PARAM_TUNING), 0.6);
+
+        assert!(gooey_engine_get_kick_param(engine, 999).is_nan());
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn snare_param_round_trip() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+
+        gooey_engine_set_snare_param(engine, SNARE_PARAM_DECAY, 0.55);
+        gooey_engine_set_snare_param(engine, SNARE_PARAM_NOISE, 0.31);
+        gooey_engine_set_snare_param(engine, SNARE_PARAM_FILTER_TYPE, 2.0);
+
+        approx_eq(
+            gooey_engine_get_snare_param(engine, SNARE_PARAM_DECAY),
+            0.55,
+        );
+        approx_eq(
+            gooey_engine_get_snare_param(engine, SNARE_PARAM_NOISE),
+            0.31,
+        );
+        assert_eq!(
+            gooey_engine_get_snare_param(engine, SNARE_PARAM_FILTER_TYPE),
+            2.0
+        );
+
+        assert!(gooey_engine_get_snare_param(engine, 999).is_nan());
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn hihat_param_round_trip() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+
+        gooey_engine_set_hihat_param(engine, HIHAT_PARAM_TONE, 0.81);
+        gooey_engine_set_hihat_param(engine, HIHAT_PARAM_ATTACK, 0.22);
+
+        approx_eq(gooey_engine_get_hihat_param(engine, HIHAT_PARAM_TONE), 0.81);
+        approx_eq(
+            gooey_engine_get_hihat_param(engine, HIHAT_PARAM_ATTACK),
+            0.22,
+        );
+
+        assert!(gooey_engine_get_hihat_param(engine, 999).is_nan());
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn tom_param_round_trip() {
+    unsafe {
+        let engine = gooey_engine_new(44100.0);
+
+        // Params 0-7 are stored as 0-100 internally; the FFI must renormalize.
+        gooey_engine_set_tom_param(engine, TOM_PARAM_TUNE, 0.4);
+        gooey_engine_set_tom_param(engine, TOM_PARAM_DECAY, 0.9);
+        // Tuning is the exception that stays on a 0-1 scale internally.
+        gooey_engine_set_tom_param(engine, TOM_PARAM_TUNING, 0.7);
+
+        approx_eq(gooey_engine_get_tom_param(engine, TOM_PARAM_TUNE), 0.4);
+        approx_eq(gooey_engine_get_tom_param(engine, TOM_PARAM_DECAY), 0.9);
+        approx_eq(gooey_engine_get_tom_param(engine, TOM_PARAM_TUNING), 0.7);
+
+        assert!(gooey_engine_get_tom_param(engine, 999).is_nan());
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn null_engine_returns_nan() {
+    unsafe {
+        assert!(gooey_engine_get_kick_param(std::ptr::null(), KICK_PARAM_FREQUENCY).is_nan());
+        assert!(gooey_engine_get_snare_param(std::ptr::null(), SNARE_PARAM_DECAY).is_nan());
+        assert!(gooey_engine_get_hihat_param(std::ptr::null(), HIHAT_PARAM_TONE).is_nan());
+        assert!(gooey_engine_get_tom_param(std::ptr::null(), TOM_PARAM_TUNE).is_nan());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `gooey_engine_get_{kick,snare,hihat,tom}_param` FFI entry points so Swift callers can read back the current value of every drum-synth parameter — needed for state recovery (snapshot/undo) around `mutateSequence`/`randomizeParameters` flows.
- Backed by a new `ChannelInstrument::get_param` dispatcher that returns `SmoothedParam::target()` so set→get round-trips exactly (independent of in-flight smoothing). Tom params 0-7 are renormalized from the internal 0-100 scale; `SNARE_PARAM_FILTER_TYPE` returns the raw u8 cast to f32. Returns `f32::NAN` on null engine, missing channel, or unknown param.
- New `tests/param_getters.rs` covers round-trip for each instrument, the FILTER_TYPE enum, Tom renormalization + tuning exception, and NaN sentinels.

## Test plan
- [x] \`cargo build\` and \`cargo build --features ios\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --lib --tests --all-features\` (no new warnings)
- [x] \`cargo test --verbose\` — all suites pass, 5/5 new tests green
- [x] Confirmed \`include/gooey.h\` regenerated with the four new prototypes

🤖 Generated with [Claude Code](https://claude.com/claude-code)