### PR TITLE
[codex] Improve pink noise signal path

### DIFF
--- a/src/filters/resonant_lowpass.rs
+++ b/src/filters/resonant_lowpass.rs
@@ -1,112 +1,180 @@
-/// Resonant lowpass filter for instrument use
+use std::f32::consts::PI;
+
+/// Stable two-pole resonant low-pass filter for instrument use.
 ///
-/// Simple one-pole lowpass filter with resonance boost.
-/// Designed for use within instruments (non-atomic, mutable API).
+/// Uses a topology-preserving-transform state-variable filter and exposes the
+/// low-pass output. Designed for use within instruments (non-atomic, mutable
+/// API).
 pub struct ResonantLowpassFilter {
     pub sample_rate: f32,
     pub cutoff_freq: f32,
     pub resonance: f32,
-    filter_state: f32,
-    /// Previous output for resonance feedback
-    prev_output: f32,
+    g: f32,
+    r: f32,
+    h: f32,
+    ic1eq: f32,
+    ic2eq: f32,
 }
 
 impl ResonantLowpassFilter {
-    /// Create a new resonant lowpass filter
+    /// Create a new resonant low-pass filter.
     ///
     /// # Arguments
     /// * `sample_rate` - Audio sample rate in Hz
     /// * `cutoff_freq` - Cutoff frequency in Hz
-    /// * `resonance` - Resonance/Q factor (0.0-10.0, typical 0.5-4.0)
+    /// * `resonance` - Resonance/Q factor (0.5-10.0)
     pub fn new(sample_rate: f32, cutoff_freq: f32, resonance: f32) -> Self {
-        Self {
+        let mut filter = Self {
             sample_rate,
-            cutoff_freq,
-            resonance,
-            filter_state: 0.0,
-            prev_output: 0.0,
+            cutoff_freq: cutoff_freq.clamp(20.0, 20_000.0),
+            resonance: resonance.clamp(0.5, 10.0),
+            g: 0.0,
+            r: 0.0,
+            h: 0.0,
+            ic1eq: 0.0,
+            ic2eq: 0.0,
+        };
+        filter.update_coefficients();
+        filter
+    }
+
+    /// Reset filter state.
+    pub fn reset(&mut self) {
+        self.ic1eq = 0.0;
+        self.ic2eq = 0.0;
+    }
+
+    /// Process a single sample through the low-pass output.
+    #[inline]
+    pub fn process(&mut self, input: f32) -> f32 {
+        let v1 = (self.g * (input - self.ic2eq) + self.ic1eq) * self.h;
+        let v2 = self.ic2eq + self.g * v1;
+
+        self.ic1eq = 2.0 * v1 - self.ic1eq;
+        self.ic2eq = 2.0 * v2 - self.ic2eq;
+
+        if v2.abs() < 1e-15 {
+            0.0
+        } else {
+            v2
         }
     }
 
-    /// Reset filter state
-    pub fn reset(&mut self) {
-        self.filter_state = 0.0;
-        self.prev_output = 0.0;
-    }
-
-    /// Process a single sample through the filter
-    pub fn process(&mut self, input: f32) -> f32 {
-        // Calculate filter coefficient using exponential formula
-        // This gives a smooth, stable response
-        let alpha = 1.0 - (-2.0 * std::f32::consts::PI * self.cutoff_freq / self.sample_rate).exp();
-        let alpha_clamped = alpha.clamp(0.0, 0.99);
-
-        // Apply resonance feedback from previous output
-        // This creates a peak at the cutoff frequency
-        let feedback = self.prev_output * self.resonance * 0.1;
-        let input_with_feedback = input + feedback;
-
-        // One-pole lowpass filter
-        self.filter_state += alpha_clamped * (input_with_feedback - self.filter_state);
-
-        // Apply resonance boost at cutoff frequency
-        let resonance_boost = 1.0 + (self.resonance * 0.3);
-        let output = self.filter_state * resonance_boost;
-
-        // Store for next iteration
-        self.prev_output = output;
-
-        output
-    }
-
-    /// Set cutoff frequency
+    /// Set cutoff frequency.
     pub fn set_cutoff_freq(&mut self, cutoff_freq: f32) {
-        self.cutoff_freq = cutoff_freq.clamp(20.0, 20000.0);
+        let cutoff_freq = cutoff_freq.clamp(20.0, 20_000.0);
+        if (cutoff_freq - self.cutoff_freq).abs() > 0.001 {
+            self.cutoff_freq = cutoff_freq;
+            self.update_coefficients();
+        }
     }
 
-    /// Set resonance/Q
+    /// Set resonance/Q.
     pub fn set_resonance(&mut self, resonance: f32) {
-        self.resonance = resonance.clamp(0.0, 10.0);
+        let resonance = resonance.clamp(0.5, 10.0);
+        if (resonance - self.resonance).abs() > 0.001 {
+            self.resonance = resonance;
+            self.update_coefficients();
+        }
+    }
+
+    /// Set cutoff and resonance together, recalculating coefficients once.
+    pub fn set_params(&mut self, cutoff_freq: f32, resonance: f32) {
+        let cutoff_freq = cutoff_freq.clamp(20.0, 20_000.0);
+        let resonance = resonance.clamp(0.5, 10.0);
+
+        if (cutoff_freq - self.cutoff_freq).abs() > 0.001
+            || (resonance - self.resonance).abs() > 0.001
+        {
+            self.cutoff_freq = cutoff_freq;
+            self.resonance = resonance;
+            self.update_coefficients();
+        }
+    }
+
+    fn update_coefficients(&mut self) {
+        let sample_rate = self.sample_rate.max(1.0);
+        let cutoff = self.cutoff_freq.clamp(20.0, sample_rate * 0.45);
+        let q = self.resonance.clamp(0.5, 10.0);
+
+        self.g = (PI * cutoff / sample_rate).tan();
+        self.r = 1.0 / q;
+        self.h = 1.0 / (1.0 + self.r * self.g + self.g * self.g);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::f32::consts::TAU;
 
-    #[test]
-    fn test_filter_creation() {
-        let filter = ResonantLowpassFilter::new(44100.0, 1000.0, 2.0);
-        assert_eq!(filter.sample_rate, 44100.0);
-        assert_eq!(filter.cutoff_freq, 1000.0);
-        assert_eq!(filter.resonance, 2.0);
+    fn response_rms(sample_rate: f32, cutoff: f32, q: f32, frequency: f32) -> f32 {
+        let mut filter = ResonantLowpassFilter::new(sample_rate, cutoff, q);
+        let sample_count = sample_rate as usize;
+        let mut sum_squares = 0.0_f64;
+
+        for index in 0..sample_count {
+            let input = (TAU * frequency * index as f32 / sample_rate).sin();
+            let output = filter.process(input);
+            if index >= sample_count / 2 {
+                sum_squares += (output * output) as f64;
+            }
+        }
+
+        (sum_squares / (sample_count / 2) as f64).sqrt() as f32
     }
 
     #[test]
-    fn test_filter_reset() {
-        let mut filter = ResonantLowpassFilter::new(44100.0, 1000.0, 2.0);
+    fn creation_clamps_parameters_to_stable_ranges() {
+        let filter = ResonantLowpassFilter::new(44_100.0, 30_000.0, 0.0);
+        assert_eq!(filter.sample_rate, 44_100.0);
+        assert_eq!(filter.cutoff_freq, 20_000.0);
+        assert_eq!(filter.resonance, 0.5);
+    }
 
-        // Process some samples
+    #[test]
+    fn reset_clears_filter_history() {
+        let mut filter = ResonantLowpassFilter::new(44_100.0, 1000.0, 2.0);
         for _ in 0..100 {
             filter.process(1.0);
         }
 
-        // Reset and verify
         filter.reset();
-        assert_eq!(filter.filter_state, 0.0);
-        assert_eq!(filter.prev_output, 0.0);
+        assert_eq!(filter.ic1eq, 0.0);
+        assert_eq!(filter.ic2eq, 0.0);
     }
 
     #[test]
-    fn test_filter_stability() {
-        let mut filter = ResonantLowpassFilter::new(44100.0, 1000.0, 4.0);
+    fn lowpass_attenuates_frequencies_above_cutoff() {
+        let low = response_rms(48_000.0, 1000.0, 0.707, 100.0);
+        let high = response_rms(48_000.0, 1000.0, 0.707, 8000.0);
+        assert!(low > high * 10.0, "low={low}, high={high}");
+    }
 
-        // Process many samples to ensure stability
-        for i in 0..44100 {
-            let input = (i as f32 * 0.1).sin();
-            let output = filter.process(input);
-            assert!(output.is_finite(), "Filter output should be finite");
-            assert!(output.abs() < 100.0, "Filter should remain stable");
+    #[test]
+    fn resonance_boosts_response_near_cutoff() {
+        let low_q = response_rms(48_000.0, 1000.0, 0.5, 1000.0);
+        let high_q = response_rms(48_000.0, 1000.0, 4.0, 1000.0);
+        assert!(high_q > low_q * 4.0, "low_q={low_q}, high_q={high_q}");
+    }
+
+    #[test]
+    fn remains_stable_at_extreme_settings_and_sample_rates() {
+        for sample_rate in [44_100.0, 48_000.0, 96_000.0] {
+            for cutoff in [20.0, 1000.0, 20_000.0] {
+                for resonance in [0.5, 5.0, 10.0] {
+                    let mut filter = ResonantLowpassFilter::new(sample_rate, cutoff, resonance);
+
+                    for index in 0..sample_rate as usize {
+                        let input = (index as f32 * 0.1).sin();
+                        let output = filter.process(input);
+                        assert!(
+                            output.is_finite() && output.abs() < 100.0,
+                            "unstable at sample_rate={sample_rate}, cutoff={cutoff}, resonance={resonance}: {output}"
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/src/gen/pink_noise.rs
+++ b/src/gen/pink_noise.rs
@@ -1,126 +1,187 @@
-//! Pink noise generator using the Voss-McCartney algorithm
+//! Pink noise generator using filtered white noise.
 //!
-//! Pink noise has a power spectral density that decreases by 3 dB per octave (1/f).
-//! This implementation uses running sums of white noise sources to approximate pink noise.
+//! Pink noise has a power spectral density that decreases by 3 dB per octave
+//! (1/f). This implementation uses a deterministic white-noise source followed
+//! by a sample-rate-aware version of Paul Kellet's economy pink-noise filter.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+const REFERENCE_SAMPLE_RATE: f32 = 44_100.0;
+const RNG_SEED: u64 = 0x1234_5678_9abc_def0;
+const REFERENCE_POLES: [f32; 3] = [0.99765, 0.96300, 0.57000];
+const REFERENCE_GAINS: [f32; 3] = [0.0990460, 0.2965164, 1.0526913];
+const DIRECT_GAIN: f32 = 0.1848;
+const OUTPUT_GAIN: f32 = 0.11;
 
-/// Pink noise generator with ~1/f frequency spectrum
-///
-/// Uses the Voss-McCartney algorithm with multiple octave bands
-/// to create noise that falls off at approximately 3 dB per octave.
+/// Pink noise generator with an approximately 1/f frequency spectrum.
 pub struct PinkNoise {
-    /// Current sample counter for noise generation
-    sample_counter: u64,
-
-    /// Running sums for different octave bands (typically 3-5 bands)
-    octave_sums: [f32; 5],
-
-    /// Update counters for each octave band
-    update_counters: [u32; 5],
+    rng_state: u64,
+    filter_state: [f32; 3],
+    poles: [f32; 3],
+    gains: [f32; 3],
 }
 
 impl PinkNoise {
-    /// Create a new pink noise generator
-    pub fn new() -> Self {
+    /// Create a pink-noise generator for a fixed audio sample rate.
+    pub fn new(sample_rate: f32) -> Self {
+        let sample_rate = sample_rate.max(1.0);
+        let rate_ratio = REFERENCE_SAMPLE_RATE / sample_rate;
+        let mut poles = [0.0; 3];
+        let mut gains = [0.0; 3];
+
+        for i in 0..3 {
+            poles[i] = REFERENCE_POLES[i].powf(rate_ratio);
+
+            // Preserve each filter branch's white-noise variance as its pole is
+            // moved to maintain the same response at a different sample rate.
+            gains[i] = REFERENCE_GAINS[i]
+                * ((1.0 - poles[i] * poles[i]) / (1.0 - REFERENCE_POLES[i] * REFERENCE_POLES[i]))
+                    .sqrt();
+        }
+
         Self {
-            sample_counter: 0,
-            octave_sums: [0.0; 5],
-            update_counters: [0; 5],
+            rng_state: RNG_SEED,
+            filter_state: [0.0; 3],
+            poles,
+            gains,
         }
     }
 
-    /// Reset the generator state
+    /// Reset the generator to its initial deterministic sequence.
     pub fn reset(&mut self) {
-        self.sample_counter = 0;
-        self.octave_sums = [0.0; 5];
-        self.update_counters = [0; 5];
+        self.rng_state = RNG_SEED;
+        self.filter_state = [0.0; 3];
     }
 
-    /// Generate the next pink noise sample (range approximately -1.0 to 1.0)
+    /// Generate the next pink-noise sample.
+    #[inline]
     pub fn tick(&mut self) -> f32 {
-        self.sample_counter = self.sample_counter.wrapping_add(1);
+        let white = self.next_white_sample();
 
-        // Update octave bands at different rates
-        // Band 0: every sample
-        // Band 1: every 2 samples
-        // Band 2: every 4 samples
-        // Band 3: every 8 samples
-        // Band 4: every 16 samples
-
-        for i in 0..5 {
-            let update_rate = 1 << i; // 1, 2, 4, 8, 16
-            self.update_counters[i] += 1;
-
-            if self.update_counters[i] >= update_rate {
-                self.update_counters[i] = 0;
-
-                // Generate white noise for this band
-                let white_noise = self.generate_white_noise(self.sample_counter, i as u64);
-                self.octave_sums[i] = white_noise;
-            }
+        for i in 0..3 {
+            self.filter_state[i] = self.poles[i] * self.filter_state[i] + self.gains[i] * white;
         }
 
-        // Sum all octave bands
-        let mut output = 0.0;
-        for sum in &self.octave_sums {
-            output += sum;
-        }
-
-        // Normalize (5 bands of white noise, each in range [-1, 1])
-        // Scale factor is approximately 0.2 to keep output in reasonable range
-        output * 0.2
+        (self.filter_state.iter().sum::<f32>() + white * DIRECT_GAIN) * OUTPUT_GAIN
     }
 
-    /// Generate white noise using hash function
-    fn generate_white_noise(&self, seed: u64, offset: u64) -> f32 {
-        let mut hasher = DefaultHasher::new();
-        (seed.wrapping_add(offset.wrapping_mul(1000000))).hash(&mut hasher);
-        let hash = hasher.finish();
+    #[inline]
+    fn next_white_sample(&mut self) -> f32 {
+        // xorshift64*
+        let mut x = self.rng_state;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.rng_state = x;
+        let hashed = x.wrapping_mul(0x2545_f491_4f6c_dd1d);
 
-        // Convert hash to float in range [-1.0, 1.0]
-        let normalized = (hash as f32) / (u64::MAX as f32);
-        (normalized * 2.0) - 1.0
-    }
-}
-
-impl Default for PinkNoise {
-    fn default() -> Self {
-        Self::new()
+        // Use the upper 24 bits so every integer is exactly representable as f32.
+        let normalized = (hashed >> 40) as f32 / ((1_u32 << 24) - 1) as f32;
+        normalized * 2.0 - 1.0
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::f32::consts::TAU;
 
-    #[test]
-    fn test_pink_noise_generation() {
-        let mut pink_noise = PinkNoise::new();
+    fn octave_bin_powers(sample_rate: f32) -> Vec<f64> {
+        const BLOCK_SIZE: usize = 4096;
+        const BLOCK_COUNT: usize = 64;
+        const FREQUENCIES: [f32; 6] = [250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0];
 
-        // Generate samples and check they're in a reasonable range
-        for _ in 0..1000 {
-            let sample = pink_noise.tick();
-            assert!(sample.is_finite(), "Pink noise should be finite");
-            assert!(
-                sample.abs() < 2.0,
-                "Pink noise should be roughly in range [-1, 1]"
-            );
-        }
-    }
-
-    #[test]
-    fn test_pink_noise_reset() {
-        let mut pink_noise = PinkNoise::new();
-
-        // Generate some samples
-        for _ in 0..100 {
+        let mut pink_noise = PinkNoise::new(sample_rate);
+        for _ in 0..BLOCK_SIZE {
             pink_noise.tick();
         }
 
-        // Reset and verify state
+        let mut powers = vec![0.0_f64; FREQUENCIES.len()];
+        for _ in 0..BLOCK_COUNT {
+            let samples: Vec<f32> = (0..BLOCK_SIZE).map(|_| pink_noise.tick()).collect();
+
+            for (power, frequency) in powers.iter_mut().zip(FREQUENCIES) {
+                let bin = (frequency * BLOCK_SIZE as f32 / sample_rate).round();
+                let omega = TAU * bin / BLOCK_SIZE as f32;
+                let mut real = 0.0_f64;
+                let mut imag = 0.0_f64;
+
+                for (index, sample) in samples.iter().enumerate() {
+                    let phase = omega * index as f32;
+                    real += *sample as f64 * phase.cos() as f64;
+                    imag -= *sample as f64 * phase.sin() as f64;
+                }
+
+                *power += real * real + imag * imag;
+            }
+        }
+
+        for power in &mut powers {
+            *power /= BLOCK_COUNT as f64;
+        }
+        powers
+    }
+
+    fn spectral_slope_db_per_octave(powers: &[f64]) -> f64 {
+        let first_db = 10.0 * powers.first().unwrap().log10();
+        let last_db = 10.0 * powers.last().unwrap().log10();
+        (last_db - first_db) / (powers.len() - 1) as f64
+    }
+
+    #[test]
+    fn pink_noise_is_finite_bounded_and_nearly_zero_mean() {
+        let mut pink_noise = PinkNoise::new(48_000.0);
+        let mut sum = 0.0_f64;
+
+        for _ in 0..200_000 {
+            let sample = pink_noise.tick();
+            assert!(sample.is_finite(), "pink noise should be finite");
+            assert!(sample.abs() < 2.0, "pink noise should remain bounded");
+            sum += sample as f64;
+        }
+
+        let mean = sum / 200_000.0;
+        assert!(mean.abs() < 0.03, "pink-noise mean was {mean}");
+    }
+
+    #[test]
+    fn reset_restores_the_initial_sequence() {
+        let mut pink_noise = PinkNoise::new(44_100.0);
+        let initial: Vec<f32> = (0..256).map(|_| pink_noise.tick()).collect();
+
+        for _ in 0..1000 {
+            pink_noise.tick();
+        }
         pink_noise.reset();
-        assert_eq!(pink_noise.sample_counter, 0);
+
+        let after_reset: Vec<f32> = (0..256).map(|_| pink_noise.tick()).collect();
+        assert_eq!(initial, after_reset);
+    }
+
+    #[test]
+    fn spectrum_falls_at_a_consistent_rate_across_sample_rates() {
+        let mut slopes = Vec::new();
+
+        for sample_rate in [44_100.0, 48_000.0, 96_000.0] {
+            let powers = octave_bin_powers(sample_rate);
+            for octave_pair in powers.windows(2) {
+                assert!(
+                    octave_pair[1] < octave_pair[0],
+                    "power did not fall across an octave at {sample_rate} Hz: {powers:?}"
+                );
+            }
+
+            let slope = spectral_slope_db_per_octave(&powers);
+            assert!(
+                (-4.5..=-1.5).contains(&slope),
+                "unexpected slope at {sample_rate} Hz: {slope:.2} dB/octave; powers={powers:?}"
+            );
+            slopes.push(slope);
+        }
+
+        let min_slope = slopes.iter().copied().fold(f64::INFINITY, f64::min);
+        let max_slope = slopes.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        assert!(
+            max_slope - min_slope < 0.75,
+            "sample-rate slopes diverged: {slopes:?}"
+        );
     }
 }

--- a/src/instruments/hihat2.rs
+++ b/src/instruments/hihat2.rs
@@ -369,7 +369,7 @@ impl HiHat2 {
             hpf_stage_2: BiquadHighpass::new(sample_rate),
             svf: StateVariableFilterTpt::new(sample_rate, tone_hz, 0.5),
             white_noise_state: 0x1234_5678_9abc_def0,
-            pink_noise: PinkNoise::new(),
+            pink_noise: PinkNoise::new(sample_rate),
             is_active: false,
             current_velocity: 1.0,
         }

--- a/src/instruments/kick.rs
+++ b/src/instruments/kick.rs
@@ -784,7 +784,7 @@ impl KickDrum {
             triggered_pitch_multiplier,
             click_filter: ResonantHighpassFilter::new(sample_rate, 8000.0, 4.0),
             phase_modulator: PhaseModulator::new(sample_rate),
-            pink_noise: PinkNoise::new(),
+            pink_noise: PinkNoise::new(sample_rate),
             noise_filter: ResonantLowpassFilter::new(sample_rate, noise_cutoff_hz, noise_res),
             noise_envelope: Envelope::new(),
             waveshaper: FeedbackWaveshaper::new(
@@ -1166,8 +1166,7 @@ impl KickDrum {
             // Update filter parameters from smoothed params (denormalized to actual Hz/resonance)
             let noise_cutoff = self.params.noise_cutoff_hz();
             let noise_resonance = self.params.noise_resonance_value();
-            self.noise_filter.set_cutoff_freq(noise_cutoff);
-            self.noise_filter.set_resonance(noise_resonance);
+            self.noise_filter.set_params(noise_cutoff, noise_resonance);
 
             // Apply resonant lowpass filter
             let filtered_noise = self.noise_filter.process(pink_noise_sample);


### PR DESCRIPTION
Replaces the Voss-McCartney sample-and-hold generator with deterministic, sample-rate-aware Kellet filtered white noise for smoother pink noise in kick and HiHat2.
The root cause of the steppy coloration was the octave-band sample-and-hold algorithm.
Upgrades the kick noise filter to a stable TPT resonant low-pass and updates cutoff and resonance coefficients together.
Validation: `cargo test`, `cargo test --no-default-features --lib`, `cargo fmt -- --check`, and `git diff --check`.
