### PR TITLE
[codex] Add configurable anti-alias oversampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_mask_ring_buf"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac85b1322307fc253c24060df1e8b4e8ea681e13d2d02d14f59dbdf9f64b0e13"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,9 +515,21 @@ dependencies = [
  "crossterm",
  "gl",
  "glfw",
+ "halfband",
  "hound",
  "midir",
  "rustfft",
+]
+
+[[package]]
+name = "halfband"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c21ea2524c2b1a846750d6c68b85f6cbe292d6eb847b5a7bea86e18c999870d5"
+dependencies = [
+ "bit_mask_ring_buf",
+ "paste",
+ "windowfunctions",
 ]
 
 [[package]]
@@ -907,6 +925,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pkg-config"
@@ -1412,6 +1436,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windowfunctions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90628d739333b7c5d2ee0b70210b97b8cddc38440c682c96fd9e2c24c2db5f3a"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ gl = { version = "0.14", optional = true }
 rustfft = { version = "6.2", optional = true }
 midir = { version = "0.10", optional = true }
 hound = { version = "3.5", optional = true }
+halfband = "0.2"
 
 [[example]]
 name = "kick"
@@ -101,3 +102,7 @@ required-features = ["bounce"]
 [[example]]
 name = "granulator"
 required-features = ["native", "crossterm", "bounce"]
+
+[[example]]
+name = "antialias_validation"
+required-features = ["bounce"]

--- a/examples/antialias_validation.rs
+++ b/examples/antialias_validation.rs
@@ -1,0 +1,181 @@
+//! Generate off/2x/4x artifacts and measurements for nonlinear anti-aliasing.
+//!
+//! Run with:
+//! `cargo run --release --example antialias_validation --no-default-features --features bounce`
+
+use gooey::utils::{Oversampler, OversamplingMode};
+use std::f64::consts::TAU;
+use std::hint::black_box;
+use std::path::Path;
+use std::time::Instant;
+
+const SAMPLE_RATE: f32 = 48_000.0;
+const DRIVE: f32 = 10.0;
+const WARMUP_SAMPLES: usize = 1_024;
+const MEASUREMENT_SAMPLES: usize = 4_800;
+
+fn shape(input: f32) -> f32 {
+    (input * DRIVE).tanh()
+}
+
+fn coherent_sine(sample: usize) -> f32 {
+    (std::f32::consts::TAU * 10_000.0 * sample as f32 / SAMPLE_RATE).sin() * 0.8
+}
+
+fn bin_power(samples: &[f32], frequency: f32) -> f64 {
+    let phase_step = TAU * frequency as f64 / SAMPLE_RATE as f64;
+    let (real, imag) =
+        samples
+            .iter()
+            .enumerate()
+            .fold((0.0_f64, 0.0_f64), |(real, imag), (i, &x)| {
+                let phase = phase_step * i as f64;
+                (real + x as f64 * phase.cos(), imag - x as f64 * phase.sin())
+            });
+    real * real + imag * imag
+}
+
+fn combined_alias_power(samples: &[f32]) -> f64 {
+    [2_000.0, 18_000.0, 22_000.0]
+        .iter()
+        .map(|&frequency| bin_power(samples, frequency))
+        .sum()
+}
+
+struct ModeRenders {
+    off: Vec<f32>,
+    x2: Vec<f32>,
+    x4: Vec<f32>,
+}
+
+fn render_alias_measurement() -> ModeRenders {
+    let mut off = Oversampler::new(OversamplingMode::Off);
+    let mut x2 = Oversampler::new(OversamplingMode::X2);
+    let mut x4 = Oversampler::new(OversamplingMode::X4);
+    let mut renders = ModeRenders {
+        off: Vec::with_capacity(MEASUREMENT_SAMPLES),
+        x2: Vec::with_capacity(MEASUREMENT_SAMPLES),
+        x4: Vec::with_capacity(MEASUREMENT_SAMPLES),
+    };
+
+    for i in 0..WARMUP_SAMPLES + MEASUREMENT_SAMPLES {
+        let input = coherent_sine(i);
+        let off_output = off.process(input, shape);
+        let x2_output = x2.process(input, shape);
+        let x4_output = x4.process(input, shape);
+        if i >= WARMUP_SAMPLES {
+            renders.off.push(off_output);
+            renders.x2.push(x2_output);
+            renders.x4.push(x4_output);
+        }
+    }
+
+    renders
+}
+
+fn render_sweeps() -> ModeRenders {
+    let duration_seconds = 5.0;
+    let samples = (duration_seconds * SAMPLE_RATE) as usize;
+    let start_frequency = 1_000.0_f32;
+    let end_frequency = 20_000.0_f32;
+    let frequency_ratio = end_frequency / start_frequency;
+    let mut phase = 0.0_f32;
+    let mut off = Oversampler::new(OversamplingMode::Off);
+    let mut x2 = Oversampler::new(OversamplingMode::X2);
+    let mut x4 = Oversampler::new(OversamplingMode::X4);
+    let mut renders = ModeRenders {
+        off: Vec::with_capacity(samples),
+        x2: Vec::with_capacity(samples),
+        x4: Vec::with_capacity(samples),
+    };
+
+    for i in 0..samples {
+        let progress = i as f32 / samples as f32;
+        let frequency = start_frequency * frequency_ratio.powf(progress);
+        phase = (phase + std::f32::consts::TAU * frequency / SAMPLE_RATE)
+            .rem_euclid(std::f32::consts::TAU);
+        let input = phase.sin() * 0.8;
+        renders.off.push(off.process(input, shape));
+        renders.x2.push(x2.process(input, shape));
+        renders.x4.push(x4.process(input, shape));
+    }
+
+    renders
+}
+
+fn write_float_wav(path: &Path, samples: &[f32]) -> Result<(), String> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: SAMPLE_RATE as u32,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
+    let mut writer = hound::WavWriter::create(path, spec).map_err(|error| error.to_string())?;
+    for &sample in samples {
+        writer
+            .write_sample(sample)
+            .map_err(|error| error.to_string())?;
+    }
+    writer.finalize().map_err(|error| error.to_string())
+}
+
+fn benchmark_mode(mode: OversamplingMode) -> std::time::Duration {
+    const SAMPLES: usize = 5_000_000;
+    let mut oversampler = Oversampler::new(mode);
+
+    let start = Instant::now();
+    let mut output = 0.0_f32;
+    for i in 0..SAMPLES {
+        output = oversampler.process(black_box(coherent_sine(i)), shape);
+    }
+    black_box(output);
+    start.elapsed()
+}
+
+fn benchmark() {
+    const SAMPLES: usize = 5_000_000;
+    let off_elapsed = benchmark_mode(OversamplingMode::Off);
+    let x2_elapsed = benchmark_mode(OversamplingMode::X2);
+    let x4_elapsed = benchmark_mode(OversamplingMode::X4);
+
+    println!(
+        "Off throughput: {:.2} ns/sample",
+        off_elapsed.as_nanos() as f64 / SAMPLES as f64
+    );
+    println!(
+        "2x throughput: {:.2} ns/sample ({:.2}x off cost)",
+        x2_elapsed.as_nanos() as f64 / SAMPLES as f64,
+        x2_elapsed.as_secs_f64() / off_elapsed.as_secs_f64()
+    );
+    println!(
+        "4x throughput: {:.2} ns/sample ({:.2}x off cost)",
+        x4_elapsed.as_nanos() as f64 / SAMPLES as f64,
+        x4_elapsed.as_secs_f64() / off_elapsed.as_secs_f64()
+    );
+}
+
+fn main() -> Result<(), String> {
+    let output_dir = Path::new(".context/antialias-validation");
+    std::fs::create_dir_all(output_dir).map_err(|error| error.to_string())?;
+
+    let measurement = render_alias_measurement();
+    let off_alias_power = combined_alias_power(&measurement.off);
+    let x2_reduction_db = 10.0 * (off_alias_power / combined_alias_power(&measurement.x2)).log10();
+    let x4_reduction_db = 10.0 * (off_alias_power / combined_alias_power(&measurement.x4)).log10();
+    println!("2x known-bin alias reduction versus off: {x2_reduction_db:.2} dB");
+    println!("4x known-bin alias reduction versus off: {x4_reduction_db:.2} dB");
+
+    let sweeps = render_sweeps();
+    let base_path = output_dir.join("base-rate-sweep.wav");
+    let x2_path = output_dir.join("oversampled-2x-sweep.wav");
+    let x4_path = output_dir.join("oversampled-4x-sweep.wav");
+    write_float_wav(&base_path, &sweeps.off)?;
+    write_float_wav(&x2_path, &sweeps.x2)?;
+    write_float_wav(&x4_path, &sweeps.x4)?;
+    println!("Wrote {}", base_path.display());
+    println!("Wrote {}", x2_path.display());
+    println!("Wrote {}", x4_path.display());
+
+    benchmark();
+    Ok(())
+}

--- a/examples/kick.rs
+++ b/examples/kick.rs
@@ -13,7 +13,7 @@ use std::io::{self, Write};
 
 use gooey::engine::{Engine, EngineOutput, Instrument};
 use gooey::instruments::{KickConfig, KickDrum};
-use gooey::utils::PresetBlender;
+use gooey::utils::{OversamplingMode, PresetBlender};
 use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "midi")]
@@ -248,6 +248,22 @@ fn make_bar(normalized: f32, width: usize) -> String {
     format!("{}{}", "█".repeat(filled), "░".repeat(empty))
 }
 
+fn oversampling_label(mode: OversamplingMode) -> &'static str {
+    match mode {
+        OversamplingMode::Off => "Off",
+        OversamplingMode::X2 => "2x",
+        OversamplingMode::X4 => "4x",
+    }
+}
+
+fn next_oversampling_mode(mode: OversamplingMode) -> OversamplingMode {
+    match mode {
+        OversamplingMode::Off => OversamplingMode::X2,
+        OversamplingMode::X2 => OversamplingMode::X4,
+        OversamplingMode::X4 => OversamplingMode::Off,
+    }
+}
+
 // Blend mode state
 struct BlendState {
     enabled: bool,
@@ -286,10 +302,10 @@ fn render_display(
 
     print!("=== Kick Drum Lab ===\r\n");
     if blend.enabled {
-        print!("SPACE=hit Q=quit WASD=blend B=exit blend mode\r\n");
+        print!("SPACE=hit O=oversampling Q=quit WASD=blend B=exit blend mode\r\n");
         print!("Z/X/C/V=vel 25/50/75/100%\r\n");
     } else {
-        print!("SPACE=hit Q=quit ↑↓=sel ←→=adj []=fine B=blend\r\n");
+        print!("SPACE=hit O=oversampling Q=quit ↑↓=sel ←→=adj []=fine B=blend\r\n");
         print!("Z/X/C/V=vel 25/50/75/100% +/-=adj 1-4=preset\r\n");
     }
     print!("Preset: {}\r\n", preset_name);
@@ -348,7 +364,12 @@ fn render_display(
     }
 
     print!("\r\n");
-    print!("Hits: {} | Vel: {:.0}%", trigger_count, velocity * 100.0);
+    print!(
+        "Hits: {} | Vel: {:.0}% | Oversampling: {}",
+        trigger_count,
+        velocity * 100.0,
+        oversampling_label(kick.oversampling_mode())
+    );
 
     // Flush to ensure display updates
     io::stdout().flush().unwrap();
@@ -669,6 +690,14 @@ fn main() -> anyhow::Result<()> {
                     }
                     KeyCode::Char('-') | KeyCode::Char('_') => {
                         current_velocity = (current_velocity - 0.05).max(0.05);
+                        needs_redraw = true;
+                    }
+
+                    // Cycle kick waveshaper oversampling for live A/B comparison
+                    KeyCode::Char('o') | KeyCode::Char('O') => {
+                        let mut k = kick.lock().unwrap();
+                        let next_mode = next_oversampling_mode(k.oversampling_mode());
+                        k.set_oversampling_mode(next_mode);
                         needs_redraw = true;
                     }
 

--- a/src/effects/feedback_waveshaper.rs
+++ b/src/effects/feedback_waveshaper.rs
@@ -6,6 +6,8 @@
 //! DC drift. Higher feedback on kicks creates sub-harmonic growl,
 //! moderate feedback on snares adds a gritty, self-exciting tail.
 
+use crate::utils::oversampler::{Oversampler, OversamplingMode};
+
 /// Threshold for flushing denormal numbers to zero
 const DENORMAL_THRESHOLD: f32 = 1e-15;
 
@@ -27,7 +29,8 @@ const ENV_FLOOR: f32 = 0.05;
 /// Waveshaper with feedback loop for richer harmonic distortion
 ///
 /// The feedback path includes a one-pole lowpass filter (controllable cutoff)
-/// and a DC blocker to keep the loop stable.
+/// and a DC blocker to keep the loop stable. The tanh nonlinearity defaults to
+/// 4x oversampling to reduce audible foldback.
 pub struct FeedbackWaveshaper {
     // Parameters
     drive: f32,
@@ -45,6 +48,7 @@ pub struct FeedbackWaveshaper {
     dc_x1: f32,
     dc_y1: f32,
     env: f32,
+    oversampler: Oversampler,
 }
 
 impl FeedbackWaveshaper {
@@ -75,6 +79,7 @@ impl FeedbackWaveshaper {
             dc_x1: 0.0,
             dc_y1: 0.0,
             env: 0.0,
+            oversampler: Oversampler::default(),
         }
     }
 
@@ -108,8 +113,9 @@ impl FeedbackWaveshaper {
         // Sum input with filtered feedback
         let fb_input = self.drive * input + self.feedback * self.last_out;
 
-        // Waveshape with tanh
-        let shaped = fb_input.tanh();
+        // Oversample only the memoryless nonlinearity. Feedback state and
+        // filtering remain at the engine rate to preserve loop timing.
+        let shaped = self.oversampler.process(fb_input, |x| x.tanh());
 
         // Track the amplitude envelope of the dry input with a slow follower.
         // Referencing the makeup gain to this level (instead of a fixed 0.5)
@@ -167,6 +173,7 @@ impl FeedbackWaveshaper {
         self.dc_x1 = 0.0;
         self.dc_y1 = 0.0;
         self.env = 0.0;
+        self.oversampler.reset();
     }
 
     /// Set the drive amount (1.0-100.0)
@@ -208,6 +215,16 @@ impl FeedbackWaveshaper {
     /// Get the current mix amount
     pub fn mix(&self) -> f32 {
         self.mix
+    }
+
+    /// Set the oversampling rate. Changing it clears oversampling filter history.
+    pub fn set_oversampling_mode(&mut self, mode: OversamplingMode) {
+        self.oversampler.set_mode(mode);
+    }
+
+    /// Get the current oversampling rate.
+    pub fn oversampling_mode(&self) -> OversamplingMode {
+        self.oversampler.mode()
     }
 
     #[inline]
@@ -265,9 +282,10 @@ mod tests {
             let s = (i as f32 * 0.3).sin();
             peak_full = peak_full.max(ws.process(s).abs());
         }
-        // Soft-clipped: peak stays below unity but is substantial.
+        // Soft-clipped: the peak remains tightly bounded but is substantial.
+        // The IIR anti-alias filters can reconstruct a small overshoot above 1.0.
         assert!(
-            peak_full > 0.5 && peak_full < 1.0,
+            peak_full > 0.5 && peak_full < 1.1,
             "peak_full was {peak_full}"
         );
 
@@ -292,6 +310,15 @@ mod tests {
         assert_eq!(ws.feedback(), 0.98);
         assert_eq!(ws.filter_cutoff(), 200.0);
         assert_eq!(ws.mix(), 1.0);
+    }
+
+    #[test]
+    fn test_configurable_oversampling_defaults_to_4x() {
+        let mut ws = FeedbackWaveshaper::new(44100.0, 5.0, 0.5, 2000.0, 1.0);
+        assert_eq!(ws.oversampling_mode(), OversamplingMode::X4);
+
+        ws.set_oversampling_mode(OversamplingMode::Off);
+        assert_eq!(ws.oversampling_mode(), OversamplingMode::Off);
     }
 
     #[test]

--- a/src/effects/saturation.rs
+++ b/src/effects/saturation.rs
@@ -6,11 +6,11 @@
 //! generation for a more analog sound than simple tanh.
 
 use crate::effects::Effect;
-use crate::utils::oversampler::Oversampler2x;
+use crate::utils::oversampler::{Oversampler, OversamplingMode};
 use crate::utils::smoother::SmoothedParam;
 use std::cell::UnsafeCell;
 use std::f32::consts::FRAC_2_PI;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU8, Ordering};
 
 /// Threshold for flushing denormal numbers to zero
 const DENORMAL_THRESHOLD: f32 = 1e-15;
@@ -29,8 +29,8 @@ struct SaturationState {
     dc_x1: f32,
     dc_y1: f32,
 
-    // 2x oversampler to reduce aliasing from nonlinear processing
-    oversampler: Oversampler2x,
+    // Selectable oversampler to reduce aliasing from nonlinear processing
+    oversampler: Oversampler,
 }
 
 /// Tube-style saturation effect
@@ -48,6 +48,7 @@ pub struct TubeSaturation {
     drive_target: AtomicU32,
     warmth_target: AtomicU32,
     mix_target: AtomicU32,
+    oversampling_mode_target: AtomicU8,
 }
 
 // SAFETY: UnsafeCell only accessed from single audio thread
@@ -74,11 +75,12 @@ impl TubeSaturation {
                 mix_smoothed: SmoothedParam::new(mix_clamped, 0.0, 1.0, sample_rate, 30.0),
                 dc_x1: 0.0,
                 dc_y1: 0.0,
-                oversampler: Oversampler2x::new(),
+                oversampler: Oversampler::default(),
             }),
             drive_target: AtomicU32::new(drive_clamped.to_bits()),
             warmth_target: AtomicU32::new(warmth_clamped.to_bits()),
             mix_target: AtomicU32::new(mix_clamped.to_bits()),
+            oversampling_mode_target: AtomicU8::new(OversamplingMode::X4 as u8),
         }
     }
 
@@ -154,6 +156,12 @@ impl TubeSaturation {
         self.mix_target.store(clamped.to_bits(), Ordering::Relaxed);
     }
 
+    /// Set the oversampling rate. The audio thread clears filter history when it applies the change.
+    pub fn set_oversampling_mode(&self, mode: OversamplingMode) {
+        self.oversampling_mode_target
+            .store(mode as u8, Ordering::Relaxed);
+    }
+
     // Parameter getters
 
     /// Get the current drive setting
@@ -171,12 +179,17 @@ impl TubeSaturation {
         f32::from_bits(self.mix_target.load(Ordering::Relaxed))
     }
 
+    /// Get the requested oversampling rate.
+    pub fn get_oversampling_mode(&self) -> OversamplingMode {
+        OversamplingMode::from_u8(self.oversampling_mode_target.load(Ordering::Relaxed))
+    }
+
     /// Reset internal state (DC blocker)
     pub fn reset(&self) {
         let state = unsafe { &mut *self.state.get() };
         state.dc_x1 = 0.0;
         state.dc_y1 = 0.0;
-        state.oversampler = Oversampler2x::new();
+        state.oversampler.reset();
     }
 }
 
@@ -184,6 +197,7 @@ impl Effect for TubeSaturation {
     fn process(&self, input: f32) -> f32 {
         // NaN/infinity protection at input
         if !input.is_finite() {
+            self.reset();
             return 0.0;
         }
 
@@ -193,6 +207,10 @@ impl Effect for TubeSaturation {
         let drive_target = f32::from_bits(self.drive_target.load(Ordering::Relaxed));
         let warmth_target = f32::from_bits(self.warmth_target.load(Ordering::Relaxed));
         let mix_target = f32::from_bits(self.mix_target.load(Ordering::Relaxed));
+        let oversampling_mode =
+            OversamplingMode::from_u8(self.oversampling_mode_target.load(Ordering::Relaxed));
+
+        state.oversampler.set_mode(oversampling_mode);
 
         state.drive_smoothed.set_target(drive_target);
         state.warmth_smoothed.set_target(warmth_target);
@@ -208,7 +226,7 @@ impl Effect for TubeSaturation {
             return input;
         }
 
-        // Apply saturation with 2x oversampling to reduce aliasing
+        // Apply saturation at the selected oversampling rate
         let saturated = state
             .oversampler
             .process(input, |x| Self::saturate(x, drive, warmth));
@@ -223,6 +241,7 @@ impl Effect for TubeSaturation {
         if !output.is_finite() {
             state.dc_x1 = 0.0;
             state.dc_y1 = 0.0;
+            state.oversampler.reset();
             return 0.0;
         }
 
@@ -244,19 +263,25 @@ mod tests {
     #[test]
     fn test_soft_limiting() {
         let sat = TubeSaturation::new(44100.0, 1.0, 0.0, 1.0);
-        // Run samples with a sine wave to let smoothers settle
-        // (DC blocker removes constant signals, so we use an oscillating input)
+        // Run an oscillating signal because the DC blocker removes constants.
         let freq = 1000.0_f32;
         let sr = 44100.0_f32;
-        for i in 0..2000 {
+        let mut max_output = 0.0_f32;
+        for i in 0..4000 {
             let input = (2.0 * std::f32::consts::PI * freq * i as f32 / sr).sin();
-            sat.process(input);
+            let output = sat.process(input);
+            if i >= 2000 {
+                max_output = max_output.max(output.abs());
+            }
         }
-        // Process a positive peak
-        let output = sat.process(0.9);
-        // Output should be soft-limited below input
-        assert!(output.abs() < 0.9, "Expected output < 0.9, got {}", output);
-        assert!(output.abs() > 0.1, "Expected output > 0.1, got {}", output);
+        assert!(
+            max_output < 1.0,
+            "Expected soft-limited peak < 1.0, got {max_output}"
+        );
+        assert!(
+            max_output > 0.1,
+            "Expected audible output, got {max_output}"
+        );
     }
 
     #[test]
@@ -293,9 +318,44 @@ mod tests {
         sat.set_drive(0.7);
         sat.set_warmth(0.5);
         sat.set_mix(0.8);
+        sat.set_oversampling_mode(OversamplingMode::X2);
 
         assert!((sat.get_drive() - 0.7).abs() < 0.001);
         assert!((sat.get_warmth() - 0.5).abs() < 0.001);
         assert!((sat.get_mix() - 0.8).abs() < 0.001);
+        assert_eq!(sat.get_oversampling_mode(), OversamplingMode::X2);
+    }
+
+    #[test]
+    fn test_oversampling_defaults_to_4x() {
+        let sat = TubeSaturation::new(44100.0, 0.5, 0.5, 1.0);
+        assert_eq!(sat.get_oversampling_mode(), OversamplingMode::X4);
+    }
+
+    #[test]
+    fn test_reset_matches_fresh_instance() {
+        let reset = TubeSaturation::new(44100.0, 0.5, 0.5, 1.0);
+        for i in 0..1000 {
+            reset.process((i as f32 * 0.1).sin());
+        }
+        reset.reset();
+
+        let fresh = TubeSaturation::new(44100.0, 0.5, 0.5, 1.0);
+        for i in 0..100 {
+            let input = (i as f32 * 0.27).sin();
+            assert_eq!(reset.process(input), fresh.process(input));
+        }
+    }
+
+    #[test]
+    fn test_nan_protection_resets_state() {
+        let reset = TubeSaturation::new(44100.0, 0.5, 0.5, 1.0);
+        for i in 0..1000 {
+            reset.process((i as f32 * 0.1).sin());
+        }
+        assert_eq!(reset.process(f32::NAN), 0.0);
+
+        let fresh = TubeSaturation::new(44100.0, 0.5, 0.5, 1.0);
+        assert_eq!(reset.process(0.5), fresh.process(0.5));
     }
 }

--- a/src/effects/waveshaper.rs
+++ b/src/effects/waveshaper.rs
@@ -3,20 +3,20 @@
 //! Provides soft-clipping waveshaping similar to Max MSP's overdrive~ object,
 //! with adjustable drive and mix for saturation and warmth.
 
-use crate::utils::oversampler::Oversampler2x;
+use crate::utils::oversampler::{Oversampler, OversamplingMode};
 
 /// Waveshaper distortion with configurable drive
 ///
 /// Uses soft clipping (tanh) for smooth saturation similar to tube overdrive.
 /// Matches the behavior of Max MSP's overdrive~ object.
-/// Includes 2x oversampling to reduce aliasing from the nonlinear processing.
+/// Defaults to 4x oversampling to reduce aliasing from the nonlinear processing.
 pub struct Waveshaper {
     /// Distortion amount (1.0-10.0, 1.0 = bypass)
     drive: f32,
     /// Dry/wet mix (0.0-1.0)
     mix: f32,
-    /// 2x oversampler for alias reduction
-    oversampler: Oversampler2x,
+    /// Selectable oversampler for alias reduction
+    oversampler: Oversampler,
 }
 
 impl Waveshaper {
@@ -29,7 +29,7 @@ impl Waveshaper {
         Self {
             drive: drive.clamp(1.0, 10.0),
             mix: mix.clamp(0.0, 1.0),
-            oversampler: Oversampler2x::new(),
+            oversampler: Oversampler::default(),
         }
     }
 
@@ -46,6 +46,11 @@ impl Waveshaper {
     /// 3. Mix with dry signal
     #[inline]
     pub fn process(&mut self, input: f32) -> f32 {
+        if !input.is_finite() {
+            self.reset();
+            return 0.0;
+        }
+
         // Bypass if no effect or drive is 1.0
         if self.mix <= 0.0001 || self.drive <= 1.0 {
             return input;
@@ -57,7 +62,7 @@ impl Waveshaper {
         let reference = 0.5_f32;
         let compensation = reference.tanh() / (reference * drive).tanh();
 
-        // Apply drive gain and soft-clip using tanh with 2x oversampling
+        // Apply drive gain and soft-clip using tanh at the selected oversampling rate
         let saturated = self
             .oversampler
             .process(input, |x| (x * drive).tanh() * compensation);
@@ -84,6 +89,21 @@ impl Waveshaper {
     /// Get the current mix amount
     pub fn mix(&self) -> f32 {
         self.mix
+    }
+
+    /// Set the oversampling rate. Changing it clears oversampling filter history.
+    pub fn set_oversampling_mode(&mut self, mode: OversamplingMode) {
+        self.oversampler.set_mode(mode);
+    }
+
+    /// Get the current oversampling rate.
+    pub fn oversampling_mode(&self) -> OversamplingMode {
+        self.oversampler.mode()
+    }
+
+    /// Reset the oversampling filter history.
+    pub fn reset(&mut self) {
+        self.oversampler.reset();
     }
 }
 
@@ -153,6 +173,15 @@ mod tests {
     }
 
     #[test]
+    fn test_configurable_oversampling_defaults_to_4x() {
+        let mut ws = Waveshaper::new(5.0, 1.0);
+        assert_eq!(ws.oversampling_mode(), OversamplingMode::X4);
+
+        ws.set_oversampling_mode(OversamplingMode::Off);
+        assert_eq!(ws.oversampling_mode(), OversamplingMode::Off);
+    }
+
+    #[test]
     fn test_zero_input() {
         let mut ws = Waveshaper::new(5.0, 1.0);
         // Warm up oversampler
@@ -161,5 +190,32 @@ mod tests {
         }
         let output = ws.process(0.0);
         assert_eq!(output, 0.0);
+    }
+
+    #[test]
+    fn test_reset_matches_fresh_instance() {
+        let mut reset = Waveshaper::new(5.0, 1.0);
+        for i in 0..1000 {
+            reset.process((i as f32 * 0.1).sin());
+        }
+        reset.reset();
+
+        let mut fresh = Waveshaper::new(5.0, 1.0);
+        for i in 0..100 {
+            let input = (i as f32 * 0.27).sin();
+            assert_eq!(reset.process(input), fresh.process(input));
+        }
+    }
+
+    #[test]
+    fn test_nan_protection_resets_state() {
+        let mut reset = Waveshaper::new(5.0, 1.0);
+        for i in 0..1000 {
+            reset.process((i as f32 * 0.1).sin());
+        }
+        assert_eq!(reset.process(f32::NAN), 0.0);
+
+        let mut fresh = Waveshaper::new(5.0, 1.0);
+        assert_eq!(reset.process(0.5), fresh.process(0.5));
     }
 }

--- a/src/instruments/kick.rs
+++ b/src/instruments/kick.rs
@@ -5,7 +5,9 @@ use crate::gen::oscillator::Oscillator;
 use crate::gen::pink_noise::PinkNoise;
 use crate::gen::waveform::Waveform;
 use crate::instruments::fm_snap::PhaseModulator;
-use crate::utils::{tuning_to_multiplier, Blendable, SmoothedParam, DEFAULT_SMOOTH_TIME_MS};
+use crate::utils::{
+    tuning_to_multiplier, Blendable, OversamplingMode, SmoothedParam, DEFAULT_SMOOTH_TIME_MS,
+};
 
 /// Normalization ranges for kick drum parameters
 /// All external-facing parameters use 0.0-1.0 normalized values
@@ -1320,6 +1322,16 @@ impl KickDrum {
         self.params.overdrive.set_target(amount.clamp(0.0, 1.0));
     }
 
+    /// Set the oversampling rate used by the kick's feedback waveshaper.
+    pub fn set_oversampling_mode(&mut self, mode: OversamplingMode) {
+        self.waveshaper.set_oversampling_mode(mode);
+    }
+
+    /// Get the oversampling rate used by the kick's feedback waveshaper.
+    pub fn oversampling_mode(&self) -> OversamplingMode {
+        self.waveshaper.oversampling_mode()
+    }
+
     /// Set feedback waveshaper amount (smoothed, 0-1 → 0.0-0.9 gain)
     pub fn set_feedback(&mut self, amount: f32) {
         self.params.feedback.set_target(amount.clamp(0.0, 1.0));
@@ -1487,5 +1499,19 @@ impl crate::engine::Modulatable for KickDrum {
             "tuning" => Some(self.params.tuning.range()),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kick_oversampling_mode_defaults_to_4x_and_is_configurable() {
+        let mut kick = KickDrum::new(48_000.0);
+        assert_eq!(kick.oversampling_mode(), OversamplingMode::X4);
+
+        kick.set_oversampling_mode(OversamplingMode::Off);
+        assert_eq!(kick.oversampling_mode(), OversamplingMode::Off);
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,7 +5,7 @@ pub mod oversampler;
 pub mod smoother;
 
 pub use blendable::{Blendable, PresetBlender};
-pub use oversampler::Oversampler2x;
+pub use oversampler::{Oversampler, Oversampler2x, Oversampler4x, OversamplingMode};
 pub use smoother::{ParamSmoother, SmoothedParam, DEFAULT_SMOOTH_TIME_MS};
 
 /// Convert a normalized tuning value (0.0–1.0) to a frequency multiplier.

--- a/src/utils/oversampler.rs
+++ b/src/utils/oversampler.rs
@@ -1,46 +1,283 @@
-/// 2x oversampling for nonlinear audio effects.
+use halfband::iir::{Downsampler8, Upsampler8};
+
+/// Selects the sample-rate multiplier used around a nonlinear function.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[repr(u8)]
+pub enum OversamplingMode {
+    /// Process the nonlinear function at the engine sample rate.
+    Off = 0,
+    /// Process the nonlinear function at twice the engine sample rate.
+    X2 = 2,
+    /// Process the nonlinear function at four times the engine sample rate.
+    #[default]
+    X4 = 4,
+}
+
+impl OversamplingMode {
+    /// Return the nonlinear function's sample-rate multiplier.
+    pub const fn factor(self) -> usize {
+        match self {
+            Self::Off => 1,
+            Self::X2 => 2,
+            Self::X4 => 4,
+        }
+    }
+
+    pub(crate) const fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Off,
+            2 => Self::X2,
+            _ => Self::X4,
+        }
+    }
+}
+
+/// Low-latency 2x oversampling for nonlinear audio effects.
 ///
-/// Upsamples input by 2x using linear interpolation, applies the nonlinear
-/// function at the higher rate, then downsamples by averaging. This reduces
-/// aliasing from waveshaping, saturation, and other nonlinear processing.
+/// Uses a polyphase IIR half-band filter pair with 94 dB attenuation.
 pub struct Oversampler2x {
-    /// Previous input sample for linear interpolation during upsampling
-    prev_input: f32,
+    upsampler: Upsampler8,
+    downsampler: Downsampler8,
 }
 
 impl Oversampler2x {
     pub fn new() -> Self {
-        Self { prev_input: 0.0 }
+        Self {
+            upsampler: Upsampler8::default(),
+            downsampler: Downsampler8::default(),
+        }
     }
 
     /// Process one input sample through a nonlinear function at 2x rate.
-    ///
-    /// 1. Upsamples by inserting a linearly interpolated midpoint
-    /// 2. Applies `f` to both oversampled values
-    /// 3. Downsamples by averaging the two processed samples
     #[inline]
     pub fn process(&mut self, input: f32, mut f: impl FnMut(f32) -> f32) -> f32 {
-        // Upsample: create interpolated midpoint between previous and current
-        let mid = (self.prev_input + input) * 0.5;
-        self.prev_input = input;
+        let [s0, s1] = self.upsampler.process(input);
+        self.downsampler.process(f(s0), f(s1))
+    }
 
-        // Process both samples through the nonlinear function
-        let y0 = f(mid);
-        let y1 = f(input);
+    /// Clear all filter history without reallocating coefficients.
+    pub fn reset(&mut self) {
+        self.upsampler.clear();
+        self.downsampler.clear();
+    }
+}
 
-        // Downsample by averaging (acts as a simple lowpass)
-        (y0 + y1) * 0.5
+impl Default for Oversampler2x {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Low-latency 4x oversampling for nonlinear audio effects.
+///
+/// Cascades two polyphase IIR half-band filter pairs. The nonlinear closure is
+/// evaluated four times per engine-rate input sample.
+pub struct Oversampler4x {
+    outer_upsampler: Upsampler8,
+    inner_upsampler: Upsampler8,
+    inner_downsampler: Downsampler8,
+    outer_downsampler: Downsampler8,
+}
+
+impl Oversampler4x {
+    pub fn new() -> Self {
+        Self {
+            outer_upsampler: Upsampler8::default(),
+            inner_upsampler: Upsampler8::default(),
+            inner_downsampler: Downsampler8::default(),
+            outer_downsampler: Downsampler8::default(),
+        }
+    }
+
+    /// Process one input sample through a nonlinear function at 4x rate.
+    #[inline]
+    pub fn process(&mut self, input: f32, mut f: impl FnMut(f32) -> f32) -> f32 {
+        let [outer_0, outer_1] = self.outer_upsampler.process(input);
+
+        let [inner_0, inner_1] = self.inner_upsampler.process(outer_0);
+        let down_0 = self.inner_downsampler.process(f(inner_0), f(inner_1));
+
+        let [inner_2, inner_3] = self.inner_upsampler.process(outer_1);
+        let down_1 = self.inner_downsampler.process(f(inner_2), f(inner_3));
+
+        self.outer_downsampler.process(down_0, down_1)
+    }
+
+    /// Clear all filter history without reallocating coefficients.
+    pub fn reset(&mut self) {
+        self.outer_upsampler.clear();
+        self.inner_upsampler.clear();
+        self.inner_downsampler.clear();
+        self.outer_downsampler.clear();
+    }
+}
+
+impl Default for Oversampler4x {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Runtime-selectable oversampling for nonlinear audio effects.
+///
+/// Changing mode clears both filter paths so stale history is never reused.
+/// The default mode is [`OversamplingMode::X4`].
+pub struct Oversampler {
+    mode: OversamplingMode,
+    x2: Oversampler2x,
+    x4: Oversampler4x,
+}
+
+impl Oversampler {
+    pub fn new(mode: OversamplingMode) -> Self {
+        Self {
+            mode,
+            x2: Oversampler2x::new(),
+            x4: Oversampler4x::new(),
+        }
+    }
+
+    /// Process one input sample at the selected oversampling rate.
+    #[inline]
+    pub fn process(&mut self, input: f32, f: impl FnMut(f32) -> f32) -> f32 {
+        match self.mode {
+            OversamplingMode::Off => {
+                let mut f = f;
+                f(input)
+            }
+            OversamplingMode::X2 => self.x2.process(input, f),
+            OversamplingMode::X4 => self.x4.process(input, f),
+        }
+    }
+
+    /// Change the oversampling rate and clear all filter history.
+    ///
+    /// Switching an active signal can create a discontinuity, so clean A/B
+    /// comparisons should change mode while stopped or silent.
+    pub fn set_mode(&mut self, mode: OversamplingMode) {
+        if self.mode != mode {
+            self.mode = mode;
+            self.reset();
+        }
+    }
+
+    pub fn mode(&self) -> OversamplingMode {
+        self.mode
+    }
+
+    /// Clear all filter history without changing the selected mode.
+    pub fn reset(&mut self) {
+        self.x2.reset();
+        self.x4.reset();
+    }
+}
+
+impl Default for Oversampler {
+    fn default() -> Self {
+        Self::new(OversamplingMode::default())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::f64::consts::TAU;
+
+    const TEST_SAMPLE_RATE: f32 = 48_000.0;
+    const TEST_FREQUENCY: f32 = 10_000.0;
+    const TEST_DRIVE: f32 = 10.0;
+    const TEST_SAMPLES: usize = 4_800;
+    const WARMUP_SAMPLES: usize = 1_024;
+
+    struct Oversampler16x {
+        outer: Oversampler4x,
+        inner: Oversampler4x,
+    }
+
+    impl Oversampler16x {
+        fn new() -> Self {
+            Self {
+                outer: Oversampler4x::new(),
+                inner: Oversampler4x::new(),
+            }
+        }
+
+        fn process(&mut self, input: f32, mut f: impl FnMut(f32) -> f32) -> f32 {
+            let outer = &mut self.outer;
+            let inner = &mut self.inner;
+            outer.process(input, |x| inner.process(x, &mut f))
+        }
+    }
+
+    fn test_input(sample: usize) -> f32 {
+        (std::f32::consts::TAU * TEST_FREQUENCY * sample as f32 / TEST_SAMPLE_RATE).sin() * 0.8
+    }
+
+    fn render_base_rate() -> Vec<f32> {
+        (WARMUP_SAMPLES..WARMUP_SAMPLES + TEST_SAMPLES)
+            .map(|i| (test_input(i) * TEST_DRIVE).tanh())
+            .collect()
+    }
+
+    fn render_4x() -> Vec<f32> {
+        let mut oversampler = Oversampler4x::new();
+        (0..WARMUP_SAMPLES + TEST_SAMPLES)
+            .filter_map(|i| {
+                let output = oversampler.process(test_input(i), |x| (x * TEST_DRIVE).tanh());
+                (i >= WARMUP_SAMPLES).then_some(output)
+            })
+            .collect()
+    }
+
+    fn render_16x_reference() -> Vec<f32> {
+        let mut oversampler = Oversampler16x::new();
+        (0..WARMUP_SAMPLES + TEST_SAMPLES)
+            .filter_map(|i| {
+                let output = oversampler.process(test_input(i), |x| (x * TEST_DRIVE).tanh());
+                (i >= WARMUP_SAMPLES).then_some(output)
+            })
+            .collect()
+    }
+
+    fn bin_power(samples: &[f32], frequency: f32) -> f64 {
+        let phase_step = TAU * frequency as f64 / TEST_SAMPLE_RATE as f64;
+        let (real, imag) =
+            samples
+                .iter()
+                .enumerate()
+                .fold((0.0_f64, 0.0_f64), |(real, imag), (i, &x)| {
+                    let phase = phase_step * i as f64;
+                    (real + x as f64 * phase.cos(), imag - x as f64 * phase.sin())
+                });
+        real * real + imag * imag
+    }
+
+    fn combined_power(samples: &[f32], frequencies: &[f32]) -> f64 {
+        frequencies
+            .iter()
+            .map(|&frequency| bin_power(samples, frequency))
+            .sum()
+    }
+
+    fn magnitude_vector(samples: &[f32], frequencies: &[f32]) -> Vec<f64> {
+        frequencies
+            .iter()
+            .map(|&frequency| bin_power(samples, frequency).sqrt())
+            .collect()
+    }
+
+    fn squared_vector_error(actual: &[f64], reference: &[f64]) -> f64 {
+        actual
+            .iter()
+            .zip(reference)
+            .map(|(actual, reference)| (actual - reference).powi(2))
+            .sum()
+    }
 
     #[test]
     fn test_oversampler_passthrough_dc() {
         let mut os = Oversampler2x::new();
-        // Feed constant DC — output should converge to the same DC value
+        // Feed constant DC - output should converge to the same DC value.
         let mut last = 0.0;
         for _ in 0..100 {
             last = os.process(1.0, |x| x);
@@ -55,7 +292,7 @@ mod tests {
     #[test]
     fn test_oversampler_with_nonlinearity() {
         let mut os = Oversampler2x::new();
-        // Process a sine wave through tanh — should not panic or produce NaN
+        // Process a sine wave through tanh - should not panic or produce NaN.
         let sample_rate = 44100.0_f32;
         let freq = 1000.0;
         for i in 0..44100 {
@@ -68,5 +305,112 @@ mod tests {
                 output
             );
         }
+    }
+
+    #[test]
+    fn test_oversampler_4x_passthrough_dc() {
+        let mut os = Oversampler4x::new();
+        let mut last = 0.0;
+        for _ in 0..200 {
+            last = os.process(1.0, |x| x);
+        }
+        assert!(
+            (last - 1.0).abs() < 0.01,
+            "DC passthrough expected ~1.0, got {last}"
+        );
+    }
+
+    #[test]
+    fn test_oversampler_4x_reset_matches_fresh_instance() {
+        let mut reset = Oversampler4x::new();
+        for i in 0..1000 {
+            reset.process((i as f32 * 0.1).sin(), |x| (x * 5.0).tanh());
+        }
+        reset.reset();
+
+        let mut fresh = Oversampler4x::new();
+        for i in 0..100 {
+            let input = (i as f32 * 0.27).sin();
+            assert_eq!(
+                reset.process(input, |x| (x * 5.0).tanh()),
+                fresh.process(input, |x| (x * 5.0).tanh())
+            );
+        }
+    }
+
+    #[test]
+    fn test_selectable_oversampler_defaults_to_4x() {
+        let oversampler = Oversampler::default();
+        assert_eq!(oversampler.mode(), OversamplingMode::X4);
+        assert_eq!(oversampler.mode().factor(), 4);
+    }
+
+    #[test]
+    fn test_selectable_oversampler_off_is_exact() {
+        let mut oversampler = Oversampler::new(OversamplingMode::Off);
+        assert_eq!(oversampler.process(0.25, |x| x * 2.0), 0.5);
+    }
+
+    #[test]
+    fn test_selectable_oversampler_mode_change_resets_filter_history() {
+        let mut switched = Oversampler::new(OversamplingMode::X4);
+        for i in 0..1000 {
+            switched.process((i as f32 * 0.1).sin(), |x| (x * 5.0).tanh());
+        }
+        switched.set_mode(OversamplingMode::X2);
+
+        let mut fresh = Oversampler::new(OversamplingMode::X2);
+        for i in 0..100 {
+            let input = (i as f32 * 0.27).sin();
+            assert_eq!(
+                switched.process(input, |x| (x * 5.0).tanh()),
+                fresh.process(input, |x| (x * 5.0).tanh())
+            );
+        }
+    }
+
+    #[test]
+    fn test_oversampler_4x_reduces_known_tanh_aliases_by_20_db() {
+        let base_rate = render_base_rate();
+        let oversampled = render_4x();
+        let alias_frequencies = [2_000.0, 18_000.0, 22_000.0];
+
+        let base_alias_power = combined_power(&base_rate, &alias_frequencies);
+        let oversampled_alias_power = combined_power(&oversampled, &alias_frequencies);
+        let reduction_db = 10.0 * (base_alias_power / oversampled_alias_power).log10();
+
+        assert!(
+            reduction_db >= 20.0,
+            "expected at least 20 dB alias reduction, measured {reduction_db:.2} dB"
+        );
+
+        let base_fundamental = bin_power(&base_rate, TEST_FREQUENCY).sqrt();
+        let oversampled_fundamental = bin_power(&oversampled, TEST_FREQUENCY).sqrt();
+        let fundamental_change_db = 20.0 * (oversampled_fundamental / base_fundamental).log10();
+        assert!(
+            fundamental_change_db.abs() < 1.0,
+            "fundamental changed by {fundamental_change_db:.2} dB"
+        );
+    }
+
+    #[test]
+    fn test_oversampler_4x_is_closer_to_16x_spectral_reference_than_base_rate() {
+        let base_rate = render_base_rate();
+        let oversampled = render_4x();
+        let reference = render_16x_reference();
+        let measured_frequencies = [2_000.0, 10_000.0, 18_000.0, 22_000.0];
+
+        let base_magnitudes = magnitude_vector(&base_rate, &measured_frequencies);
+        let oversampled_magnitudes = magnitude_vector(&oversampled, &measured_frequencies);
+        let reference_magnitudes = magnitude_vector(&reference, &measured_frequencies);
+
+        let base_error = squared_vector_error(&base_magnitudes, &reference_magnitudes);
+        let oversampled_error =
+            squared_vector_error(&oversampled_magnitudes, &reference_magnitudes);
+
+        assert!(
+            oversampled_error < base_error * 0.1,
+            "4x spectral error ({oversampled_error:.3}) should be at least 10x lower than base-rate error ({base_error:.3})"
+        );
     }
 }


### PR DESCRIPTION
Replaces the weak interpolation oversampler with low-latency polyphase IIR 2x/4x oversampling and applies it to the explicit waveshaper, tube saturation, and kick feedback distortion stages. Adds runtime-selectable Off, 2x, and 4x modes while preserving 4x as the default, existing constructors, bypass behavior, and FFI contracts. Adds deterministic spectral tests and an artifact/throughput example; measured known-bin alias reduction was 25.11 dB at 2x and 26.04 dB at 4x versus off. The kick CLI now cycles modes with `O` for live listening comparisons. Validation passed with `cargo fmt --check`, no-default/full test suites, the kick CLI build and interactive smoke test, native release build, and iOS device/simulator release builds.
