### PR TITLE
Granulator Milestone 1: random timing, random amp, drive, soft stealing

### DIFF
--- a/examples/granulator.rs
+++ b/examples/granulator.rs
@@ -23,7 +23,7 @@ struct ParamInfo {
     fine_step: f32,
 }
 
-const PARAM_INFO: [ParamInfo; 9] = [
+const PARAM_INFO: [ParamInfo; 12] = [
     ParamInfo {
         name: "scan_position",
         coarse_step: 0.05,
@@ -69,6 +69,21 @@ const PARAM_INFO: [ParamInfo; 9] = [
         coarse_step: 0.05,
         fine_step: 0.01,
     },
+    ParamInfo {
+        name: "random_timing",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+    ParamInfo {
+        name: "random_amp",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
+    ParamInfo {
+        name: "drive",
+        coarse_step: 0.05,
+        fine_step: 0.01,
+    },
 ];
 
 struct SharedGranulator(Arc<Mutex<Granulator>>);
@@ -102,6 +117,9 @@ fn get_param_value(granulator: &Granulator, index: usize) -> f32 {
         6 => granulator.direction(),
         7 => granulator.cloud_duration(),
         8 => granulator.volume(),
+        9 => granulator.random_timing(),
+        10 => granulator.random_amp(),
+        11 => granulator.drive(),
         _ => 0.0,
     }
 }
@@ -117,6 +135,9 @@ fn set_param_value(granulator: &mut Granulator, index: usize, value: f32) {
         6 => granulator.set_direction(value),
         7 => granulator.set_cloud_duration(value),
         8 => granulator.set_volume(value),
+        9 => granulator.set_random_timing(value),
+        10 => granulator.set_random_amp(value),
+        11 => granulator.set_drive(value),
         _ => {}
     }
 }

--- a/plans/granulator-original-design-gap-plan.md
+++ b/plans/granulator-original-design-gap-plan.md
@@ -1,0 +1,205 @@
+# Bring The Granulator Closer To The Original Arbhär Design
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This repository contains `.agent/PLANS.md`, and this document must be maintained in accordance with that file. If this plan is revised, keep it self-contained: a future contributor should be able to read only this file and the current working tree, then continue safely.
+
+## Purpose / Big Picture
+
+The current granulator works and sounds good as a first mono frozen-scan instrument. The purpose of this plan is to extend it toward the original Arbhär-style granular design in small, demonstrable stages while preserving the working command-line listening experience.
+
+After the next milestone, a user should be able to run `cargo run --example granulator --features native,crossterm,bounce`, hear a richer cloud with less mechanical repetition, and adjust new random timing, random amplitude, grain stealing, and saturation controls from the terminal. Later milestones add stereo-aware buffers, multiple layers, follow mode, quantized pitch behavior, live capture, and iOS FFI exposure.
+
+## Progress
+
+- [x] (2026-05-23 16:16 EDT) Created an initial gap plan describing what the V1 granulator does and what remains from the original Arbhär design.
+- [x] (2026-05-23 16:37 EDT) Read `.agent/PLANS.md` and converted the gap plan into a self-contained ExecPlan format.
+- [x] (2026-05-23 16:37 EDT) Recorded current V1 state, deferred original-design features, recommended milestones, validation commands, and implementation interfaces in this plan.
+- [ ] Implement Milestone 1: add `random_timing`, `random_amp`, soft grain stealing, and optional per-instrument saturation to the current mono granulator.
+- [ ] Implement Milestone 2: add stereo-aware buffer internals while still returning mono from `Instrument::tick`.
+- [ ] Implement Milestone 3: add static multi-layer playback and layer interpolation.
+- [ ] Implement Milestone 4: add follow mode, where the read position moves through the buffer automatically.
+- [ ] Implement Milestone 5: add pitch deviation, quantized pitch tables, and optional chord distribution.
+- [ ] Implement Milestone 6: add live recording/capture into an internal buffer.
+- [ ] Implement Milestone 7: expose the stable granulator through the iOS-facing FFI engine.
+
+## Surprises & Discoveries
+
+- Observation: The first V1 granulator produced non-intentional popping even though its user parameters used `SmoothedParam`.
+  Evidence: Inspection showed two audio-rate discontinuities: grains were killed immediately when playback crossed buffer edges, and active-grain gain compensation changed instantly when the number of active grains changed. The fix was to constrain grain start positions so grains finish under their envelope and smooth gain compensation with another `SmoothedParam`.
+
+- Observation: The generated demo buffer itself contained hard pulse edges that could be mistaken for granulator artifacts.
+  Evidence: The fallback sample generator in `examples/granulator.rs` originally used an on/off pulse. It was changed to a sine-shaped pulse.
+
+- Observation: The current public `Engine` trait returns one `f32` sample per tick, so true stereo output is not available through the main Rust `Engine` without a broader API change.
+  Evidence: `src/engine/mod.rs` defines `Instrument::tick(&mut self, current_time: f64) -> f32` and `Engine::tick(&mut self, current_time: f64) -> f32`.
+
+## Decision Log
+
+- Decision: Keep the first completed granulator implementation mono and core-Rust-only.
+  Rationale: The existing engine, bounce path, and examples are mono at the `Instrument` trait boundary. A mono implementation allowed a working listening tool before committing to stereo engine API changes or iOS FFI buffer ownership.
+  Date/Author: 2026-05-23 / Codex
+
+- Decision: Store this plan in `.context/granulator_original_design_gap_plan.md`.
+  Rationale: `.context` is gitignored workspace-local context for future agents in Conductor. The plan can be referenced later without changing the library source.
+  Date/Author: 2026-05-23 / Codex
+
+- Decision: The next implementation milestone should be random timing, random amplitude, soft grain stealing, and optional saturation.
+  Rationale: These are audible improvements that fit the current mono/static-buffer architecture and avoid large unresolved decisions around stereo, layers, recording, and FFI.
+  Date/Author: 2026-05-23 / Codex
+
+- Decision: Stereo, layers, follow mode, pitch tables, recording, and FFI are separate milestones.
+  Rationale: Each changes a different boundary: audio channel shape, buffer ownership, playhead state, pitch scheduling, realtime input capture, or external API. Keeping them separate makes each milestone independently testable.
+  Date/Author: 2026-05-23 / Codex
+
+## Outcomes & Retrospective
+
+V1 achieved a useful listening result: a working granular instrument, WAV loading helper, deterministic grain generation, and an interactive terminal example. A follow-up pass reduced processing artifacts by smoothing gain compensation and preventing abrupt edge kills. What remains is not a bug fix but feature growth toward the original Arbhär design.
+
+The most important lesson is that granular synthesis clicks can come from sources other than parameter smoothing. Any future milestone must preserve zero-start/zero-end grain envelopes, avoid abrupt voice termination, and smooth aggregate gain changes when voices are added or removed.
+
+## Context and Orientation
+
+This repository is a Rust audio engine named `gooey`. The primary public instrument abstraction lives in `src/engine/mod.rs`. The trait is called `Instrument`; an instrument can be triggered and then asked for one mono audio sample at a time through `tick`. A second trait, `Modulatable`, lets LFOs change named instrument parameters.
+
+The current granulator implementation lives in `src/instruments/granulator.rs`. It defines `SampleBuffer`, `GranulatorConfig`, and `Granulator`. `SampleBuffer` owns mono sample data. `GranulatorConfig` stores normalized `0.0..1.0` parameter values. `Granulator` owns the sample buffer, a fixed array of active grains, smoothed parameters, and a deterministic pseudo-random generator. A grain is a short playback voice: it reads a small region from the sample buffer, applies a window envelope that starts and ends at zero, and contributes to the output cloud.
+
+The terminal listening example lives in `examples/granulator.rs`. It follows the pattern of other examples such as `examples/tom2.rs` and `examples/bass.rs`: it creates a shared instrument behind `Arc<Mutex<_>>`, adds it to `Engine`, starts `EngineOutput`, then uses `crossterm` to read keyboard input and redraw parameter bars.
+
+The original Arbhär source material is under `/Users/pretzel/Downloads/arbhar_updater_2-13`. The most relevant files are `arbhar_play_with_buffers`, `arbharGrainCore.pd`, `configurationDataInitFile.txt`, and `arbhar_structure.md`. The C/PD implementation includes stereo playback, multiple layers, live recording into buffers, follow mode, random timing and amplitude, quantized pitch deviation, MIDI/chord behavior, per-grain panning, soft grain killing, and hardware/shared-memory integration.
+
+Important plain-language terms used in this plan:
+
+A grain is one short playback voice reading a small slice of audio. A cloud is many grains overlapping. A window is the envelope shape that fades each grain in and out. A playhead is the current read position in a buffer. Scan mode means the user chooses a mostly fixed read position. Follow mode means the playhead moves automatically through the buffer. FFI means foreign function interface: C-callable functions in `src/ffi.rs` used by iOS/Swift code.
+
+## Plan of Work
+
+The plan proceeds through milestones. Each milestone leaves the system working and audible through `examples/granulator.rs`.
+
+Milestone 1 improves the existing mono static-buffer granulator. In `src/instruments/granulator.rs`, extend `GranulatorConfig` and `GranulatorParams` with normalized `random_timing`, `random_amp`, and `drive` parameters. Random timing should jitter each scheduled grain by a bounded fraction of the grain interval while keeping average density stable. Random amplitude should scale each grain volume by a deterministic random factor between `1.0 - amount` and `1.0`. Drive should apply a soft saturation after grain summing and before final volume; use a local `tanh`-style curve so this milestone does not require changing the global effects chain. Implement soft grain stealing by choosing an active grain to fade out when all slots are occupied instead of dropping the new grain. Add a small per-grain kill/fade state so stolen grains leave under a short fade rather than stopping immediately.
+
+Milestone 1 must also update `examples/granulator.rs`. Add visible controls for `random_timing`, `random_amp`, and `drive`. Keep the current keyboard model: arrow keys select and coarse-adjust, brackets fine-adjust, `SPACE` triggers a cloud, `A` toggles auto-trigger, `R` reseeds, and `Q` quits. The CLI should remain useful with no WAV path by using the generated demo buffer.
+
+Milestone 2 adds stereo-aware internals without changing the `Instrument` trait. In `src/instruments/granulator.rs`, introduce a stereo buffer representation that can store left and right samples. Add WAV loading that preserves stereo when the file has two or more channels and duplicates mono files into both channels. Add per-grain panning with an equal-power pan law, which means left gain is `cos(pan * PI / 2)` and right gain is `sin(pan * PI / 2)` for `pan` in `0.0..1.0`. Because `Instrument::tick` still returns mono, fold the stereo grain result back to mono at the final step by averaging left and right. This prepares the DSP for a future stereo engine while preserving compatibility.
+
+Milestone 3 adds static multi-layer playback. Replace the single `SampleBuffer` owned by `Granulator` with a small layer collection. A layer is one loaded buffer. Add normalized `layer` and `layer_interpolate` controls. When interpolation is zero, grains read one selected layer. When interpolation is nonzero, grains crossfade between the selected layer and the next layer. Update the CLI to accept multiple WAV paths and show the selected layer. If no path is passed, generate at least two distinct demo layers.
+
+Milestone 4 adds follow mode. Add an enum-like state for `FrozenScan` and `Follow`. In follow mode, `scan_position` becomes a starting offset and a new `follow_speed` parameter moves the internal playhead each sample or each grain spawn. The pitch parameter must still control grain playback speed, not playhead movement. Add a CLI toggle for follow mode and a `follow_speed` control. Validate that the playhead wraps cleanly and does not create clicks at buffer boundaries.
+
+Milestone 5 adds musical pitch behavior. Add a pitch deviation table based on semitone offsets, quantized random pitch selection per grain, and optional MIDI-note/chord distribution. Keep the existing continuous `pitch` control as the base multiplier. This milestone should not require the iOS FFI path. It should be demonstrable through tests and, if useful, a small CLI control for enabling quantized pitch.
+
+Milestone 6 adds live recording/capture. This is the largest DSP milestone. Design a realtime-safe recording buffer that is preallocated and never grows in the audio callback. Add capture start/stop and clear APIs. Add record-head protection fades so grains do not click when reading near the point currently being written. Decide and document whether recording replaces or overdubs existing samples. Add tests that simulate writing samples while grains play.
+
+Milestone 7 exposes the stable granulator through `src/ffi.rs`. Add an instrument type constant, extend `ChannelInstrument`, add parameter constants, and add safe buffer ownership APIs for iOS callers. This milestone must decide how Swift passes sample data into Rust and how Rust releases it.
+
+## Concrete Steps
+
+All commands in this plan assume the working directory is:
+
+    /Users/pretzel/conductor/workspaces/libgooey/kathmandu-v2
+
+Before starting any milestone, inspect the current worktree:
+
+    git status --short
+
+For Milestone 1, edit `src/instruments/granulator.rs`. Add `random_timing`, `random_amp`, and `drive` fields to `GranulatorConfig`, `GranulatorParams`, getters, setters, and `Modulatable::modulatable_parameters`. Update `apply_modulation` and `parameter_range` so LFOs can target these new controls. Add per-grain fields for amplitude and soft-kill state. Change the full-pool behavior in `spawn_grain` so the new grain still starts by fading out an existing grain and reusing it once safe. Add tests in the same file or in `tests/granulator.rs` that prove dense clouds remain finite and deterministic with a fixed seed.
+
+Then edit `examples/granulator.rs`. Add the new parameters to `PARAM_INFO`, `get_param_value`, `set_param_value`, and the display details. Keep the command line unchanged:
+
+    cargo run --example granulator --features native,crossterm,bounce
+
+For every milestone, format and test before stopping:
+
+    cargo fmt
+    cargo test granulator --features bounce
+    cargo check --example granulator --features native,crossterm,bounce
+
+Expected successful output includes lines like:
+
+    test result: ok
+    Finished `dev` profile
+
+If a milestone touches shared engine behavior or FFI, run the broader tests:
+
+    cargo test --features bounce
+
+## Validation and Acceptance
+
+Milestone 1 is accepted when `cargo run --example granulator --features native,crossterm,bounce` starts the interactive CLI, `SPACE` produces a cloud, `A` auto-triggers clouds, and the visible `random_timing`, `random_amp`, and `drive` controls audibly change the sound without producing non-intentional clicks. With `random_timing` raised, grains should feel less grid-like. With `random_amp` raised, the cloud should have more dynamic variation. With `drive` raised, the output should become denser or more saturated while remaining finite and controlled.
+
+Milestone 2 is accepted when stereo WAV files load without being reduced immediately at load time, per-grain pan changes the internal left/right balance, and the final mono output remains compatible with the existing engine. Tests should prove stereo files produce finite folded-down output.
+
+Milestone 3 is accepted when the CLI can load multiple WAV paths and switching the layer parameter changes which source material is heard. Layer interpolation should produce a smooth crossfade rather than an abrupt switch.
+
+Milestone 4 is accepted when the CLI can toggle follow mode and the cloud moves through the sample over time without the user changing scan position manually. Frozen scan mode must keep its current behavior.
+
+Milestone 5 is accepted when enabling pitch deviation produces discrete, repeatable pitch choices per grain with a fixed random seed. The continuous pitch parameter must still work.
+
+Milestone 6 is accepted when a test can write generated audio into a recording buffer while the granulator plays from it, and the output remains finite and click-controlled around the write head.
+
+Milestone 7 is accepted when the FFI engine can select the granulator as a channel instrument, set its parameters, provide a sample buffer, trigger it, and render nonzero finite output from `gooey_engine_render`.
+
+## Idempotence and Recovery
+
+The plan is additive. Running `cargo fmt`, `cargo test`, and `cargo check` multiple times is safe. If a milestone fails halfway, keep the last passing state by reverting only the files touched for that milestone; do not revert unrelated user changes.
+
+The `.context` directory is workspace-local and gitignored. Updating this plan does not affect the compiled library. Source changes for milestones should stay scoped to `src/instruments/granulator.rs`, `examples/granulator.rs`, and `tests/granulator.rs` until a milestone explicitly requires broader files such as `src/ffi.rs` or `src/engine/mod.rs`.
+
+For audio regressions, first reduce the problem to the generated demo buffer and fixed seed. If clicks appear, inspect grain start/end envelope behavior, buffer-edge reads, voice stealing, and aggregate gain changes before changing user-facing controls.
+
+## Artifacts and Notes
+
+Relevant original-design source files:
+
+    /Users/pretzel/Downloads/arbhar_updater_2-13/arbhar_play_with_buffers
+    /Users/pretzel/Downloads/arbhar_updater_2-13/arbharGrainCore.pd
+    /Users/pretzel/Downloads/arbhar_updater_2-13/configurationDataInitFile.txt
+    /Users/pretzel/Downloads/arbhar_updater_2-13/arbhar_structure.md
+
+Current V1 verification commands used during initial implementation:
+
+    cargo test
+    cargo test --features bounce
+    cargo check --example granulator --features native,crossterm,bounce
+
+Focused verification after click reduction:
+
+    cargo test granulator --features bounce
+    cargo check --example granulator --features native,crossterm,bounce
+
+The most important current behavior is in `src/instruments/granulator.rs`: `spawn_grain` chooses a safe start position so grains finish under their window envelope, and `tick_grains` smooths gain compensation as the active grain count changes.
+
+## Interfaces and Dependencies
+
+Do not add new dependencies for Milestone 1. Use the existing `crate::utils::SmoothedParam` for smoothed normalized parameters and the existing local `XorShift32` pseudo-random generator for deterministic random choices. The word deterministic means that with the same seed and same inputs, the output samples are exactly repeatable.
+
+At the end of Milestone 1, these public methods should exist on `Granulator` in `src/instruments/granulator.rs`:
+
+    pub fn random_timing(&self) -> f32;
+    pub fn random_amp(&self) -> f32;
+    pub fn drive(&self) -> f32;
+    pub fn set_random_timing(&mut self, value: f32);
+    pub fn set_random_amp(&mut self, value: f32);
+    pub fn set_drive(&mut self, value: f32);
+
+The `Modulatable` parameter list for `Granulator` should include:
+
+    "scan_position"
+    "grain_length"
+    "spray"
+    "pitch"
+    "density"
+    "texture"
+    "direction"
+    "random_timing"
+    "random_amp"
+    "drive"
+    "volume"
+
+If Milestone 2 introduces stereo internals, keep `Instrument::tick` unchanged. Add any stereo-specific types inside `src/instruments/granulator.rs` first. Do not change `src/engine/mod.rs` until there is a separate plan for stereo engine output.
+
+If Milestone 7 introduces FFI support, update `src/ffi.rs` only after the core instrument behavior has tests and a stable parameter set. Any new FFI buffer API must state who owns the memory and how it is freed.
+
+## Revision Notes
+
+2026-05-23 / Codex: Rewrote the original gap list into a `.agent/PLANS.md`-compliant ExecPlan after the user imported planning instructions. The rewrite adds required living-document sections, self-contained repository context, concrete implementation milestones, exact validation commands, interface expectations, and rationale for staging the remaining Arbhär design work.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1605,8 +1605,14 @@ pub const GRANULATOR_PARAM_DIRECTION: u32 = 6;
 pub const GRANULATOR_PARAM_CLOUD_DURATION: u32 = 7;
 /// Granulator parameter: output volume (0-1)
 pub const GRANULATOR_PARAM_VOLUME: u32 = 8;
+/// Granulator parameter: per-grain spawn-time jitter (0=periodic, 1=±100% of interval)
+pub const GRANULATOR_PARAM_RANDOM_TIMING: u32 = 9;
+/// Granulator parameter: per-grain random amplitude (0=uniform, 1=full random duck to 0)
+pub const GRANULATOR_PARAM_RANDOM_AMP: u32 = 10;
+/// Granulator parameter: output soft-saturation drive (0=clean, 1=heavy tanh)
+pub const GRANULATOR_PARAM_DRIVE: u32 = 11;
 /// Total number of granulator parameters
-pub const GRANULATOR_PARAM_COUNT: u32 = 9;
+pub const GRANULATOR_PARAM_COUNT: u32 = 12;
 
 /// Bass preset: Acid - TB-303-style, high resonance, short filter sweep
 pub const BASS_PRESET_ACID: u32 = 0;
@@ -5269,6 +5275,9 @@ pub unsafe extern "C" fn gooey_engine_granulator_set_param(
         GRANULATOR_PARAM_DIRECTION => engine.granulator.set_direction(value),
         GRANULATOR_PARAM_CLOUD_DURATION => engine.granulator.set_cloud_duration(value),
         GRANULATOR_PARAM_VOLUME => engine.granulator.set_volume(value),
+        GRANULATOR_PARAM_RANDOM_TIMING => engine.granulator.set_random_timing(value),
+        GRANULATOR_PARAM_RANDOM_AMP => engine.granulator.set_random_amp(value),
+        GRANULATOR_PARAM_DRIVE => engine.granulator.set_drive(value),
         _ => {}
     }
 }
@@ -5301,6 +5310,9 @@ pub unsafe extern "C" fn gooey_engine_granulator_get_param(
         GRANULATOR_PARAM_DIRECTION => engine.granulator.direction(),
         GRANULATOR_PARAM_CLOUD_DURATION => engine.granulator.cloud_duration(),
         GRANULATOR_PARAM_VOLUME => engine.granulator.volume(),
+        GRANULATOR_PARAM_RANDOM_TIMING => engine.granulator.random_timing(),
+        GRANULATOR_PARAM_RANDOM_AMP => engine.granulator.random_amp(),
+        GRANULATOR_PARAM_DRIVE => engine.granulator.drive(),
         _ => f32::NAN,
     }
 }

--- a/src/instruments/granulator.rs
+++ b/src/instruments/granulator.rs
@@ -11,6 +11,14 @@ use crate::utils::SmoothedParam;
 use std::sync::Arc;
 
 const MAX_GRAINS: usize = 64;
+// Capacity of the auxiliary "release pool" used to hold stolen victims while
+// they fade out. Keeping the release pool separate from the main grain pool
+// means a steal can both fade the victim AND allow the new spawn into the
+// freed main slot, so we don't drop scheduled grains under sustained
+// saturation. The pool is small because each release lasts only ~4 ms; at
+// the maximum density of 80 g/s and a 4 ms release that's ≤1 concurrent
+// stolen grain on average, with headroom for bursts.
+const RELEASE_POOL_SIZE: usize = 16;
 // Length of the fade-out applied when a grain is stolen to make room for a new
 // one. ~4 ms is short enough to be inaudible as a duck but long enough to
 // avoid a click from terminating mid-envelope.
@@ -302,6 +310,11 @@ pub struct Granulator {
     buffer: SampleBuffer,
     params: GranulatorParams,
     grains: [Grain; MAX_GRAINS],
+    // Auxiliary slots that only ever hold grains in the middle of a release
+    // fade-out. Used when stealing a slot from a saturated `grains` pool: the
+    // victim is moved here so its envelope can finish cleanly while a new
+    // grain takes the freed main slot. See RELEASE_POOL_SIZE for sizing.
+    release_grains: [Grain; RELEASE_POOL_SIZE],
     gain_compensation: SmoothedParam,
     cloud_active: bool,
     cloud_end_time: f64,
@@ -327,6 +340,7 @@ impl Granulator {
             buffer,
             params: GranulatorParams::from_config(config, sample_rate),
             grains: [Grain::default(); MAX_GRAINS],
+            release_grains: [Grain::default(); RELEASE_POOL_SIZE],
             gain_compensation: SmoothedParam::new(1.0, 0.0, 1.0, sample_rate, 10.0),
             cloud_active: false,
             cloud_end_time: 0.0,
@@ -477,10 +491,18 @@ impl Granulator {
 
     pub fn active_grain_count(&self) -> usize {
         self.grains.iter().filter(|grain| grain.active).count()
+            + self
+                .release_grains
+                .iter()
+                .filter(|grain| grain.active)
+                .count()
     }
 
     fn kill_all_grains(&mut self) {
         for grain in &mut self.grains {
+            grain.active = false;
+        }
+        for grain in &mut self.release_grains {
             grain.active = false;
         }
         self.cloud_active = false;
@@ -529,12 +551,18 @@ impl Granulator {
         let slot = match self.grains.iter().position(|grain| !grain.active) {
             Some(s) => s,
             None => {
-                // Soft stealing: mark a victim for fade-out, then drop this
-                // spawn. The next scheduled spawn will pick up the freed slot
-                // once the victim's release completes. This avoids zeroing a
-                // grain mid-window and keeps the cap at MAX_GRAINS.
-                self.steal_grain();
-                return;
+                // Soft stealing: move the victim out into the release pool so
+                // it can fade out cleanly, freeing its main slot for this
+                // spawn. If the release pool is also full we drop this grain
+                // — but the steal_grain path is the common case, so the
+                // requested spawn usually proceeds instead of being lost.
+                if !self.steal_grain() {
+                    return;
+                }
+                match self.grains.iter().position(|grain| !grain.active) {
+                    Some(s) => s,
+                    None => return,
+                }
             }
         };
 
@@ -591,38 +619,43 @@ impl Granulator {
         };
     }
 
-    fn steal_grain(&mut self) {
-        // Pick the active grain with the shortest remaining playback time.
-        // Already-releasing grains will naturally have small remaining time
-        // because their release window dominates, so they are preferred.
+    /// Relocate the most-stealable active grain from `grains` into
+    /// `release_grains` with a short fade-out, freeing its main slot for a
+    /// new spawn. Returns true if a main slot was freed, false otherwise
+    /// (release pool full or no active main grains).
+    fn steal_grain(&mut self) -> bool {
+        // Pick the active main-pool grain with the shortest remaining
+        // playback time — that's the grain whose loss costs the least.
         let mut victim: Option<usize> = None;
         let mut shortest_remaining = f32::INFINITY;
         for (idx, grain) in self.grains.iter().enumerate() {
             if !grain.active {
                 continue;
             }
-            let remaining = if grain.release_samples > 0.0 {
-                grain.release_samples
-            } else {
-                (grain.duration_samples - grain.age_samples).max(0.0)
-            };
+            let remaining = (grain.duration_samples - grain.age_samples).max(0.0);
             if remaining < shortest_remaining {
                 shortest_remaining = remaining;
                 victim = Some(idx);
             }
         }
+        let Some(idx) = victim else {
+            return false;
+        };
 
-        if let Some(idx) = victim {
-            let grain = &mut self.grains[idx];
-            if grain.release_samples > 0.0 {
-                return;
-            }
-            let release = (STEAL_RELEASE_MS * 0.001 * self.sample_rate).max(1.0);
-            let remaining = (grain.duration_samples - grain.age_samples).max(1.0);
-            let release = release.min(remaining);
-            grain.release_samples = release;
-            grain.release_total = release;
-        }
+        let Some(release_slot) = self.release_grains.iter().position(|grain| !grain.active) else {
+            return false;
+        };
+
+        let release = (STEAL_RELEASE_MS * 0.001 * self.sample_rate).max(1.0);
+        let remaining = (self.grains[idx].duration_samples - self.grains[idx].age_samples).max(1.0);
+        let release = release.min(remaining);
+
+        let mut moved = self.grains[idx];
+        moved.release_samples = release;
+        moved.release_total = release;
+        self.release_grains[release_slot] = moved;
+        self.grains[idx].active = false;
+        true
     }
 
     fn tick_grains(&mut self) -> f32 {
@@ -637,7 +670,23 @@ impl Granulator {
             .set_target(1.0 / (active_count as f32).sqrt());
         let gain_comp = self.gain_compensation.tick();
         let mut output = 0.0;
-        for grain in &mut self.grains {
+        Self::tick_grain_slice(&mut self.grains, &self.buffer, gain_comp, &mut output);
+        Self::tick_grain_slice(
+            &mut self.release_grains,
+            &self.buffer,
+            gain_comp,
+            &mut output,
+        );
+        output
+    }
+
+    fn tick_grain_slice(
+        slice: &mut [Grain],
+        buffer: &SampleBuffer,
+        gain_comp: f32,
+        output: &mut f32,
+    ) {
+        for grain in slice.iter_mut() {
             if !grain.active {
                 continue;
             }
@@ -654,8 +703,8 @@ impl Granulator {
             } else {
                 1.0
             };
-            let sample = self.buffer.sample_interpolated(grain.source_pos);
-            output += sample * window * release_gain * grain.velocity * gain_comp;
+            let sample = buffer.sample_interpolated(grain.source_pos);
+            *output += sample * window * release_gain * grain.velocity * gain_comp;
 
             grain.source_pos += grain.speed * grain.direction;
             grain.age_samples += 1.0;
@@ -666,8 +715,6 @@ impl Granulator {
                 }
             }
         }
-
-        output
     }
 }
 
@@ -970,10 +1017,8 @@ mod tests {
     #[test]
     fn soft_grain_stealing_does_not_click() {
         // Force the grain pool to saturate by combining max density with
-        // long grains. Without soft stealing the older implementation would
-        // simply drop the new grain; the new implementation fades an
-        // existing grain out instead. Either way the output must stay
-        // finite and bounded.
+        // long grains. The release pool absorbs stolen victims so new
+        // spawns still land. Output must stay finite and bounded.
         let mut granulator = Granulator::new(44100.0, test_buffer());
         granulator.set_seed(31);
         granulator.set_density(1.0);
@@ -987,8 +1032,76 @@ mod tests {
             assert!(s.is_finite());
             assert!(s.abs() < 4.0, "runaway gain at sample {i}: {s}");
         }
-        // The pool is hard-capped at MAX_GRAINS.
-        assert!(granulator.active_grain_count() <= MAX_GRAINS);
+        // Total live voices are bounded by main + release pool capacity.
+        assert!(granulator.active_grain_count() <= MAX_GRAINS + RELEASE_POOL_SIZE);
+    }
+
+    #[test]
+    fn soft_steal_promotes_new_spawn_into_main_pool() {
+        // Saturate the main pool with long grains so every subsequent
+        // spawn must go through steal_grain. The contract under review:
+        // the new spawn must actually land in the main pool instead of
+        // being silently dropped while the victim fades out.
+        //
+        // Use a deliberately long buffer (3s) so grain durations aren't
+        // clamped down by buffer length — otherwise short grains free
+        // their slots naturally and the pool never saturates.
+        let sample_rate = 44100.0;
+        let long_buffer_samples: Vec<f32> = (0..(sample_rate as usize * 3))
+            .map(|i| ((i as f32 / sample_rate) * 440.0 * std::f32::consts::TAU).sin() * 0.5)
+            .collect();
+        let buffer = SampleBuffer::from_mono(long_buffer_samples, sample_rate).unwrap();
+        let mut granulator = Granulator::new(sample_rate, buffer);
+        granulator.set_seed(53);
+        granulator.set_density(1.0); // 80 g/s
+        granulator.set_grain_length(1.0); // 3000 ms — main pool fills fast
+        granulator.set_cloud_duration(1.0);
+        granulator.snap_params();
+        granulator.trigger_with_velocity(0.0, 1.0);
+
+        // Run ~1.5 s: at 80 g/s × 3 s grains, the 64-slot main pool
+        // saturates around t≈0.8 s; everything after that exercises
+        // the steal path. Track the peak releasing-pool occupancy because
+        // each release fade is only ~4 ms while steals happen every ~12 ms,
+        // so the release pool is empty more often than not at any
+        // arbitrary moment.
+        let mut peak_releasing = 0usize;
+        let mut peak_main = 0usize;
+        for i in 0..((sample_rate * 1.5) as usize) {
+            granulator.tick(i as f64 / sample_rate as f64);
+            let main_now = granulator.grains.iter().filter(|g| g.active).count();
+            let rel_now = granulator
+                .release_grains
+                .iter()
+                .filter(|g| g.active)
+                .count();
+            peak_main = peak_main.max(main_now);
+            peak_releasing = peak_releasing.max(rel_now);
+        }
+
+        assert_eq!(
+            peak_main, MAX_GRAINS,
+            "main pool should saturate under sustained density"
+        );
+        assert!(
+            peak_releasing > 0,
+            "release pool should hold at least one stolen victim at some point"
+        );
+
+        // And the youngest grain in the main pool should be very young
+        // (the post-steal spawn), proving new grains are landing rather
+        // than being dropped.
+        let youngest_age = granulator
+            .grains
+            .iter()
+            .filter(|g| g.active)
+            .map(|g| g.age_samples as i32)
+            .min()
+            .unwrap_or(i32::MAX);
+        assert!(
+            youngest_age < (sample_rate * 0.05) as i32,
+            "no recently-spawned grain found in main pool (youngest = {youngest_age} samples)"
+        );
     }
 
     #[test]

--- a/src/instruments/granulator.rs
+++ b/src/instruments/granulator.rs
@@ -10,6 +10,10 @@ use crate::utils::SmoothedParam;
 use std::sync::Arc;
 
 const MAX_GRAINS: usize = 64;
+// Length of the fade-out applied when a grain is stolen to make room for a new
+// one. ~4 ms is short enough to be inaudible as a duck but long enough to
+// avoid a click from terminating mid-envelope.
+const STEAL_RELEASE_MS: f32 = 4.0;
 const MIN_GRAIN_MS: f32 = 5.0;
 const MAX_GRAIN_MS: f32 = 3000.0;
 const MAX_SPRAY_SECS: f32 = 10.0;
@@ -160,6 +164,9 @@ pub struct GranulatorConfig {
     pub direction: f32,
     pub cloud_duration: f32,
     pub volume: f32,
+    pub random_timing: f32,
+    pub random_amp: f32,
+    pub drive: f32,
 }
 
 impl Default for GranulatorConfig {
@@ -174,6 +181,9 @@ impl Default for GranulatorConfig {
             direction: 0.0,
             cloud_duration: 0.35,
             volume: 0.8,
+            random_timing: 0.0,
+            random_amp: 0.0,
+            drive: 0.0,
         }
     }
 }
@@ -189,6 +199,9 @@ struct GranulatorParams {
     direction: SmoothedParam,
     cloud_duration: SmoothedParam,
     volume: SmoothedParam,
+    random_timing: SmoothedParam,
+    random_amp: SmoothedParam,
+    drive: SmoothedParam,
 }
 
 impl GranulatorParams {
@@ -203,6 +216,9 @@ impl GranulatorParams {
             direction: SmoothedParam::new_normalized(config.direction, sample_rate),
             cloud_duration: SmoothedParam::new_normalized(config.cloud_duration, sample_rate),
             volume: SmoothedParam::new_normalized(config.volume, sample_rate),
+            random_timing: SmoothedParam::new_normalized(config.random_timing, sample_rate),
+            random_amp: SmoothedParam::new_normalized(config.random_amp, sample_rate),
+            drive: SmoothedParam::new_normalized(config.drive, sample_rate),
         }
     }
 
@@ -217,6 +233,9 @@ impl GranulatorParams {
         self.direction.tick();
         self.cloud_duration.tick();
         self.volume.tick();
+        self.random_timing.tick();
+        self.random_amp.tick();
+        self.drive.tick();
     }
 
     fn snap_all(&mut self) {
@@ -229,6 +248,9 @@ impl GranulatorParams {
         self.direction.snap();
         self.cloud_duration.snap();
         self.volume.snap();
+        self.random_timing.snap();
+        self.random_amp.snap();
+        self.drive.snap();
     }
 }
 
@@ -242,6 +264,11 @@ struct Grain {
     direction: f32,
     window_shape: f32,
     velocity: f32,
+    // Soft-kill fade-out state. While `release_samples > 0`, the grain is being
+    // faded out (used when a new spawn steals this slot); when it hits 0 the
+    // grain deactivates without producing a sample-edge discontinuity.
+    release_samples: f32,
+    release_total: f32,
 }
 
 impl Default for Grain {
@@ -255,6 +282,8 @@ impl Default for Grain {
             direction: 1.0,
             window_shape: 1.0,
             velocity: 1.0,
+            release_samples: 0.0,
+            release_total: 0.0,
         }
     }
 }
@@ -351,6 +380,18 @@ impl Granulator {
         self.params.volume.target()
     }
 
+    pub fn random_timing(&self) -> f32 {
+        self.params.random_timing.target()
+    }
+
+    pub fn random_amp(&self) -> f32 {
+        self.params.random_amp.target()
+    }
+
+    pub fn drive(&self) -> f32 {
+        self.params.drive.target()
+    }
+
     pub fn grain_length_ms(&self) -> f32 {
         grain_length_ms(self.grain_length())
     }
@@ -407,6 +448,18 @@ impl Granulator {
         self.params.volume.set_target(value);
     }
 
+    pub fn set_random_timing(&mut self, value: f32) {
+        self.params.random_timing.set_target(value);
+    }
+
+    pub fn set_random_amp(&mut self, value: f32) {
+        self.params.random_amp.set_target(value);
+    }
+
+    pub fn set_drive(&mut self, value: f32) {
+        self.params.drive.set_target(value);
+    }
+
     pub fn active_grain_count(&self) -> usize {
         self.grains.iter().filter(|grain| grain.active).count()
     }
@@ -434,10 +487,18 @@ impl Granulator {
         }
 
         let interval = 1.0 / density as f64;
+        let random_timing = self.params.random_timing.get().clamp(0.0, 1.0) as f64;
         let mut guard = 0;
         while self.cloud_active && current_time + 1e-12 >= self.next_grain_time && guard < 8 {
             self.spawn_grain();
             self.next_grain_time += interval;
+            // Random timing jitter: signed offset bounded by ±interval * amount.
+            // Average density is preserved because the jitter is zero-mean and
+            // applied after the interval has already advanced.
+            if random_timing > 0.0 {
+                let jitter = ((self.rng.next_f32() as f64) * 2.0 - 1.0) * interval * random_timing;
+                self.next_grain_time = (self.next_grain_time + jitter).max(current_time);
+            }
             if self.next_grain_time > self.cloud_end_time {
                 self.cloud_active = false;
             }
@@ -446,8 +507,20 @@ impl Granulator {
     }
 
     fn spawn_grain(&mut self) {
-        let Some(slot) = self.grains.iter().position(|grain| !grain.active) else {
-            return;
+        // Pre-roll the RNG for amp jitter so the deterministic-output test still
+        // sees a stable sequence regardless of whether the slot is free or stolen.
+        let amp_jitter = self.rng.next_f32();
+
+        let slot = match self.grains.iter().position(|grain| !grain.active) {
+            Some(s) => s,
+            None => {
+                // Soft stealing: mark a victim for fade-out, then drop this
+                // spawn. The next scheduled spawn will pick up the freed slot
+                // once the victim's release completes. This avoids zeroing a
+                // grain mid-window and keeps the cap at MAX_GRAINS.
+                self.steal_grain();
+                return;
+            }
         };
 
         let last_sample = (self.buffer.len() - 1) as f32;
@@ -485,6 +558,10 @@ impl Granulator {
             requested_source_pos.clamp(0.0, last_sample - source_travel)
         };
 
+        // Per-grain random amplitude: factor in [1 - random_amp, 1.0].
+        let random_amp = self.params.random_amp.get().clamp(0.0, 1.0);
+        let amp_factor = 1.0 - random_amp * amp_jitter;
+
         self.grains[slot] = Grain {
             active: true,
             source_pos,
@@ -493,8 +570,44 @@ impl Granulator {
             speed,
             direction,
             window_shape,
-            velocity: self.current_velocity,
+            velocity: self.current_velocity * amp_factor,
+            release_samples: 0.0,
+            release_total: 0.0,
         };
+    }
+
+    fn steal_grain(&mut self) {
+        // Pick the active grain with the shortest remaining playback time.
+        // Already-releasing grains will naturally have small remaining time
+        // because their release window dominates, so they are preferred.
+        let mut victim: Option<usize> = None;
+        let mut shortest_remaining = f32::INFINITY;
+        for (idx, grain) in self.grains.iter().enumerate() {
+            if !grain.active {
+                continue;
+            }
+            let remaining = if grain.release_samples > 0.0 {
+                grain.release_samples
+            } else {
+                (grain.duration_samples - grain.age_samples).max(0.0)
+            };
+            if remaining < shortest_remaining {
+                shortest_remaining = remaining;
+                victim = Some(idx);
+            }
+        }
+
+        if let Some(idx) = victim {
+            let grain = &mut self.grains[idx];
+            if grain.release_samples > 0.0 {
+                return;
+            }
+            let release = (STEAL_RELEASE_MS * 0.001 * self.sample_rate).max(1.0);
+            let remaining = (grain.duration_samples - grain.age_samples).max(1.0);
+            let release = release.min(remaining);
+            grain.release_samples = release;
+            grain.release_total = release;
+        }
     }
 
     fn tick_grains(&mut self) -> f32 {
@@ -521,11 +634,22 @@ impl Granulator {
 
             let phase = (grain.age_samples / grain.duration_samples).clamp(0.0, 1.0);
             let window = raised_sine_window(phase, grain.window_shape);
+            let release_gain = if grain.release_total > 0.0 {
+                (grain.release_samples / grain.release_total).clamp(0.0, 1.0)
+            } else {
+                1.0
+            };
             let sample = self.buffer.sample_interpolated(grain.source_pos);
-            output += sample * window * grain.velocity * gain_comp;
+            output += sample * window * release_gain * grain.velocity * gain_comp;
 
             grain.source_pos += grain.speed * grain.direction;
             grain.age_samples += 1.0;
+            if grain.release_samples > 0.0 {
+                grain.release_samples -= 1.0;
+                if grain.release_samples <= 0.0 {
+                    grain.active = false;
+                }
+            }
         }
 
         output
@@ -544,7 +668,9 @@ impl Instrument for Granulator {
     fn tick(&mut self, current_time: f64) -> f32 {
         self.params.tick();
         self.spawn_due_grains(current_time);
-        self.tick_grains() * self.params.volume.get()
+        let raw = self.tick_grains();
+        let driven = soft_saturate(raw, self.params.drive.get());
+        driven * self.params.volume.get()
     }
 
     fn is_active(&self) -> bool {
@@ -566,6 +692,9 @@ impl Modulatable for Granulator {
             "density",
             "texture",
             "direction",
+            "random_timing",
+            "random_amp",
+            "drive",
             "volume",
         ]
     }
@@ -579,6 +708,9 @@ impl Modulatable for Granulator {
             "density" => self.params.density.set_bipolar(value),
             "texture" => self.params.texture.set_bipolar(value),
             "direction" => self.params.direction.set_bipolar(value),
+            "random_timing" => self.params.random_timing.set_bipolar(value),
+            "random_amp" => self.params.random_amp.set_bipolar(value),
+            "drive" => self.params.drive.set_bipolar(value),
             "volume" => self.params.volume.set_bipolar(value),
             _ => return Err(format!("Unknown granulator parameter: {parameter}")),
         }
@@ -588,7 +720,7 @@ impl Modulatable for Granulator {
     fn parameter_range(&self, parameter: &str) -> Option<(f32, f32)> {
         match parameter {
             "scan_position" | "grain_length" | "spray" | "pitch" | "density" | "texture"
-            | "direction" | "volume" => Some((0.0, 1.0)),
+            | "direction" | "random_timing" | "random_amp" | "drive" | "volume" => Some((0.0, 1.0)),
             _ => None,
         }
     }
@@ -634,6 +766,19 @@ fn raised_sine_window(phase: f32, shape: f32) -> f32 {
         .sin()
         .max(0.0)
         .powf(shape)
+}
+
+#[inline]
+fn soft_saturate(x: f32, drive: f32) -> f32 {
+    let drive = drive.clamp(0.0, 1.0);
+    if drive <= 0.0 {
+        return x;
+    }
+    // Map drive 0..1 to gain 1..5, then normalize by tanh(gain) so that a
+    // unity-input maps to a unity-output (avoids the loudness boost a raw
+    // tanh would add and keeps quiet signal recognizable).
+    let gain = 1.0 + drive * 4.0;
+    (x * gain).tanh() / gain.tanh()
 }
 
 #[inline]
@@ -750,6 +895,107 @@ mod tests {
         for parameter in granulator.modulatable_parameters() {
             assert_eq!(granulator.parameter_range(parameter), Some((0.0, 1.0)));
         }
+    }
+
+    #[test]
+    fn dense_cloud_with_random_amp_remains_finite() {
+        let mut granulator = Granulator::new(44100.0, test_buffer());
+        granulator.set_seed(13);
+        granulator.set_density(1.0);
+        granulator.set_random_amp(1.0);
+        granulator.set_random_timing(1.0);
+        granulator.set_cloud_duration(1.0);
+        granulator.snap_params();
+        granulator.trigger_with_velocity(0.0, 1.0);
+
+        let mut max_abs = 0.0_f32;
+        for i in 0..88_200 {
+            let sample = granulator.tick(i as f64 / 44100.0);
+            assert!(sample.is_finite(), "non-finite sample at {i}");
+            max_abs = max_abs.max(sample.abs());
+        }
+        assert!(max_abs > 0.001, "expected audible output");
+    }
+
+    #[test]
+    fn random_timing_preserves_average_density() {
+        // With random_timing = 1.0 the spawn times are heavily jittered. The
+        // long-run average density must still track the target because the
+        // jitter is zero-mean.
+        let mut granulator = Granulator::new(44100.0, test_buffer());
+        granulator.set_seed(101);
+        granulator.set_density(0.5); // 0.5 * MAX_DENSITY(80) = 40 grains/sec target
+        granulator.set_grain_length(0.0); // shortest grains so they end quickly and free slots
+        granulator.set_random_timing(1.0);
+        granulator.set_cloud_duration(1.0);
+        granulator.snap_params();
+        granulator.trigger_with_velocity(0.0, 1.0);
+
+        // Run ~2 seconds and count grain spawns by sampling the pool. Because
+        // grain_length is the shortest setting (~5 ms) each grain ends fast
+        // enough that we can approximate the spawn rate from active counts
+        // observed at large intervals — but a simpler accept-band check is
+        // enough here: confirm the granulator is producing audio across the
+        // whole cloud duration, which only happens if scheduling is healthy.
+        let mut audible_blocks = 0;
+        let block = 4410; // 0.1s
+        for b in 0..20 {
+            let mut block_max = 0.0_f32;
+            for i in 0..block {
+                let t = (b * block + i) as f64 / 44100.0;
+                let s = granulator.tick(t);
+                assert!(s.is_finite());
+                block_max = block_max.max(s.abs());
+            }
+            if block_max > 1e-4 {
+                audible_blocks += 1;
+            }
+        }
+        // At density 40/s with grains across a 2s cloud, the vast majority
+        // of 0.1s windows should be audible even under heavy jitter.
+        assert!(
+            audible_blocks >= 12,
+            "random_timing collapsed scheduling: only {audible_blocks}/20 blocks audible"
+        );
+    }
+
+    #[test]
+    fn soft_grain_stealing_does_not_click() {
+        // Force the grain pool to saturate by combining max density with
+        // long grains. Without soft stealing the older implementation would
+        // simply drop the new grain; the new implementation fades an
+        // existing grain out instead. Either way the output must stay
+        // finite and bounded.
+        let mut granulator = Granulator::new(44100.0, test_buffer());
+        granulator.set_seed(31);
+        granulator.set_density(1.0);
+        granulator.set_grain_length(1.0); // 3000 ms grains
+        granulator.set_cloud_duration(1.0);
+        granulator.snap_params();
+        granulator.trigger_with_velocity(0.0, 1.0);
+
+        for i in 0..88_200 {
+            let s = granulator.tick(i as f64 / 44100.0);
+            assert!(s.is_finite());
+            assert!(s.abs() < 4.0, "runaway gain at sample {i}: {s}");
+        }
+        // The pool is hard-capped at MAX_GRAINS.
+        assert!(granulator.active_grain_count() <= MAX_GRAINS);
+    }
+
+    #[test]
+    fn drive_increases_peak_for_quiet_signal_and_is_bounded() {
+        // Saturation should raise small-signal output (the tanh derivative at
+        // 0 is `gain / tanh(gain) > 1`) and keep large-signal output bounded
+        // near unity. The exact ceiling is `1 / tanh(1 + 4*drive)`, which at
+        // drive=1.0 is ~1.0001 — so we use a small slack rather than 1.0.
+        let dry = soft_saturate(0.1, 0.0);
+        let wet = soft_saturate(0.1, 1.0);
+        assert!(wet > dry);
+        assert!(soft_saturate(10.0, 1.0).abs() <= 1.01);
+        assert!(soft_saturate(-10.0, 1.0).abs() <= 1.01);
+        // drive = 0 is identity.
+        assert_eq!(soft_saturate(0.42, 0.0), 0.42);
     }
 
     #[cfg(feature = "bounce")]

--- a/src/instruments/granulator.rs
+++ b/src/instruments/granulator.rs
@@ -5,6 +5,7 @@
 //! position, with random spray, pitch/speed, direction probability, and a
 //! shaped window envelope.
 
+use crate::effects::Waveshaper;
 use crate::engine::{Instrument, Modulatable};
 use crate::utils::SmoothedParam;
 use std::sync::Arc;
@@ -14,6 +15,13 @@ const MAX_GRAINS: usize = 64;
 // one. ~4 ms is short enough to be inaudible as a duck but long enough to
 // avoid a click from terminating mid-envelope.
 const STEAL_RELEASE_MS: f32 = 4.0;
+// Fixed internal drive for the shared Waveshaper effect. The user-facing
+// `drive` parameter controls the Waveshaper's mix rather than its drive
+// gain, so going from 0 to 1 fades the saturated path in against the dry
+// path instead of pushing more level into the saturator. The Waveshaper's
+// own compensation (`tanh(0.5) / tanh(0.5 * drive)`) keeps the wet path
+// unity at ±0.5 amplitude, so peaks soften and quiet signal is preserved.
+const DRIVE_INTERNAL_AMOUNT: f32 = 4.0;
 const MIN_GRAIN_MS: f32 = 5.0;
 const MAX_GRAIN_MS: f32 = 3000.0;
 const MAX_SPRAY_SECS: f32 = 10.0;
@@ -300,6 +308,7 @@ pub struct Granulator {
     next_grain_time: f64,
     current_velocity: f32,
     rng: XorShift32,
+    drive_shaper: Waveshaper,
 }
 
 impl Granulator {
@@ -308,6 +317,11 @@ impl Granulator {
     }
 
     pub fn with_config(sample_rate: f32, buffer: SampleBuffer, config: GranulatorConfig) -> Self {
+        // Initialize Waveshaper with mix = configured drive so the wet path
+        // matches the requested drive level on construction; internal drive
+        // is fixed so the user-facing param is gain-neutral (see
+        // DRIVE_INTERNAL_AMOUNT comment).
+        let drive_shaper = Waveshaper::new(DRIVE_INTERNAL_AMOUNT, config.drive.clamp(0.0, 1.0));
         Self {
             sample_rate,
             buffer,
@@ -319,6 +333,7 @@ impl Granulator {
             next_grain_time: 0.0,
             current_velocity: 1.0,
             rng: XorShift32::new(0x1234_abcd),
+            drive_shaper,
         }
     }
 
@@ -669,7 +684,13 @@ impl Instrument for Granulator {
         self.params.tick();
         self.spawn_due_grains(current_time);
         let raw = self.tick_grains();
-        let driven = soft_saturate(raw, self.params.drive.get());
+        // Push the latest smoothed drive target into the Waveshaper's mix.
+        // Drive=0 → mix=0 → exact dry passthrough; drive=1 → fully wet at
+        // the fixed internal drive. Internal drive is held constant so this
+        // user-facing knob fades saturation in/out rather than boosting
+        // level into the saturator.
+        self.drive_shaper.set_mix(self.params.drive.get());
+        let driven = self.drive_shaper.process(raw);
         driven * self.params.volume.get()
     }
 
@@ -766,19 +787,6 @@ fn raised_sine_window(phase: f32, shape: f32) -> f32 {
         .sin()
         .max(0.0)
         .powf(shape)
-}
-
-#[inline]
-fn soft_saturate(x: f32, drive: f32) -> f32 {
-    let drive = drive.clamp(0.0, 1.0);
-    if drive <= 0.0 {
-        return x;
-    }
-    // Map drive 0..1 to gain 1..5, then normalize by tanh(gain) so that a
-    // unity-input maps to a unity-output (avoids the loudness boost a raw
-    // tanh would add and keeps quiet signal recognizable).
-    let gain = 1.0 + drive * 4.0;
-    (x * gain).tanh() / gain.tanh()
 }
 
 #[inline]
@@ -984,18 +992,40 @@ mod tests {
     }
 
     #[test]
-    fn drive_increases_peak_for_quiet_signal_and_is_bounded() {
-        // Saturation should raise small-signal output (the tanh derivative at
-        // 0 is `gain / tanh(gain) > 1`) and keep large-signal output bounded
-        // near unity. The exact ceiling is `1 / tanh(1 + 4*drive)`, which at
-        // drive=1.0 is ~1.0001 — so we use a small slack rather than 1.0.
-        let dry = soft_saturate(0.1, 0.0);
-        let wet = soft_saturate(0.1, 1.0);
-        assert!(wet > dry);
-        assert!(soft_saturate(10.0, 1.0).abs() <= 1.01);
-        assert!(soft_saturate(-10.0, 1.0).abs() <= 1.01);
-        // drive = 0 is identity.
-        assert_eq!(soft_saturate(0.42, 0.0), 0.42);
+    fn drive_is_roughly_gain_neutral() {
+        // The drive parameter is wired into the Waveshaper's mix while the
+        // internal drive is fixed. With Waveshaper's reference-level
+        // compensation centered at ±0.5, full drive (mix=1) must not boost
+        // the cloud's peak level substantially over a clean (drive=0) cloud.
+        // Same seed and inputs → directly comparable peak levels.
+        fn peak_with_drive(drive: f32) -> f32 {
+            let mut g = Granulator::new(44100.0, test_buffer());
+            g.set_seed(17);
+            g.set_density(0.4);
+            g.set_cloud_duration(0.6);
+            g.set_volume(1.0);
+            g.set_drive(drive);
+            g.snap_params();
+            g.trigger_with_velocity(0.0, 1.0);
+            let mut peak = 0.0_f32;
+            for i in 0..44_100 {
+                let s = g.tick(i as f64 / 44100.0);
+                assert!(s.is_finite());
+                peak = peak.max(s.abs());
+            }
+            peak
+        }
+        let dry_peak = peak_with_drive(0.0);
+        let wet_peak = peak_with_drive(1.0);
+        // Wet path must not exceed the dry peak by more than ~25%. This is
+        // the user-visible contract: turning drive up should saturate, not
+        // boost loudness.
+        assert!(
+            wet_peak <= dry_peak * 1.25,
+            "drive boosted peak too much: dry={dry_peak}, wet={wet_peak}"
+        );
+        // And the peak should still be bounded (no runaway).
+        assert!(wet_peak.is_finite() && wet_peak < 4.0);
     }
 
     #[cfg(feature = "bounce")]

--- a/tests/ffi_granulator.rs
+++ b/tests/ffi_granulator.rs
@@ -101,6 +101,9 @@ fn param_round_trip() {
         gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_DIRECTION, 0.0);
         gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_CLOUD_DURATION, 0.5);
         gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_VOLUME, 0.9);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_RANDOM_TIMING, 0.45);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_RANDOM_AMP, 0.65);
+        gooey_engine_granulator_set_param(engine, GRANULATOR_PARAM_DRIVE, 0.8);
 
         approx_eq(
             gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_SCAN_POSITION),
@@ -137,6 +140,18 @@ fn param_round_trip() {
         approx_eq(
             gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_VOLUME),
             0.9,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_RANDOM_TIMING),
+            0.45,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_RANDOM_AMP),
+            0.65,
+        );
+        approx_eq(
+            gooey_engine_granulator_get_param(engine, GRANULATOR_PARAM_DRIVE),
+            0.8,
         );
 
         assert!(gooey_engine_granulator_get_param(engine, 999).is_nan());

--- a/tests/granulator.rs
+++ b/tests/granulator.rs
@@ -51,6 +51,9 @@ fn granulator_parameters_are_modulatable() {
         "density",
         "texture",
         "direction",
+        "random_timing",
+        "random_amp",
+        "drive",
         "volume",
     ];
 


### PR DESCRIPTION
## Summary

- Adds `random_timing`, `random_amp`, and `drive` parameters to `Granulator` (smoothed, modulatable, surfaced in the CLI and FFI).
- Replaces hard grain-drop at the 64-grain cap with soft stealing: the shortest-remaining grain enters a ~4 ms release fade instead of terminating mid-window.
- Extends the FFI append-only (new IDs 9/10/11, `GRANULATOR_PARAM_COUNT` → 12) so the existing iOS integration is unaffected.
- Checks in the multi-milestone ExecPlan under `plans/granulator-original-design-gap-plan.md` as the guiding doc for upcoming work (stereo, layers, follow mode, recording, etc.).

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo build\` and \`cargo build --example granulator --features native,crossterm,bounce\`
- [x] \`cargo test\` (181 passing) and \`cargo test --features bounce\` (182 passing)
- [x] \`cargo clippy --lib --tests --all-features\` (clean; pre-existing warnings only)
- [ ] Listen via \`cargo run --example granulator --features native,crossterm,bounce\` and confirm \`random_timing\` removes the periodic grid, \`random_amp\` adds dynamic variation, and \`drive\` saturates without clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)