### PR TITLE
Expose granulator over the FFI

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -827,11 +827,14 @@ impl GooeyEngine {
             sequencer_triggers_enabled: true,
             // Polyphonic synthesizer for chord playback
             poly_synth: PolySynth::new(sample_rate),
-            // Granulator with a silent placeholder buffer until the host loads samples
+            // Granulator with a silent placeholder buffer until the host loads samples.
+            // The placeholder uses a hardcoded sample rate so this constructor cannot
+            // fail on a non-finite or non-positive `sample_rate` argument — `gooey_engine_new`
+            // is an `extern "C"` entry point and must never panic on user input.
             granulator: Granulator::new(
                 sample_rate,
-                SampleBuffer::from_mono(vec![0.0_f32], sample_rate)
-                    .expect("placeholder sample buffer"),
+                SampleBuffer::from_mono(vec![0.0_f32], 44_100.0)
+                    .unwrap_or_else(|_| unreachable!("constant placeholder buffer is valid")),
             ),
             // External sync (e.g. Ableton Link)
             link_enabled: AtomicBool::new(false),

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -10,8 +10,8 @@ use crate::effects::{
 use crate::engine::lfo::{Lfo, MusicalDivision};
 use crate::engine::{Instrument, Sequencer, SequencerBlendSetting, SequencerStepSettings};
 use crate::instruments::{
-    BassConfig, BassSynth, HiHat2, HiHat2Config, KickConfig, KickDrum, PolySynth, PolySynthConfig,
-    SnareConfig, SnareDrum, Tom2, Tom2Config,
+    BassConfig, BassSynth, Granulator, HiHat2, HiHat2Config, KickConfig, KickDrum, PolySynth,
+    PolySynthConfig, SampleBuffer, SnareConfig, SnareDrum, Tom2, Tom2Config,
 };
 use crate::music::{apply_voicing, available_voicings, Key, NoteName, ScaleType, VoicingType};
 use crate::utils::{PresetBlender, SmoothedParam};
@@ -653,6 +653,9 @@ pub struct GooeyEngine {
     // Polyphonic synthesizer for chord playback
     poly_synth: PolySynth,
 
+    // Mono granular instrument (sample buffer loaded by the host)
+    granulator: Granulator,
+
     // When true, an external source (e.g. Ableton Link) owns the tempo.
     // The host should check this flag to decide whether local BPM changes
     // should be applied directly or routed through the external sync source.
@@ -824,6 +827,12 @@ impl GooeyEngine {
             sequencer_triggers_enabled: true,
             // Polyphonic synthesizer for chord playback
             poly_synth: PolySynth::new(sample_rate),
+            // Granulator with a silent placeholder buffer until the host loads samples
+            granulator: Granulator::new(
+                sample_rate,
+                SampleBuffer::from_mono(vec![0.0_f32], sample_rate)
+                    .expect("placeholder sample buffer"),
+            ),
             // External sync (e.g. Ableton Link)
             link_enabled: AtomicBool::new(false),
             // Error state
@@ -1052,6 +1061,9 @@ impl GooeyEngine {
 
             // Mix in poly synth output
             output += self.poly_synth.tick(self.current_time);
+
+            // Mix in granulator output
+            output += self.granulator.tick(self.current_time);
 
             // Apply global effects chain (order is user-configurable; limiter is always last)
             for &effect_id in &self.effect_order {
@@ -1564,6 +1576,34 @@ pub const BASS_PARAM_OVERDRIVE: u32 = 13;
 pub const BASS_PARAM_VOLUME: u32 = 14;
 /// Bass parameter: tuning offset (0=−12 semitones, 0.5=neutral, 1=+12 semitones)
 pub const BASS_PARAM_TUNING: u32 = 15;
+
+// =============================================================================
+// Granulator parameter constants
+// =============================================================================
+//
+// All values are normalized 0.0-1.0. Mapping to internal units (ms, Hz, ratio)
+// happens inside `Granulator`; see `src/instruments/granulator.rs`.
+
+/// Granulator parameter: scan position into the loaded buffer (0=start, 1=end)
+pub const GRANULATOR_PARAM_SCAN_POSITION: u32 = 0;
+/// Granulator parameter: grain length (0-1 -> 5-3000 ms, quadratic curve)
+pub const GRANULATOR_PARAM_GRAIN_LENGTH: u32 = 1;
+/// Granulator parameter: spray / randomization of grain start (0-1 -> 0-10 s, cubic)
+pub const GRANULATOR_PARAM_SPRAY: u32 = 2;
+/// Granulator parameter: playback pitch (0-1 -> 0.25x-4x, exponential)
+pub const GRANULATOR_PARAM_PITCH: u32 = 3;
+/// Granulator parameter: density of grains per second (0-1 -> 0-80 g/s)
+pub const GRANULATOR_PARAM_DENSITY: u32 = 4;
+/// Granulator parameter: window shape / texture (0=soft, 1=hard)
+pub const GRANULATOR_PARAM_TEXTURE: u32 = 5;
+/// Granulator parameter: probability a grain plays in reverse (0=forward only, 1=reverse only)
+pub const GRANULATOR_PARAM_DIRECTION: u32 = 6;
+/// Granulator parameter: cloud duration after a trigger (0-1 -> 50-8000 ms, quadratic)
+pub const GRANULATOR_PARAM_CLOUD_DURATION: u32 = 7;
+/// Granulator parameter: output volume (0-1)
+pub const GRANULATOR_PARAM_VOLUME: u32 = 8;
+/// Total number of granulator parameters
+pub const GRANULATOR_PARAM_COUNT: u32 = 9;
 
 /// Bass preset: Acid - TB-303-style, high resonance, short filter sweep
 pub const BASS_PRESET_ACID: u32 = 0;
@@ -5097,6 +5137,214 @@ pub unsafe extern "C" fn gooey_engine_poly_available_voicing_count(
     let chords = key.diatonic_sevenths();
     let degree = degree as usize % chords.len();
     available_voicings(&chords[degree].quality).len() as u32
+}
+
+// ---------------------------------------------------------------------------
+// Granulator
+// ---------------------------------------------------------------------------
+
+/// Load a mono sample buffer into the granulator.
+///
+/// Copies `len` samples from `samples` into the engine. Replaces any
+/// previously loaded buffer and kills all currently active grains.
+///
+/// The granulator is mono only. Stereo or multichannel hosts should downmix
+/// before calling this function.
+///
+/// Returns `true` on success, `false` if any argument is invalid (null engine,
+/// null `samples`, `len == 0`, non-finite or non-positive `sample_rate`, or
+/// any non-finite value in the sample slice).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`. `samples`
+/// must point to at least `len` valid `f32` values when `len > 0`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_granulator_set_buffer(
+    engine: *mut GooeyEngine,
+    samples: *const f32,
+    len: u32,
+    sample_rate: f32,
+) -> bool {
+    if engine.is_null() || samples.is_null() || len == 0 {
+        return false;
+    }
+    let engine = &mut *engine;
+    let slice = slice::from_raw_parts(samples, len as usize);
+    let owned = slice.to_vec();
+    match SampleBuffer::from_mono(owned, sample_rate) {
+        Ok(buffer) => {
+            engine.granulator.set_buffer(buffer);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Return the length, in samples, of the granulator's currently loaded buffer.
+///
+/// Returns 0 if `engine` is null. Immediately after `gooey_engine_new`, the
+/// granulator holds a 1-sample silent placeholder, so a return value of 1
+/// (with no `set_buffer` call) indicates "no host buffer loaded yet".
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_granulator_buffer_len(engine: *const GooeyEngine) -> u32 {
+    if engine.is_null() {
+        return 0;
+    }
+    let engine = &*engine;
+    engine.granulator.buffer_len() as u32
+}
+
+/// Return the sample rate of the granulator's currently loaded buffer.
+///
+/// Returns 0.0 if `engine` is null.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_granulator_buffer_sample_rate(
+    engine: *const GooeyEngine,
+) -> f32 {
+    if engine.is_null() {
+        return 0.0;
+    }
+    let engine = &*engine;
+    engine.granulator.buffer_sample_rate()
+}
+
+/// Trigger the granulator with a velocity, starting a cloud of grains.
+///
+/// Unlike drum-channel triggers, granulator triggers are applied immediately
+/// against the engine's current time and are not deferred through an atomic
+/// pending flag. The caller is expected to invoke this from the host thread
+/// (e.g. UI / MIDI input handler), not from inside the audio render callback.
+///
+/// `velocity` is clamped to 0.0-1.0.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_granulator_trigger(engine: *mut GooeyEngine, velocity: f32) {
+    if engine.is_null() {
+        return;
+    }
+    let engine = &mut *engine;
+    let velocity = velocity.clamp(0.0, 1.0);
+    engine
+        .granulator
+        .trigger_with_velocity(engine.current_time, velocity);
+}
+
+/// Set a granulator parameter by index. All values are normalized 0.0-1.0.
+///
+/// Parameter indices: see the `GRANULATOR_PARAM_*` constants. Unknown indices
+/// are silently ignored, matching the pattern used by other instrument
+/// setters in this file.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_granulator_set_param(
+    engine: *mut GooeyEngine,
+    param: u32,
+    value: f32,
+) {
+    if engine.is_null() {
+        return;
+    }
+    let engine = &mut *engine;
+    let value = value.clamp(0.0, 1.0);
+    match param {
+        GRANULATOR_PARAM_SCAN_POSITION => engine.granulator.set_scan_position(value),
+        GRANULATOR_PARAM_GRAIN_LENGTH => engine.granulator.set_grain_length(value),
+        GRANULATOR_PARAM_SPRAY => engine.granulator.set_spray(value),
+        GRANULATOR_PARAM_PITCH => engine.granulator.set_pitch(value),
+        GRANULATOR_PARAM_DENSITY => engine.granulator.set_density(value),
+        GRANULATOR_PARAM_TEXTURE => engine.granulator.set_texture(value),
+        GRANULATOR_PARAM_DIRECTION => engine.granulator.set_direction(value),
+        GRANULATOR_PARAM_CLOUD_DURATION => engine.granulator.set_cloud_duration(value),
+        GRANULATOR_PARAM_VOLUME => engine.granulator.set_volume(value),
+        _ => {}
+    }
+}
+
+/// Read the most-recently-set value of a granulator parameter, in the same
+/// normalized 0.0-1.0 range used by `gooey_engine_granulator_set_param`.
+///
+/// Returns `f32::NAN` if `engine` is null or `param` is unrecognized.
+/// Reads the `SmoothedParam::target()` so callers see the value they last
+/// wrote even before the audio thread has finished smoothing into it.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_granulator_get_param(
+    engine: *const GooeyEngine,
+    param: u32,
+) -> f32 {
+    if engine.is_null() {
+        return f32::NAN;
+    }
+    let engine = &*engine;
+    match param {
+        GRANULATOR_PARAM_SCAN_POSITION => engine.granulator.scan_position(),
+        GRANULATOR_PARAM_GRAIN_LENGTH => engine.granulator.grain_length(),
+        GRANULATOR_PARAM_SPRAY => engine.granulator.spray(),
+        GRANULATOR_PARAM_PITCH => engine.granulator.pitch(),
+        GRANULATOR_PARAM_DENSITY => engine.granulator.density(),
+        GRANULATOR_PARAM_TEXTURE => engine.granulator.texture(),
+        GRANULATOR_PARAM_DIRECTION => engine.granulator.direction(),
+        GRANULATOR_PARAM_CLOUD_DURATION => engine.granulator.cloud_duration(),
+        GRANULATOR_PARAM_VOLUME => engine.granulator.volume(),
+        _ => f32::NAN,
+    }
+}
+
+/// Seed the granulator's grain-spray PRNG. Used for reproducible output in
+/// tests; callers that don't need determinism can ignore this.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_granulator_set_seed(engine: *mut GooeyEngine, seed: u32) {
+    if engine.is_null() {
+        return;
+    }
+    let engine = &mut *engine;
+    engine.granulator.set_seed(seed);
+}
+
+/// Return the number of grains currently sounding inside the granulator.
+/// Returns 0 if `engine` is null. Useful for UI metering.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_granulator_active_grain_count(
+    engine: *const GooeyEngine,
+) -> u32 {
+    if engine.is_null() {
+        return 0;
+    }
+    let engine = &*engine;
+    engine.granulator.active_grain_count() as u32
+}
+
+/// Snap all granulator smoothed parameters to their target values, bypassing
+/// the usual ~15 ms exponential smoothing. Useful when loading a preset or
+/// resetting state between songs without introducing audible glides.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_granulator_snap_params(engine: *mut GooeyEngine) {
+    if engine.is_null() {
+        return;
+    }
+    let engine = &mut *engine;
+    engine.granulator.snap_params();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/instruments/granulator.rs
+++ b/src/instruments/granulator.rs
@@ -302,6 +302,14 @@ impl Granulator {
         self.rng = XorShift32::new(seed);
     }
 
+    pub fn buffer_len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    pub fn buffer_sample_rate(&self) -> f32 {
+        self.buffer.sample_rate()
+    }
+
     pub fn snap_params(&mut self) {
         self.params.snap_all();
         self.gain_compensation.snap();

--- a/tests/ffi_granulator.rs
+++ b/tests/ffi_granulator.rs
@@ -1,0 +1,213 @@
+//! End-to-end tests for the granulator FFI surface introduced in
+//! `gooey_engine_granulator_*`. Mirrors the host-side calling sequence that
+//! a Swift / AUv3 wrapper would use: create engine → load samples → set
+//! parameters → trigger → render → inspect output.
+
+use gooey::ffi::*;
+
+const SAMPLE_RATE: f32 = 44100.0;
+
+fn approx_eq(a: f32, b: f32) {
+    assert!(
+        (a - b).abs() < 1e-6,
+        "expected {b}, got {a} (delta {})",
+        (a - b).abs()
+    );
+}
+
+fn sine_samples(seconds: f32, hz: f32) -> Vec<f32> {
+    let n = (SAMPLE_RATE * seconds) as usize;
+    (0..n)
+        .map(|i| (i as f32 / SAMPLE_RATE * hz * std::f32::consts::TAU).sin() * 0.5)
+        .collect()
+}
+
+#[test]
+fn placeholder_buffer_present_until_set_buffer() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        assert_eq!(gooey_engine_granulator_buffer_len(engine), 1);
+        approx_eq(
+            gooey_engine_granulator_buffer_sample_rate(engine),
+            SAMPLE_RATE,
+        );
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn set_buffer_replaces_placeholder() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        let samples = sine_samples(1.0, 220.0);
+        let ok = gooey_engine_granulator_set_buffer(
+            engine,
+            samples.as_ptr(),
+            samples.len() as u32,
+            SAMPLE_RATE,
+        );
+        assert!(ok);
+        assert_eq!(
+            gooey_engine_granulator_buffer_len(engine),
+            samples.len() as u32
+        );
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn set_buffer_rejects_invalid_inputs() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        let samples = sine_samples(0.1, 440.0);
+
+        assert!(!gooey_engine_granulator_set_buffer(
+            engine,
+            std::ptr::null(),
+            samples.len() as u32,
+            SAMPLE_RATE,
+        ));
+        assert!(!gooey_engine_granulator_set_buffer(
+            engine,
+            samples.as_ptr(),
+            0,
+            SAMPLE_RATE,
+        ));
+        assert!(!gooey_engine_granulator_set_buffer(
+            engine,
+            samples.as_ptr(),
+            samples.len() as u32,
+            0.0,
+        ));
+
+        // Buffer should still be the 1-sample placeholder
+        assert_eq!(gooey_engine_granulator_buffer_len(engine), 1);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn param_round_trip() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_SCAN_POSITION, 0.25);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_GRAIN_LENGTH, 0.6);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_SPRAY, 0.1);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_PITCH, 0.75);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_DENSITY, 0.42);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_TEXTURE, 0.33);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_DIRECTION, 0.0);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_CLOUD_DURATION, 0.5);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_VOLUME, 0.9);
+
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_SCAN_POSITION),
+            0.25,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_GRAIN_LENGTH),
+            0.6,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_SPRAY),
+            0.1,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_PITCH),
+            0.75,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_DENSITY),
+            0.42,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_TEXTURE),
+            0.33,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_DIRECTION),
+            0.0,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_CLOUD_DURATION),
+            0.5,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_VOLUME),
+            0.9,
+        );
+
+        assert!(gooey_engine_granulator_get_param(engine, 999).is_nan());
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn param_get_nan_on_null_engine() {
+    unsafe {
+        assert!(
+            gooey_engine_granulator_get_param(std::ptr::null(), GRANULATOR_PARAM_VOLUME,).is_nan()
+        );
+    }
+}
+
+#[test]
+fn trigger_and_render_produces_finite_nonzero_audio() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        let samples = sine_samples(1.0, 220.0);
+        assert!(gooey_engine_granulator_set_buffer(
+            engine,
+            samples.as_ptr(),
+            samples.len() as u32,
+            SAMPLE_RATE,
+        ));
+        gooey_engine_granulator_set_seed(engine, 7);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_VOLUME, 1.0);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_DENSITY, 0.5);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_CLOUD_DURATION, 0.5);
+        gooey_engine_granulator_snap_params(engine);
+        gooey_engine_granulator_trigger(engine, 1.0);
+
+        let frames = 22_050usize; // ~0.5 seconds
+        let mut buffer = vec![0.0_f32; frames];
+        gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+
+        let max_abs = buffer.iter().fold(0.0_f32, |acc, s| {
+            assert!(s.is_finite(), "non-finite sample in render output");
+            acc.max(s.abs())
+        });
+        assert!(max_abs > 1e-4, "expected audible granulator output");
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn active_grain_count_rises_after_trigger() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        let samples = sine_samples(1.0, 220.0);
+        gooey_engine_granulator_set_buffer(
+            engine,
+            samples.as_ptr(),
+            samples.len() as u32,
+            SAMPLE_RATE,
+        );
+        gooey_engine_granulator_set_seed(engine, 11);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_DENSITY, 0.6);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_CLOUD_DURATION, 0.5);
+        gooey_engine_granulator_snap_params(engine);
+        gooey_engine_granulator_trigger(engine, 1.0);
+
+        let mut buffer = vec![0.0_f32; 4096];
+        gooey_engine_render(engine, buffer.as_mut_ptr(), buffer.len() as u32);
+
+        assert!(
+            gooey_engine_granulator_active_grain_count(engine) > 0,
+            "expected at least one active grain after trigger+render"
+        );
+        gooey_engine_free(engine);
+    }
+}

--- a/tests/ffi_granulator.rs
+++ b/tests/ffi_granulator.rs
@@ -26,11 +26,12 @@ fn sine_samples(seconds: f32, hz: f32) -> Vec<f32> {
 fn placeholder_buffer_present_until_set_buffer() {
     unsafe {
         let engine = gooey_engine_new(SAMPLE_RATE);
+        // Length is the contract: 1 means "no host buffer loaded yet".
+        // The placeholder's internal sample rate is an implementation
+        // detail (intentionally hardcoded to avoid panicking on a bad
+        // engine `sample_rate`) and is not asserted here.
         assert_eq!(gooey_engine_granulator_buffer_len(engine), 1);
-        approx_eq(
-            gooey_engine_granulator_buffer_sample_rate(engine),
-            SAMPLE_RATE,
-        );
+        assert!(gooey_engine_granulator_buffer_sample_rate(engine) > 0.0);
         gooey_engine_free(engine);
     }
 }


### PR DESCRIPTION
## Summary

- Wires the `Granulator` instrument (merged in #191) into the `GooeyEngine` FFI handle by mirroring the `PolySynth` pattern: a plain field on the engine, initialized with a 1-sample silent placeholder, mixed into the per-sample render loop right after `poly_synth` so the existing reorderable effects chain applies to it untouched.
- Adds the `gooey_engine_granulator_*` C surface — `set_buffer` (raw mono `f32` slice + sample rate, returns `bool`), `buffer_len` / `buffer_sample_rate`, `trigger`, `set_param` / `get_param` (NaN sentinel on unknown index, matching #190), `set_seed`, `active_grain_count`, and `snap_params` — plus 10 `GRANULATOR_PARAM_*` constants covering all nine knobs surfaced by `examples/granulator.rs`.
- New `tests/ffi_granulator.rs` exercises the full surface end-to-end through `gooey_engine_render` (placeholder buffer, replace-on-load, invalid-input rejection, param round-trip, NaN on unknown / null, audible non-zero output, active grain count after trigger).

## Test plan

- [x] `cargo build`
- [x] `cargo build --features ios`
- [x] `cargo test --verbose` (all suites incl. 7 new `tests/ffi_granulator.rs`)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --lib --tests --all-features` (no errors / new warnings on lib/tests)
- [x] `include/gooey.h` regenerated by cbindgen; contains every new symbol + constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)