### PR TITLE
[codex] Fix kick and snare volume scaling

### DIFF
--- a/src/instruments/kick.rs
+++ b/src/instruments/kick.rs
@@ -868,7 +868,7 @@ impl KickDrum {
 
     /// Apply current smoothed parameters to oscillators (called per-sample)
     ///
-    /// NOTE: Only mix/volume parameters are applied here. Pitch-related parameters
+    /// NOTE: Only mix parameters are applied here. Pitch-related parameters
     /// (frequency, pitch_start_multiplier) are frozen at trigger time to prevent
     /// discontinuities when parameters change during decay.
     #[inline]
@@ -876,18 +876,17 @@ impl KickDrum {
         let punch = self.params.punch.get();
         let sub = self.params.sub.get();
         let click = self.params.click.get();
-        let volume = self.params.volume.get();
 
         // Light velocity scaling for click: range [0.6, 1.0]
         // Higher velocity = more click, lower velocity = less click
         let click_vel_scale = 0.6 + 0.4 * self.current_velocity;
 
-        // Update oscillator volumes (these can change smoothly without pops)
-        self.sub_oscillator.set_volume(sub * volume);
-        self.punch_oscillator.set_volume(punch * volume * 0.7);
+        // Update relative oscillator levels. Master volume is applied once at output.
+        self.sub_oscillator.set_volume(sub);
+        self.punch_oscillator.set_volume(punch * 0.7);
         // Click reduced from 0.3 to 0.15, with velocity scaling
         self.click_oscillator
-            .set_volume(click * volume * 0.15 * click_vel_scale);
+            .set_volume(click * 0.15 * click_vel_scale);
     }
 
     pub fn set_config(&mut self, config: KickConfig) {
@@ -932,7 +931,8 @@ impl KickDrum {
         // Envelope configurations (decay times, curves) are applied on trigger,
         // not during parameter changes. This prevents pops/discontinuities when
         // parameters change while a sound is still decaying.
-        // Smoothable params (volume, filter, mix) update in real-time via apply_params().
+        // Smoothable filter/mix params update in real-time via apply_params().
+        // Master volume is read directly at final output.
     }
 
     /// Snap all smoothed parameters to their targets instantly.
@@ -1089,7 +1089,7 @@ impl KickDrum {
             return 0.0;
         }
 
-        // Apply smoothed parameters to oscillators (mix/volume only)
+        // Apply smoothed mix parameters to oscillators
         self.apply_params();
 
         // Re-apply oscillator decay times each sample so LFO modulation of
@@ -1175,7 +1175,7 @@ impl KickDrum {
             // Apply noise envelope
             // Scale noise_amount by 0.5 to reduce maximum volume
             let noise_env = self.noise_envelope.get_amplitude(current_time);
-            filtered_noise * noise_env * noise_amount * 0.5 * self.params.volume.get()
+            filtered_noise * noise_env * noise_amount * 0.5
         } else {
             0.0
         };

--- a/src/instruments/snare.rs
+++ b/src/instruments/snare.rs
@@ -890,7 +890,6 @@ impl SnareDrum {
         // Get current smoothed parameter values (use helper methods for denormalized values)
         let base_freq = self.params.frequency_hz();
         let base_decay = self.params.decay_secs();
-        let volume = self.params.volume.get();
         let brightness = self.params.brightness.get();
         let tonal_amount = self.params.tonal.get();
         let noise_amount = self.params.noise.get();
@@ -926,7 +925,7 @@ impl SnareDrum {
         // Configure tonal oscillator envelope to hold (sustain=1.0)
         // The dedicated tonal_envelope controls the actual decay shape
         self.tonal_oscillator.frequency_hz = base_freq;
-        self.tonal_oscillator.set_volume(tonal_amount * volume);
+        self.tonal_oscillator.set_volume(tonal_amount);
         self.tonal_oscillator.set_adsr(ADSRConfig::new(
             0.001,              // Very fast attack
             0.001,              // Minimal decay (go straight to sustain)
@@ -937,8 +936,7 @@ impl SnareDrum {
         // Configure noise oscillator envelope to hold (sustain=1.0)
         // The dedicated noise envelopes control the actual decay shape
         self.noise_oscillator.frequency_hz = base_freq * 8.0;
-        self.noise_oscillator
-            .set_volume(noise_amount * volume * 0.8);
+        self.noise_oscillator.set_volume(noise_amount * 0.8);
         self.noise_oscillator.set_adsr(ADSRConfig::new(
             0.001,              // Very fast attack
             0.001,              // Minimal decay (go straight to sustain)
@@ -951,7 +949,7 @@ impl SnareDrum {
         let crack_vel_scale = 0.7 + 0.3 * vel;
         self.crack_oscillator.frequency_hz = base_freq * 25.0;
         self.crack_oscillator
-            .set_volume(brightness * volume * 0.4 * crack_vel_scale);
+            .set_volume(brightness * 0.4 * crack_vel_scale);
         self.crack_oscillator.set_adsr(ADSRConfig::new(
             0.001,              // Very fast attack
             scaled_decay * 0.2, // Very short decay for crack (velocity-scaled)
@@ -1206,7 +1204,6 @@ impl SnareDrum {
     /// Apply current smoothed parameters to oscillators (called per-sample)
     #[inline]
     fn apply_params(&mut self) {
-        let volume = self.params.volume.get();
         let brightness = self.params.brightness.get();
         let tonal_amount = self.params.tonal.get();
         let noise_amount = self.params.noise.get();
@@ -1214,12 +1211,11 @@ impl SnareDrum {
         // Crack gets velocity-sensitive volume boost (more snap at high velocity)
         let crack_vel_scale = 0.7 + 0.3 * self.current_velocity;
 
-        // Update oscillator volumes with smoothed values
-        self.tonal_oscillator.set_volume(tonal_amount * volume);
-        self.noise_oscillator
-            .set_volume(noise_amount * volume * 0.8);
+        // Update relative oscillator levels. Master volume is applied once at output.
+        self.tonal_oscillator.set_volume(tonal_amount);
+        self.noise_oscillator.set_volume(noise_amount * 0.8);
         self.crack_oscillator
-            .set_volume(brightness * volume * 0.4 * crack_vel_scale);
+            .set_volume(brightness * 0.4 * crack_vel_scale);
     }
 
     /// Set volume (smoothed, 0-1)

--- a/tests/drum_volume_linearity.rs
+++ b/tests/drum_volume_linearity.rs
@@ -1,0 +1,58 @@
+//! Regression tests for linear kick and snare master volume.
+
+use gooey::instruments::{KickDrum, SnareDrum};
+
+const SAMPLE_RATE: f32 = 44_100.0;
+const RENDER_FRAMES: usize = 4_096;
+const HALF_VOLUME: f32 = 0.5;
+const MAX_ERROR: f32 = 1e-5;
+
+fn render_kick(volume: f32) -> Vec<f32> {
+    let mut kick = KickDrum::new(SAMPLE_RATE);
+    kick.set_volume(volume);
+    kick.snap_params();
+    kick.trigger_with_velocity(0.0, 1.0);
+
+    (0..RENDER_FRAMES)
+        .map(|sample| kick.tick(sample as f64 / SAMPLE_RATE as f64))
+        .collect()
+}
+
+fn render_snare(volume: f32) -> Vec<f32> {
+    let mut snare = SnareDrum::new(SAMPLE_RATE);
+    snare.set_volume(volume);
+    snare.snap_params();
+    snare.trigger_with_velocity(0.0, 1.0);
+
+    (0..RENDER_FRAMES)
+        .map(|sample| snare.tick(sample as f64 / SAMPLE_RATE as f64))
+        .collect()
+}
+
+fn assert_half_volume_is_linear(name: &str, full: &[f32], half: &[f32]) {
+    let peak = full
+        .iter()
+        .map(|sample| sample.abs())
+        .fold(0.0_f32, f32::max);
+    assert!(peak > 0.01, "{name} full-volume output should be audible");
+
+    let max_error = full
+        .iter()
+        .zip(half)
+        .map(|(full, half)| (half - full * HALF_VOLUME).abs())
+        .fold(0.0_f32, f32::max);
+    assert!(
+        max_error < MAX_ERROR,
+        "{name} 0.5 volume should equal full output scaled by 0.5, max error was {max_error}"
+    );
+}
+
+#[test]
+fn kick_master_volume_is_linear() {
+    assert_half_volume_is_linear("kick", &render_kick(1.0), &render_kick(HALF_VOLUME));
+}
+
+#[test]
+fn snare_master_volume_is_linear() {
+    assert_half_volume_is_linear("snare", &render_snare(1.0), &render_snare(HALF_VOLUME));
+}


### PR DESCRIPTION
Kick and snare master volume was applied to internal oscillator/noise levels and again at final output, producing a squared fader response and changing nonlinear processing input levels. This removes the internal master-volume multipliers while preserving existing component balance coefficients and the final zero-volume silence gate. Deterministic waveform regression tests now verify that volume 0.5 produces exactly half of the full-volume kick and snare output. Validation: `cargo fmt --check`, targeted linearity and zero-volume tests, and `cargo test`.