### PR TITLE
Add granulator engine and CLI example

### DIFF
--- a/.agent/PLANS.md
+++ b/.agent/PLANS.md
@@ -1,0 +1,150 @@
+# Codex Execution Plans (ExecPlans):
+
+This document describes the requirements for an execution plan ("ExecPlan"), a design document that a coding agent can follow to deliver a working feature or system change. Treat the reader as a complete beginner to this repository: they have only the current working tree and the single ExecPlan file you provide. There is no memory of prior plans and no external context.
+
+## How to use ExecPlans and PLANS.md
+
+When authoring an executable specification (ExecPlan), follow PLANS.md _to the letter_. If it is not in your context, refresh your memory by reading the entire PLANS.md file. Be thorough in reading (and re-reading) source material to produce an accurate specification. When creating a spec, start from the skeleton and flesh it out as you do your research.
+
+When implementing an executable specification (ExecPlan), do not prompt the user for "next steps"; simply proceed to the next milestone. Keep all sections up to date, add or split entries in the list at every stopping point to affirmatively state the progress made and next steps. Resolve ambiguities autonomously, and commit frequently.
+
+When discussing an executable specification (ExecPlan), record decisions in a log in the spec for posterity; it should be unambiguously clear why any change to the specification was made. ExecPlans are living documents, and it should always be possible to restart from _only_ the ExecPlan and no other work.
+
+When researching a design with challenging requirements or significant unknowns, use milestones to implement proof of concepts, "toy implementations", etc., that allow validating whether the user's proposal is feasible. Read the source code of libraries by finding or acquiring them, research deeply, and include prototypes to guide a fuller implementation.
+
+## Requirements
+
+NON-NEGOTIABLE REQUIREMENTS:
+
+* Every ExecPlan must be fully self-contained. Self-contained means that in its current form it contains all knowledge and instructions needed for a novice to succeed.
+* Every ExecPlan is a living document. Contributors are required to revise it as progress is made, as discoveries occur, and as design decisions are finalized. Each revision must remain fully self-contained.
+* Every ExecPlan must enable a complete novice to implement the feature end-to-end without prior knowledge of this repo.
+* Every ExecPlan must produce a demonstrably working behavior, not merely code changes to "meet a definition".
+* Every ExecPlan must define every term of art in plain language or do not use it.
+
+Purpose and intent come first. Begin by explaining, in a few sentences, why the work matters from a user's perspective: what someone can do after this change that they could not do before, and how to see it working. Then guide the reader through the exact steps to achieve that outcome, including what to edit, what to run, and what they should observe.
+
+The agent executing your plan can list files, read files, search, run the project, and run tests. It does not know any prior context and cannot infer what you meant from earlier milestones. Repeat any assumption you rely on. Do not point to external blogs or docs; if knowledge is required, embed it in the plan itself in your own words. If an ExecPlan builds upon a prior ExecPlan and that file is checked in, incorporate it by reference. If it is not, you must include all relevant context from that plan.
+
+## Formatting
+
+Format and envelope are simple and strict. Each ExecPlan must be one single fenced code block labeled as `md` that begins and ends with triple backticks. Do not nest additional triple-backtick code fences inside; when you need to show commands, transcripts, diffs, or code, present them as indented blocks within that single fence. Use indentation for clarity rather than code fences inside an ExecPlan to avoid prematurely closing the ExecPlan's code fence. Use two newlines after every heading, use # and ## and so on, and correct syntax for ordered and unordered lists.
+
+When writing an ExecPlan to a Markdown (.md) file where the content of the file *is only* the single ExecPlan, you should omit the triple backticks.
+
+Write in plain prose. Prefer sentences over lists. Avoid checklists, tables, and long enumerations unless brevity would obscure meaning. Checklists are permitted only in the `Progress` section, where they are mandatory. Narrative sections must remain prose-first.
+
+## Guidelines
+
+Self-containment and plain language are paramount. If you introduce a phrase that is not ordinary English ("daemon", "middleware", "RPC gateway", "filter graph"), define it immediately and remind the reader how it manifests in this repository (for example, by naming the files or commands where it appears). Do not say "as defined previously" or "according to the architecture doc." Include the needed explanation here, even if you repeat yourself.
+
+Avoid common failure modes. Do not rely on undefined jargon. Do not describe "the letter of a feature" so narrowly that the resulting code compiles but does nothing meaningful. Do not outsource key decisions to the reader. When ambiguity exists, resolve it in the plan itself and explain why you chose that path. Err on the side of over-explaining user-visible effects and under-specifying incidental implementation details.
+
+Anchor the plan with observable outcomes. State what the user can do after implementation, the commands to run, and the outputs they should see. Acceptance should be phrased as behavior a human can verify ("after starting the server, navigating to [http://localhost:8080/health](http://localhost:8080/health) returns HTTP 200 with body OK") rather than internal attributes ("added a HealthCheck struct"). If a change is internal, explain how its impact can still be demonstrated (for example, by running tests that fail before and pass after, and by showing a scenario that uses the new behavior).
+
+Specify repository context explicitly. Name files with full repository-relative paths, name functions and modules precisely, and describe where new files should be created. If touching multiple areas, include a short orientation paragraph that explains how those parts fit together so a novice can navigate confidently. When running commands, show the working directory and exact command line. When outcomes depend on environment, state the assumptions and provide alternatives when reasonable.
+
+Be idempotent and safe. Write the steps so they can be run multiple times without causing damage or drift. If a step can fail halfway, include how to retry or adapt. If a migration or destructive operation is necessary, spell out backups or safe fallbacks. Prefer additive, testable changes that can be validated as you go.
+
+Validation is not optional. Include instructions to run tests, to start the system if applicable, and to observe it doing something useful. Describe comprehensive testing for any new features or capabilities. Include expected outputs and error messages so a novice can tell success from failure. Where possible, show how to prove that the change is effective beyond compilation (for example, through a small end-to-end scenario, a CLI invocation, or an HTTP request/response transcript). State the exact test commands appropriate to the project’s toolchain and how to interpret their results.
+
+Capture evidence. When your steps produce terminal output, short diffs, or logs, include them inside the single fenced block as indented examples. Keep them concise and focused on what proves success. If you need to include a patch, prefer file-scoped diffs or small excerpts that a reader can recreate by following your instructions rather than pasting large blobs.
+
+## Milestones
+
+Milestones are narrative, not bureaucracy. If you break the work into milestones, introduce each with a brief paragraph that describes the scope, what will exist at the end of the milestone that did not exist before, the commands to run, and the acceptance you expect to observe. Keep it readable as a story: goal, work, result, proof. Progress and milestones are distinct: milestones tell the story, progress tracks granular work. Both must exist. Never abbreviate a milestone merely for the sake of brevity, do not leave out details that could be crucial to a future implementation.
+
+Each milestone must be independently verifiable and incrementally implement the overall goal of the execution plan.
+
+## Living plans and design decisions
+
+* ExecPlans are living documents. As you make key design decisions, update the plan to record both the decision and the thinking behind it. Record all decisions in the `Decision Log` section.
+* ExecPlans must contain and maintain a `Progress` section, a `Surprises & Discoveries` section, a `Decision Log`, and an `Outcomes & Retrospective` section. These are not optional.
+* When you discover optimizer behavior, performance tradeoffs, unexpected bugs, or inverse/unapply semantics that shaped your approach, capture those observations in the `Surprises & Discoveries` section with short evidence snippets (test output is ideal).
+* If you change course mid-implementation, document why in the `Decision Log` and reflect the implications in `Progress`. Plans are guides for the next contributor as much as checklists for you.
+* At completion of a major task or the full plan, write an `Outcomes & Retrospective` entry summarizing what was achieved, what remains, and lessons learned.
+
+# Prototyping milestones and parallel implementations
+
+It is acceptable—-and often encouraged—-to include explicit prototyping milestones when they de-risk a larger change. Examples: adding a low-level operator to a dependency to validate feasibility, or exploring two composition orders while measuring optimizer effects. Keep prototypes additive and testable. Clearly label the scope as “prototyping”; describe how to run and observe results; and state the criteria for promoting or discarding the prototype.
+
+Prefer additive code changes followed by subtractions that keep tests passing. Parallel implementations (e.g., keeping an adapter alongside an older path during migration) are fine when they reduce risk or enable tests to continue passing during a large migration. Describe how to validate both paths and how to retire one safely with tests. When working with multiple new libraries or feature areas, consider creating spikes that evaluate the feasibility of these features _independently_ of one another, proving that the external library performs as expected and implements the features we need in isolation.
+
+## Skeleton of a Good ExecPlan
+
+    # <Short, action-oriented description>
+
+    This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+    If PLANS.md file is checked into the repo, reference the path to that file here from the repository root and note that this document must be maintained in accordance with PLANS.md.
+
+    ## Purpose / Big Picture
+
+    Explain in a few sentences what someone gains after this change and how they can see it working. State the user-visible behavior you will enable.
+
+    ## Progress
+
+    Use a list with checkboxes to summarize granular steps. Every stopping point must be documented here, even if it requires splitting a partially completed task into two (“done” vs. “remaining”). This section must always reflect the actual current state of the work.
+
+    - [x] (2025-10-01 13:00Z) Example completed step.
+    - [ ] Example incomplete step.
+    - [ ] Example partially completed step (completed: X; remaining: Y).
+
+    Use timestamps to measure rates of progress.
+
+    ## Surprises & Discoveries
+
+    Document unexpected behaviors, bugs, optimizations, or insights discovered during implementation. Provide concise evidence.
+
+    - Observation: …
+      Evidence: …
+
+    ## Decision Log
+
+    Record every decision made while working on the plan in the format:
+
+    - Decision: …
+      Rationale: …
+      Date/Author: …
+
+    ## Outcomes & Retrospective
+
+    Summarize outcomes, gaps, and lessons learned at major milestones or at completion. Compare the result against the original purpose.
+
+    ## Context and Orientation
+
+    Describe the current state relevant to this task as if the reader knows nothing. Name the key files and modules by full path. Define any non-obvious term you will use. Do not refer to prior plans.
+
+    ## Plan of Work
+
+    Describe, in prose, the sequence of edits and additions. For each edit, name the file and location (function, module) and what to insert or change. Keep it concrete and minimal.
+
+    ## Concrete Steps
+
+    State the exact commands to run and where to run them (working directory). When a command generates output, show a short expected transcript so the reader can compare. This section must be updated as work proceeds.
+
+    ## Validation and Acceptance
+
+    Describe how to start or exercise the system and what to observe. Phrase acceptance as behavior, with specific inputs and outputs. If tests are involved, say "run <project’s test command> and expect <N> passed; the new test <name> fails before the change and passes after>".
+
+    ## Idempotence and Recovery
+
+    If steps can be repeated safely, say so. If a step is risky, provide a safe retry or rollback path. Keep the environment clean after completion.
+
+    ## Artifacts and Notes
+
+    Include the most important transcripts, diffs, or snippets as indented examples. Keep them concise and focused on what proves success.
+
+    ## Interfaces and Dependencies
+
+    Be prescriptive. Name the libraries, modules, and services to use and why. Specify the types, traits/interfaces, and function signatures that must exist at the end of the milestone. Prefer stable names and paths such as `crate::module::function` or `package.submodule.Interface`. E.g.:
+
+    In crates/foo/planner.rs, define:
+
+        pub trait Planner {
+            fn plan(&self, observed: &Observed) -> Vec<Action>;
+        }
+
+If you follow the guidance above, a single, stateless agent -- or a human novice -- can read your ExecPlan from top to bottom and produce a working, observable result. That is the bar: SELF-CONTAINED, SELF-SUFFICIENT, NOVICE-GUIDING, OUTCOME-FOCUSED.
+
+When you revise a plan, you must ensure your changes are comprehensively reflected across all sections, including the living document sections, and you must write a note at the bottom of the plan describing the change and the reason why. ExecPlans must describe not just the what but the why for almost everything.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,12 @@ Sequencer ──trigger──▶ Instruments ──tick──▶ Sum ──▶ M
 - **Thread safety**: `Engine` wrapped in `Arc<Mutex<>>` for audio thread. Trigger queue decouples main/audio threads.
 - **Click prevention**: `SmoothedParam` (~15ms smoothing) used on all real-time parameter changes.
 
+## Planning Conventions
+
+- Store execution plans in `.context/plans/`.
+- Use dash-separated lowercase filenames for plans, for example `granulator-original-design-gap-plan.md`.
+- When writing an ExecPlan, follow `.agent/PLANS.md` and keep the plan self-contained.
+
 ## Feature Flags
 
 | Feature | Description |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,7 @@ cargo clippy --all-targets --all-features          # Clippy
 #[cfg(feature = "native")]
 pub mod engine_output;
 ```
+
+## Exec Plans
+
+When the user asks to create or manage an exec plan, read .agent/PLANS.md for more information

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,3 +97,7 @@ required-features = ["native", "crossterm"]
 [[example]]
 name = "bounce"
 required-features = ["bounce"]
+
+[[example]]
+name = "granulator"
+required-features = ["native", "crossterm", "bounce"]

--- a/examples/granulator.rs
+++ b/examples/granulator.rs
@@ -1,0 +1,391 @@
+//! Granulator Lab - interactive CLI for frozen-scan granular playback.
+//!
+//! Run with:
+//! cargo run --example granulator --features native,crossterm,bounce -- path/to/file.wav
+
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyEvent},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
+};
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use gooey::engine::{Engine, EngineOutput, Instrument};
+use gooey::instruments::{Granulator, SampleBuffer};
+
+struct ParamInfo {
+    name: &'static str,
+    coarse_step: f32,
+    fine_step: f32,
+}
+
+const PARAM_INFO: [ParamInfo; 9] = [
+    ParamInfo {
+        name: "scan_position",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+    ParamInfo {
+        name: "grain_length",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+    ParamInfo {
+        name: "spray",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+    ParamInfo {
+        name: "pitch",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+    ParamInfo {
+        name: "density",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+    ParamInfo {
+        name: "texture",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+    ParamInfo {
+        name: "direction",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+    ParamInfo {
+        name: "cloud_duration",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+    ParamInfo {
+        name: "volume",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+];
+
+struct SharedGranulator(Arc<Mutex<Granulator>>);
+
+impl Instrument for SharedGranulator {
+    fn trigger_with_velocity(&mut self, time: f64, velocity: f32) {
+        self.0.lock().unwrap().trigger_with_velocity(time, velocity);
+    }
+
+    fn tick(&mut self, current_time: f64) -> f32 {
+        self.0.lock().unwrap().tick(current_time)
+    }
+
+    fn is_active(&self) -> bool {
+        self.0.lock().unwrap().is_active()
+    }
+
+    fn as_modulatable(&mut self) -> Option<&mut dyn gooey::engine::Modulatable> {
+        None
+    }
+}
+
+fn get_param_value(granulator: &Granulator, index: usize) -> f32 {
+    match index {
+        0 => granulator.scan_position(),
+        1 => granulator.grain_length(),
+        2 => granulator.spray(),
+        3 => granulator.pitch(),
+        4 => granulator.density(),
+        5 => granulator.texture(),
+        6 => granulator.direction(),
+        7 => granulator.cloud_duration(),
+        8 => granulator.volume(),
+        _ => 0.0,
+    }
+}
+
+fn set_param_value(granulator: &mut Granulator, index: usize, value: f32) {
+    match index {
+        0 => granulator.set_scan_position(value),
+        1 => granulator.set_grain_length(value),
+        2 => granulator.set_spray(value),
+        3 => granulator.set_pitch(value),
+        4 => granulator.set_density(value),
+        5 => granulator.set_texture(value),
+        6 => granulator.set_direction(value),
+        7 => granulator.set_cloud_duration(value),
+        8 => granulator.set_volume(value),
+        _ => {}
+    }
+}
+
+fn adjust_param(granulator: &mut Granulator, index: usize, delta: f32) {
+    let current = get_param_value(granulator, index);
+    set_param_value(granulator, index, (current + delta).clamp(0.0, 1.0));
+}
+
+fn make_bar(normalized: f32, width: usize) -> String {
+    let filled = (normalized.clamp(0.0, 1.0) * width as f32).round() as usize;
+    let filled = filled.min(width);
+    format!("{}{}", "#".repeat(filled), "-".repeat(width - filled))
+}
+
+fn render_display(
+    granulator: &Granulator,
+    selected: usize,
+    trigger_count: u32,
+    velocity: f32,
+    auto_trigger: bool,
+    source_name: &str,
+    seed: u32,
+) {
+    print!("\x1b[2J\x1b[H\x1b[?7l");
+    print!("=== Granulator Lab ===\r\n");
+    print!("SPACE=cloud A=auto Q=quit UP/DOWN=sel LEFT/RIGHT=adj []=fine\r\n");
+    print!("Z/X/C/V=vel 25/50/75/100% R=reseed\r\n");
+    print!("Source: {}\r\n", source_name);
+    print!("\r\n");
+
+    for (i, info) in PARAM_INFO.iter().enumerate() {
+        let value = get_param_value(granulator, i);
+        let indicator = if i == selected { ">" } else { " " };
+        let detail = match i {
+            1 => format!("{:.0} ms", granulator.grain_length_ms()),
+            2 => format!("{:.0} ms", granulator.spray_ms()),
+            3 => format!("{:.2}x", granulator.pitch_ratio()),
+            4 => format!("{:.1}/s", granulator.density_grains_per_second()),
+            7 => format!("{:.0} ms", granulator.cloud_duration_ms()),
+            _ => String::new(),
+        };
+
+        if detail.is_empty() {
+            print!(
+                "{} {:<15} [{}] {:>5.2}\r\n",
+                indicator,
+                info.name,
+                make_bar(value, 14),
+                value
+            );
+        } else {
+            print!(
+                "{} {:<15} [{}] {:>5.2} ({})\r\n",
+                indicator,
+                info.name,
+                make_bar(value, 14),
+                value,
+                detail
+            );
+        }
+    }
+
+    let auto = if auto_trigger { "ON" } else { "OFF" };
+    print!("\r\n");
+    print!(
+        "Clouds: {} | Vel: {:.0}% | Auto: {} | Seed: {} | Active grains: {}\r\n",
+        trigger_count,
+        velocity * 100.0,
+        auto,
+        seed,
+        granulator.active_grain_count()
+    );
+    io::stdout().flush().unwrap();
+}
+
+fn demo_buffer(sample_rate: f32) -> SampleBuffer {
+    let len = (sample_rate * 3.0) as usize;
+    let mut samples = Vec::with_capacity(len);
+    for i in 0..len {
+        let t = i as f32 / sample_rate;
+        let sweep = 110.0 + 330.0 * (t / 3.0);
+        let carrier = (std::f32::consts::TAU * sweep * t).sin();
+        let overtone = (std::f32::consts::TAU * 660.0 * t).sin() * 0.25;
+        let pulse_phase = (t * 4.0).fract();
+        let pulse = if pulse_phase < 0.08 {
+            (std::f32::consts::PI * pulse_phase / 0.08).sin() * 0.25
+        } else {
+            0.0
+        };
+        samples.push((carrier * 0.5 + overtone + pulse) * 0.7);
+    }
+    SampleBuffer::from_mono(samples, sample_rate).unwrap()
+}
+
+fn load_source(sample_rate: f32) -> anyhow::Result<(SampleBuffer, String)> {
+    let path = std::env::args_os().nth(1).map(PathBuf::from);
+    if let Some(path) = path {
+        let buffer = SampleBuffer::from_wav_mono(&path).map_err(anyhow::Error::msg)?;
+        Ok((buffer, path.display().to_string()))
+    } else {
+        Ok((
+            demo_buffer(sample_rate),
+            "generated demo buffer".to_string(),
+        ))
+    }
+}
+
+#[cfg(feature = "native")]
+fn main() -> anyhow::Result<()> {
+    let sample_rate = 44100.0;
+    let (buffer, source_name) = load_source(sample_rate)?;
+
+    let granulator = Arc::new(Mutex::new(Granulator::new(sample_rate, buffer)));
+    granulator.lock().unwrap().snap_params();
+
+    let mut engine = Engine::new(sample_rate);
+    engine.set_master_gain(0.9);
+    engine.add_instrument("granulator", Box::new(SharedGranulator(granulator.clone())));
+
+    let audio_engine = Arc::new(Mutex::new(engine));
+    let mut engine_output = EngineOutput::new();
+    engine_output.initialize(sample_rate)?;
+    engine_output.create_stream_with_engine(audio_engine.clone())?;
+    engine_output.start()?;
+
+    let mut selected_param = 0;
+    let mut trigger_count = 0;
+    let mut current_velocity = 0.75;
+    let mut auto_trigger = false;
+    let mut next_auto_trigger = Instant::now();
+    let mut seed = 0x1234_abcd;
+    let mut needs_redraw = true;
+    let mut last_redraw = Instant::now();
+
+    execute!(io::stdout(), Clear(ClearType::All), cursor::Hide)?;
+    enable_raw_mode()?;
+
+    let result = loop {
+        let now = Instant::now();
+        if auto_trigger && now >= next_auto_trigger {
+            audio_engine
+                .lock()
+                .unwrap()
+                .trigger_instrument_with_velocity("granulator", current_velocity);
+            trigger_count += 1;
+
+            let cloud_ms = granulator.lock().unwrap().cloud_duration_ms();
+            let interval = Duration::from_millis((cloud_ms.max(100.0) * 0.75) as u64);
+            next_auto_trigger = now + interval;
+            needs_redraw = true;
+        }
+
+        if needs_redraw || last_redraw.elapsed() > Duration::from_millis(100) {
+            let g = granulator.lock().unwrap();
+            render_display(
+                &g,
+                selected_param,
+                trigger_count,
+                current_velocity,
+                auto_trigger,
+                &source_name,
+                seed,
+            );
+            needs_redraw = false;
+            last_redraw = Instant::now();
+        }
+
+        if event::poll(Duration::from_millis(16))? {
+            if let Event::Key(KeyEvent { code, .. }) = event::read()? {
+                match code {
+                    KeyCode::Up => {
+                        selected_param = selected_param.saturating_sub(1);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Down => {
+                        selected_param = (selected_param + 1).min(PARAM_INFO.len() - 1);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Left => {
+                        let step = PARAM_INFO[selected_param].coarse_step;
+                        adjust_param(&mut granulator.lock().unwrap(), selected_param, -step);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Right => {
+                        let step = PARAM_INFO[selected_param].coarse_step;
+                        adjust_param(&mut granulator.lock().unwrap(), selected_param, step);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('[') => {
+                        let step = PARAM_INFO[selected_param].fine_step;
+                        adjust_param(&mut granulator.lock().unwrap(), selected_param, -step);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char(']') => {
+                        let step = PARAM_INFO[selected_param].fine_step;
+                        adjust_param(&mut granulator.lock().unwrap(), selected_param, step);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char(' ') => {
+                        audio_engine
+                            .lock()
+                            .unwrap()
+                            .trigger_instrument_with_velocity("granulator", current_velocity);
+                        trigger_count += 1;
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('a') | KeyCode::Char('A') => {
+                        auto_trigger = !auto_trigger;
+                        next_auto_trigger = Instant::now();
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('z') | KeyCode::Char('Z') => {
+                        current_velocity = 0.25;
+                        audio_engine
+                            .lock()
+                            .unwrap()
+                            .trigger_instrument_with_velocity("granulator", current_velocity);
+                        trigger_count += 1;
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('x') | KeyCode::Char('X') => {
+                        current_velocity = 0.50;
+                        audio_engine
+                            .lock()
+                            .unwrap()
+                            .trigger_instrument_with_velocity("granulator", current_velocity);
+                        trigger_count += 1;
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('c') | KeyCode::Char('C') => {
+                        current_velocity = 0.75;
+                        audio_engine
+                            .lock()
+                            .unwrap()
+                            .trigger_instrument_with_velocity("granulator", current_velocity);
+                        trigger_count += 1;
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('v') | KeyCode::Char('V') => {
+                        current_velocity = 1.0;
+                        audio_engine
+                            .lock()
+                            .unwrap()
+                            .trigger_instrument_with_velocity("granulator", current_velocity);
+                        trigger_count += 1;
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('r') | KeyCode::Char('R') => {
+                        seed = seed.wrapping_add(0x9e37_79b9);
+                        granulator.lock().unwrap().set_seed(seed);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => break Ok(()),
+                    _ => {}
+                }
+            }
+        }
+    };
+
+    print!("\x1b[?7h");
+    execute!(io::stdout(), cursor::Show)?;
+    disable_raw_mode()?;
+    println!("\nQuitting...");
+
+    result
+}
+
+#[cfg(not(feature = "native"))]
+fn main() {
+    println!("This example requires the 'native' feature.");
+}

--- a/src/instruments/granulator.rs
+++ b/src/instruments/granulator.rs
@@ -1,0 +1,774 @@
+//! Mono frozen-scan granular instrument.
+//!
+//! This is a small, engine-native subset inspired by the Arbhar grain player:
+//! a fixed pool of grains reads from an in-memory sample buffer around a scan
+//! position, with random spray, pitch/speed, direction probability, and a
+//! shaped window envelope.
+
+use crate::engine::{Instrument, Modulatable};
+use crate::utils::SmoothedParam;
+use std::sync::Arc;
+
+const MAX_GRAINS: usize = 64;
+const MIN_GRAIN_MS: f32 = 5.0;
+const MAX_GRAIN_MS: f32 = 3000.0;
+const MAX_SPRAY_SECS: f32 = 10.0;
+const MIN_CLOUD_MS: f32 = 50.0;
+const MAX_CLOUD_MS: f32 = 8000.0;
+const MAX_DENSITY: f32 = 80.0;
+const MIN_PITCH: f32 = 0.25;
+const MAX_PITCH: f32 = 4.0;
+
+/// Shared mono sample data for granular playback.
+#[derive(Clone, Debug)]
+pub struct SampleBuffer {
+    samples: Arc<[f32]>,
+    sample_rate: f32,
+}
+
+impl SampleBuffer {
+    pub fn from_mono(samples: Vec<f32>, sample_rate: f32) -> Result<Self, String> {
+        if samples.is_empty() {
+            return Err("SampleBuffer requires at least one sample".to_string());
+        }
+        if !sample_rate.is_finite() || sample_rate <= 0.0 {
+            return Err(format!("Invalid sample rate: {sample_rate}"));
+        }
+        if samples.iter().any(|sample| !sample.is_finite()) {
+            return Err("SampleBuffer samples must be finite".to_string());
+        }
+
+        Ok(Self {
+            samples: Arc::from(samples.into_boxed_slice()),
+            sample_rate,
+        })
+    }
+
+    #[cfg(feature = "bounce")]
+    pub fn from_wav_mono(path: impl AsRef<std::path::Path>) -> Result<Self, String> {
+        let mut reader = hound::WavReader::open(path.as_ref())
+            .map_err(|e| format!("Failed to open WAV: {e}"))?;
+        let spec = reader.spec();
+        if spec.channels == 0 {
+            return Err("WAV must have at least one channel".to_string());
+        }
+        if spec.sample_rate == 0 {
+            return Err("WAV sample rate must be greater than zero".to_string());
+        }
+
+        let channels = spec.channels as usize;
+        let interleaved = match spec.sample_format {
+            hound::SampleFormat::Float => reader
+                .samples::<f32>()
+                .map(|s| s.map_err(|e| format!("Failed to read WAV sample: {e}")))
+                .collect::<Result<Vec<_>, _>>()?,
+            hound::SampleFormat::Int => match spec.bits_per_sample {
+                0 => return Err("WAV bit depth must be greater than zero".to_string()),
+                1..=8 => {
+                    let scale = ((1_i32 << (spec.bits_per_sample - 1)) - 1) as f32;
+                    reader
+                        .samples::<i8>()
+                        .map(|s| {
+                            s.map(|v| v as f32 / scale)
+                                .map_err(|e| format!("Failed to read WAV sample: {e}"))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                }
+                9..=16 => {
+                    let scale = ((1_i32 << (spec.bits_per_sample - 1)) - 1) as f32;
+                    reader
+                        .samples::<i16>()
+                        .map(|s| {
+                            s.map(|v| v as f32 / scale)
+                                .map_err(|e| format!("Failed to read WAV sample: {e}"))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                }
+                17..=32 => {
+                    let scale = ((1_i64 << (spec.bits_per_sample - 1)) - 1) as f32;
+                    reader
+                        .samples::<i32>()
+                        .map(|s| {
+                            s.map(|v| v as f32 / scale)
+                                .map_err(|e| format!("Failed to read WAV sample: {e}"))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                }
+                bits => return Err(format!("Unsupported WAV bit depth: {bits}")),
+            },
+        };
+
+        if interleaved.is_empty() {
+            return Err("WAV contains no samples".to_string());
+        }
+
+        let mut mono = Vec::with_capacity(interleaved.len() / channels);
+        for frame in interleaved.chunks_exact(channels) {
+            mono.push(frame.iter().sum::<f32>() / channels as f32);
+        }
+
+        Self::from_mono(mono, spec.sample_rate as f32)
+    }
+
+    pub fn len(&self) -> usize {
+        self.samples.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.samples.is_empty()
+    }
+
+    pub fn sample_rate(&self) -> f32 {
+        self.sample_rate
+    }
+
+    #[inline]
+    fn sample_clamped(&self, index: isize) -> f32 {
+        let last = self.samples.len() as isize - 1;
+        self.samples[index.clamp(0, last) as usize]
+    }
+
+    #[inline]
+    fn sample_interpolated(&self, position: f32) -> f32 {
+        if self.samples.len() == 1 {
+            return self.samples[0];
+        }
+
+        let last = self.samples.len() as f32 - 1.0;
+        let position = position.clamp(0.0, last);
+        let index = position.floor() as isize;
+        let frac = position - index as f32;
+
+        let p0 = self.sample_clamped(index - 1);
+        let p1 = self.sample_clamped(index);
+        let p2 = self.sample_clamped(index + 1);
+        let p3 = self.sample_clamped(index + 2);
+
+        cubic_interpolate(p0, p1, p2, p3, frac)
+    }
+}
+
+/// Normalized granulator preset.
+#[derive(Clone, Copy, Debug)]
+pub struct GranulatorConfig {
+    pub scan_position: f32,
+    pub grain_length: f32,
+    pub spray: f32,
+    pub pitch: f32,
+    pub density: f32,
+    pub texture: f32,
+    pub direction: f32,
+    pub cloud_duration: f32,
+    pub volume: f32,
+}
+
+impl Default for GranulatorConfig {
+    fn default() -> Self {
+        Self {
+            scan_position: 0.5,
+            grain_length: 0.16,
+            spray: 0.12,
+            pitch: 0.5,
+            density: 0.35,
+            texture: 0.25,
+            direction: 0.0,
+            cloud_duration: 0.35,
+            volume: 0.8,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct GranulatorParams {
+    scan_position: SmoothedParam,
+    grain_length: SmoothedParam,
+    spray: SmoothedParam,
+    pitch: SmoothedParam,
+    density: SmoothedParam,
+    texture: SmoothedParam,
+    direction: SmoothedParam,
+    cloud_duration: SmoothedParam,
+    volume: SmoothedParam,
+}
+
+impl GranulatorParams {
+    fn from_config(config: GranulatorConfig, sample_rate: f32) -> Self {
+        Self {
+            scan_position: SmoothedParam::new_normalized(config.scan_position, sample_rate),
+            grain_length: SmoothedParam::new_normalized(config.grain_length, sample_rate),
+            spray: SmoothedParam::new_normalized(config.spray, sample_rate),
+            pitch: SmoothedParam::new_normalized(config.pitch, sample_rate),
+            density: SmoothedParam::new_normalized(config.density, sample_rate),
+            texture: SmoothedParam::new_normalized(config.texture, sample_rate),
+            direction: SmoothedParam::new_normalized(config.direction, sample_rate),
+            cloud_duration: SmoothedParam::new_normalized(config.cloud_duration, sample_rate),
+            volume: SmoothedParam::new_normalized(config.volume, sample_rate),
+        }
+    }
+
+    #[inline]
+    fn tick(&mut self) {
+        self.scan_position.tick();
+        self.grain_length.tick();
+        self.spray.tick();
+        self.pitch.tick();
+        self.density.tick();
+        self.texture.tick();
+        self.direction.tick();
+        self.cloud_duration.tick();
+        self.volume.tick();
+    }
+
+    fn snap_all(&mut self) {
+        self.scan_position.snap();
+        self.grain_length.snap();
+        self.spray.snap();
+        self.pitch.snap();
+        self.density.snap();
+        self.texture.snap();
+        self.direction.snap();
+        self.cloud_duration.snap();
+        self.volume.snap();
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Grain {
+    active: bool,
+    source_pos: f32,
+    age_samples: f32,
+    duration_samples: f32,
+    speed: f32,
+    direction: f32,
+    window_shape: f32,
+    velocity: f32,
+}
+
+impl Default for Grain {
+    fn default() -> Self {
+        Self {
+            active: false,
+            source_pos: 0.0,
+            age_samples: 0.0,
+            duration_samples: 1.0,
+            speed: 1.0,
+            direction: 1.0,
+            window_shape: 1.0,
+            velocity: 1.0,
+        }
+    }
+}
+
+/// Mono granular instrument with a frozen scan position.
+pub struct Granulator {
+    sample_rate: f32,
+    buffer: SampleBuffer,
+    params: GranulatorParams,
+    grains: [Grain; MAX_GRAINS],
+    gain_compensation: SmoothedParam,
+    cloud_active: bool,
+    cloud_end_time: f64,
+    next_grain_time: f64,
+    current_velocity: f32,
+    rng: XorShift32,
+}
+
+impl Granulator {
+    pub fn new(sample_rate: f32, buffer: SampleBuffer) -> Self {
+        Self::with_config(sample_rate, buffer, GranulatorConfig::default())
+    }
+
+    pub fn with_config(sample_rate: f32, buffer: SampleBuffer, config: GranulatorConfig) -> Self {
+        Self {
+            sample_rate,
+            buffer,
+            params: GranulatorParams::from_config(config, sample_rate),
+            grains: [Grain::default(); MAX_GRAINS],
+            gain_compensation: SmoothedParam::new(1.0, 0.0, 1.0, sample_rate, 10.0),
+            cloud_active: false,
+            cloud_end_time: 0.0,
+            next_grain_time: 0.0,
+            current_velocity: 1.0,
+            rng: XorShift32::new(0x1234_abcd),
+        }
+    }
+
+    pub fn set_buffer(&mut self, buffer: SampleBuffer) {
+        self.buffer = buffer;
+        self.kill_all_grains();
+    }
+
+    pub fn set_seed(&mut self, seed: u32) {
+        self.rng = XorShift32::new(seed);
+    }
+
+    pub fn snap_params(&mut self) {
+        self.params.snap_all();
+        self.gain_compensation.snap();
+    }
+
+    pub fn scan_position(&self) -> f32 {
+        self.params.scan_position.target()
+    }
+
+    pub fn grain_length(&self) -> f32 {
+        self.params.grain_length.target()
+    }
+
+    pub fn spray(&self) -> f32 {
+        self.params.spray.target()
+    }
+
+    pub fn pitch(&self) -> f32 {
+        self.params.pitch.target()
+    }
+
+    pub fn density(&self) -> f32 {
+        self.params.density.target()
+    }
+
+    pub fn texture(&self) -> f32 {
+        self.params.texture.target()
+    }
+
+    pub fn direction(&self) -> f32 {
+        self.params.direction.target()
+    }
+
+    pub fn cloud_duration(&self) -> f32 {
+        self.params.cloud_duration.target()
+    }
+
+    pub fn volume(&self) -> f32 {
+        self.params.volume.target()
+    }
+
+    pub fn grain_length_ms(&self) -> f32 {
+        grain_length_ms(self.grain_length())
+    }
+
+    pub fn spray_ms(&self) -> f32 {
+        spray_seconds(self.spray()) * 1000.0
+    }
+
+    pub fn pitch_ratio(&self) -> f32 {
+        pitch_ratio(self.pitch())
+    }
+
+    pub fn density_grains_per_second(&self) -> f32 {
+        density_grains_per_second(self.density())
+    }
+
+    pub fn cloud_duration_ms(&self) -> f32 {
+        cloud_duration_ms(self.cloud_duration())
+    }
+
+    pub fn set_scan_position(&mut self, value: f32) {
+        self.params.scan_position.set_target(value);
+    }
+
+    pub fn set_grain_length(&mut self, value: f32) {
+        self.params.grain_length.set_target(value);
+    }
+
+    pub fn set_spray(&mut self, value: f32) {
+        self.params.spray.set_target(value);
+    }
+
+    pub fn set_pitch(&mut self, value: f32) {
+        self.params.pitch.set_target(value);
+    }
+
+    pub fn set_density(&mut self, value: f32) {
+        self.params.density.set_target(value);
+    }
+
+    pub fn set_texture(&mut self, value: f32) {
+        self.params.texture.set_target(value);
+    }
+
+    pub fn set_direction(&mut self, value: f32) {
+        self.params.direction.set_target(value);
+    }
+
+    pub fn set_cloud_duration(&mut self, value: f32) {
+        self.params.cloud_duration.set_target(value);
+    }
+
+    pub fn set_volume(&mut self, value: f32) {
+        self.params.volume.set_target(value);
+    }
+
+    pub fn active_grain_count(&self) -> usize {
+        self.grains.iter().filter(|grain| grain.active).count()
+    }
+
+    fn kill_all_grains(&mut self) {
+        for grain in &mut self.grains {
+            grain.active = false;
+        }
+        self.cloud_active = false;
+    }
+
+    fn spawn_due_grains(&mut self, current_time: f64) {
+        if !self.cloud_active {
+            return;
+        }
+
+        if current_time > self.cloud_end_time {
+            self.cloud_active = false;
+            return;
+        }
+
+        let density = density_grains_per_second(self.params.density.get());
+        if density <= 0.0 {
+            return;
+        }
+
+        let interval = 1.0 / density as f64;
+        let mut guard = 0;
+        while self.cloud_active && current_time + 1e-12 >= self.next_grain_time && guard < 8 {
+            self.spawn_grain();
+            self.next_grain_time += interval;
+            if self.next_grain_time > self.cloud_end_time {
+                self.cloud_active = false;
+            }
+            guard += 1;
+        }
+    }
+
+    fn spawn_grain(&mut self) {
+        let Some(slot) = self.grains.iter().position(|grain| !grain.active) else {
+            return;
+        };
+
+        let last_sample = (self.buffer.len() - 1) as f32;
+        let scan = self.params.scan_position.get().clamp(0.0, 1.0) * last_sample;
+        let spray_samples = spray_seconds(self.params.spray.get()) * self.buffer.sample_rate();
+        let spray_offset = (self.rng.next_f32() * 2.0 - 1.0) * spray_samples;
+        let requested_source_pos = (scan + spray_offset).clamp(0.0, last_sample);
+
+        let direction = if self.rng.next_f32() < self.params.direction.get() {
+            -1.0
+        } else {
+            1.0
+        };
+        let speed =
+            pitch_ratio(self.params.pitch.get()) * (self.buffer.sample_rate() / self.sample_rate);
+        let mut duration_samples =
+            (grain_length_ms(self.params.grain_length.get()) * 0.001 * self.sample_rate).max(1.0);
+        let window_shape = window_shape(self.params.texture.get());
+        let source_travel = duration_samples * speed;
+
+        // Avoid hard grain termination at buffer edges. The old version let grains
+        // start anywhere and killed them when the read head crossed an edge, which
+        // bypassed the window envelope and produced clicks near the start/end of
+        // short buffers or wide spray ranges.
+        let source_pos = if source_travel >= last_sample {
+            duration_samples = (last_sample / speed).max(1.0);
+            if direction < 0.0 {
+                last_sample
+            } else {
+                0.0
+            }
+        } else if direction < 0.0 {
+            requested_source_pos.clamp(source_travel, last_sample)
+        } else {
+            requested_source_pos.clamp(0.0, last_sample - source_travel)
+        };
+
+        self.grains[slot] = Grain {
+            active: true,
+            source_pos,
+            age_samples: 0.0,
+            duration_samples,
+            speed,
+            direction,
+            window_shape,
+            velocity: self.current_velocity,
+        };
+    }
+
+    fn tick_grains(&mut self) -> f32 {
+        let active_count = self.active_grain_count();
+        if active_count == 0 {
+            self.gain_compensation.set_target(1.0);
+            self.gain_compensation.tick();
+            return 0.0;
+        }
+
+        self.gain_compensation
+            .set_target(1.0 / (active_count as f32).sqrt());
+        let gain_comp = self.gain_compensation.tick();
+        let mut output = 0.0;
+        for grain in &mut self.grains {
+            if !grain.active {
+                continue;
+            }
+
+            if grain.age_samples >= grain.duration_samples {
+                grain.active = false;
+                continue;
+            }
+
+            let phase = (grain.age_samples / grain.duration_samples).clamp(0.0, 1.0);
+            let window = raised_sine_window(phase, grain.window_shape);
+            let sample = self.buffer.sample_interpolated(grain.source_pos);
+            output += sample * window * grain.velocity * gain_comp;
+
+            grain.source_pos += grain.speed * grain.direction;
+            grain.age_samples += 1.0;
+        }
+
+        output
+    }
+}
+
+impl Instrument for Granulator {
+    fn trigger_with_velocity(&mut self, time: f64, velocity: f32) {
+        self.current_velocity = velocity.clamp(0.0, 1.0);
+        self.cloud_active = true;
+        self.cloud_end_time =
+            time + cloud_duration_ms(self.params.cloud_duration.target()) as f64 * 0.001;
+        self.next_grain_time = time;
+    }
+
+    fn tick(&mut self, current_time: f64) -> f32 {
+        self.params.tick();
+        self.spawn_due_grains(current_time);
+        self.tick_grains() * self.params.volume.get()
+    }
+
+    fn is_active(&self) -> bool {
+        self.cloud_active || self.grains.iter().any(|grain| grain.active)
+    }
+
+    fn as_modulatable(&mut self) -> Option<&mut dyn Modulatable> {
+        Some(self)
+    }
+}
+
+impl Modulatable for Granulator {
+    fn modulatable_parameters(&self) -> Vec<&'static str> {
+        vec![
+            "scan_position",
+            "grain_length",
+            "spray",
+            "pitch",
+            "density",
+            "texture",
+            "direction",
+            "volume",
+        ]
+    }
+
+    fn apply_modulation(&mut self, parameter: &str, value: f32) -> Result<(), String> {
+        match parameter {
+            "scan_position" => self.params.scan_position.set_bipolar(value),
+            "grain_length" => self.params.grain_length.set_bipolar(value),
+            "spray" => self.params.spray.set_bipolar(value),
+            "pitch" => self.params.pitch.set_bipolar(value),
+            "density" => self.params.density.set_bipolar(value),
+            "texture" => self.params.texture.set_bipolar(value),
+            "direction" => self.params.direction.set_bipolar(value),
+            "volume" => self.params.volume.set_bipolar(value),
+            _ => return Err(format!("Unknown granulator parameter: {parameter}")),
+        }
+        Ok(())
+    }
+
+    fn parameter_range(&self, parameter: &str) -> Option<(f32, f32)> {
+        match parameter {
+            "scan_position" | "grain_length" | "spray" | "pitch" | "density" | "texture"
+            | "direction" | "volume" => Some((0.0, 1.0)),
+            _ => None,
+        }
+    }
+}
+
+#[inline]
+fn grain_length_ms(value: f32) -> f32 {
+    let value = value.clamp(0.0, 1.0);
+    MIN_GRAIN_MS + value * value * (MAX_GRAIN_MS - MIN_GRAIN_MS)
+}
+
+#[inline]
+fn spray_seconds(value: f32) -> f32 {
+    let value = value.clamp(0.0, 1.0);
+    value * value * value * MAX_SPRAY_SECS
+}
+
+#[inline]
+fn pitch_ratio(value: f32) -> f32 {
+    let value = value.clamp(0.0, 1.0);
+    MIN_PITCH * (MAX_PITCH / MIN_PITCH).powf(value)
+}
+
+#[inline]
+fn density_grains_per_second(value: f32) -> f32 {
+    value.clamp(0.0, 1.0) * MAX_DENSITY
+}
+
+#[inline]
+fn cloud_duration_ms(value: f32) -> f32 {
+    let value = value.clamp(0.0, 1.0);
+    MIN_CLOUD_MS + value * value * (MAX_CLOUD_MS - MIN_CLOUD_MS)
+}
+
+#[inline]
+fn window_shape(value: f32) -> f32 {
+    0.5 + value.clamp(0.0, 1.0) * 3.5
+}
+
+#[inline]
+fn raised_sine_window(phase: f32, shape: f32) -> f32 {
+    (std::f32::consts::PI * phase.clamp(0.0, 1.0))
+        .sin()
+        .max(0.0)
+        .powf(shape)
+}
+
+#[inline]
+fn cubic_interpolate(p0: f32, p1: f32, p2: f32, p3: f32, t: f32) -> f32 {
+    let a0 = -0.5 * p0 + 1.5 * p1 - 1.5 * p2 + 0.5 * p3;
+    let a1 = p0 - 2.5 * p1 + 2.0 * p2 - 0.5 * p3;
+    let a2 = -0.5 * p0 + 0.5 * p2;
+    let a3 = p1;
+    ((a0 * t + a1) * t + a2) * t + a3
+}
+
+#[derive(Clone, Copy, Debug)]
+struct XorShift32 {
+    state: u32,
+}
+
+impl XorShift32 {
+    fn new(seed: u32) -> Self {
+        Self {
+            state: if seed == 0 { 0x6d2b_79f5 } else { seed },
+        }
+    }
+
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        let mut x = self.state;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        self.state = x;
+        x
+    }
+
+    #[inline]
+    fn next_f32(&mut self) -> f32 {
+        self.next_u32() as f32 / u32::MAX as f32
+    }
+}
+
+impl Default for XorShift32 {
+    fn default() -> Self {
+        Self::new(0x1234_abcd)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_buffer() -> SampleBuffer {
+        let samples = (0..4410)
+            .map(|i| ((i as f32 / 44100.0) * 440.0 * std::f32::consts::TAU).sin() * 0.5)
+            .collect();
+        SampleBuffer::from_mono(samples, 44100.0).unwrap()
+    }
+
+    #[test]
+    fn sample_buffer_rejects_empty_input() {
+        assert!(SampleBuffer::from_mono(Vec::new(), 44100.0).is_err());
+    }
+
+    #[test]
+    fn sample_buffer_rejects_invalid_sample_rate() {
+        assert!(SampleBuffer::from_mono(vec![0.0], 0.0).is_err());
+        assert!(SampleBuffer::from_mono(vec![0.0], f32::NAN).is_err());
+    }
+
+    #[test]
+    fn interpolation_is_finite_at_edges() {
+        let buffer = SampleBuffer::from_mono(vec![0.0, 1.0, -1.0, 0.5], 44100.0).unwrap();
+        assert!(buffer.sample_interpolated(-10.0).is_finite());
+        assert!(buffer.sample_interpolated(0.0).is_finite());
+        assert!(buffer.sample_interpolated(3.0).is_finite());
+        assert!(buffer.sample_interpolated(99.0).is_finite());
+    }
+
+    #[test]
+    fn triggered_granulator_produces_finite_audio() {
+        let mut granulator = Granulator::new(44100.0, test_buffer());
+        granulator.set_seed(7);
+        granulator.trigger_with_velocity(0.0, 1.0);
+
+        let mut max_abs = 0.0_f32;
+        for i in 0..44100 {
+            let sample = granulator.tick(i as f64 / 44100.0);
+            assert!(sample.is_finite());
+            max_abs = max_abs.max(sample.abs());
+        }
+
+        assert!(max_abs > 0.001);
+    }
+
+    #[test]
+    fn same_seed_produces_same_output() {
+        let buffer = test_buffer();
+        let mut a = Granulator::new(44100.0, buffer.clone());
+        let mut b = Granulator::new(44100.0, buffer);
+        a.set_seed(99);
+        b.set_seed(99);
+        a.snap_params();
+        b.snap_params();
+        a.trigger_with_velocity(0.0, 0.8);
+        b.trigger_with_velocity(0.0, 0.8);
+
+        for i in 0..4096 {
+            let time = i as f64 / 44100.0;
+            assert_eq!(a.tick(time), b.tick(time));
+        }
+    }
+
+    #[test]
+    fn modulatable_parameter_list_matches_ranges() {
+        let granulator = Granulator::new(44100.0, test_buffer());
+        for parameter in granulator.modulatable_parameters() {
+            assert_eq!(granulator.parameter_range(parameter), Some((0.0, 1.0)));
+        }
+    }
+
+    #[cfg(feature = "bounce")]
+    #[test]
+    fn loads_wav_as_mono() {
+        let path =
+            std::env::temp_dir().join(format!("gooey_granulator_test_{}.wav", std::process::id()));
+        let spec = hound::WavSpec {
+            channels: 2,
+            sample_rate: 44100,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        {
+            let mut writer = hound::WavWriter::create(&path, spec).unwrap();
+            writer.write_sample::<i16>(i16::MAX).unwrap();
+            writer.write_sample::<i16>(0).unwrap();
+            writer.write_sample::<i16>(0).unwrap();
+            writer.write_sample::<i16>(i16::MAX).unwrap();
+            writer.finalize().unwrap();
+        }
+
+        let buffer = SampleBuffer::from_wav_mono(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(buffer.len(), 2);
+        assert_eq!(buffer.sample_rate(), 44100.0);
+        assert!(buffer.samples.iter().all(|sample| sample.is_finite()));
+    }
+}

--- a/src/instruments/mod.rs
+++ b/src/instruments/mod.rs
@@ -1,5 +1,6 @@
 pub mod bass;
 pub mod fm_snap;
+pub mod granulator;
 pub mod hihat2;
 pub mod kick;
 pub mod poly_synth;
@@ -9,6 +10,7 @@ pub mod tom2;
 
 pub use self::bass::*;
 pub use self::fm_snap::*;
+pub use self::granulator::*;
 pub use self::hihat2::*;
 pub use self::kick::*;
 pub use self::poly_synth::*;

--- a/tests/granulator.rs
+++ b/tests/granulator.rs
@@ -1,0 +1,66 @@
+use gooey::engine::{Engine, Lfo, MusicalDivision};
+use gooey::instruments::{Granulator, SampleBuffer};
+
+fn test_buffer() -> SampleBuffer {
+    let sample_rate = 44100.0;
+    let samples = (0..44100)
+        .map(|i| {
+            let t = i as f32 / sample_rate;
+            (std::f32::consts::TAU * 220.0 * t).sin() * 0.5
+        })
+        .collect();
+    SampleBuffer::from_mono(samples, sample_rate).unwrap()
+}
+
+#[test]
+fn engine_can_trigger_granulator() {
+    let sample_rate = 44100.0;
+    let mut engine = Engine::new(sample_rate);
+    engine.add_instrument(
+        "granulator",
+        Box::new(Granulator::new(sample_rate, test_buffer())),
+    );
+    engine.trigger_instrument_with_velocity("granulator", 1.0);
+
+    let mut max_abs = 0.0_f32;
+    for i in 0..44100 {
+        let sample = engine.tick(i as f64 / sample_rate as f64);
+        assert!(sample.is_finite());
+        max_abs = max_abs.max(sample.abs());
+    }
+
+    assert!(max_abs > 0.001);
+}
+
+#[test]
+fn granulator_parameters_are_modulatable() {
+    let sample_rate = 44100.0;
+    let bpm = 120.0;
+    let mut engine = Engine::new(sample_rate);
+    engine.set_bpm(bpm);
+    engine.add_instrument(
+        "granulator",
+        Box::new(Granulator::new(sample_rate, test_buffer())),
+    );
+
+    let parameters = [
+        "scan_position",
+        "grain_length",
+        "spray",
+        "pitch",
+        "density",
+        "texture",
+        "direction",
+        "volume",
+    ];
+
+    for parameter in parameters {
+        let lfo_index = engine.add_lfo(Lfo::new_synced(MusicalDivision::OneBar, bpm, sample_rate));
+        let result = engine.map_lfo_to_parameter(lfo_index, "granulator", parameter, 1.0);
+        assert!(
+            result.is_ok(),
+            "granulator parameter '{}' should be modulatable",
+            parameter
+        );
+    }
+}


### PR DESCRIPTION
Adds a mono frozen-scan Granulator instrument with an in-memory sample buffer, optional WAV loading, deterministic grain generation, smoothing, and modulatable parameters.
Adds an interactive `granulator` CLI example for loading or generating audio, triggering clouds, and adjusting scan, grain, spray, pitch, density, texture, direction, duration, and volume controls.
Adds integration/unit tests for buffer validation, rendering, modulation, determinism, and WAV loading.
Also adds ExecPlan guidance and planning conventions in `AGENTS.md`/`CLAUDE.md` so future plans live under `.context/plans/` with dash-separated names.
Validated with `cargo test`, `cargo test --features bounce`, `cargo test granulator --features bounce`, and `cargo check --example granulator --features native,crossterm,bounce`.
