### PR TITLE
Add stereo output foundation (interleaved FFI + native CPAL)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Sequencer ──trigger──▶ Instruments ──tick──▶ Sum ──▶ M
 
 ## Planning Conventions
 
-- Store execution plans in `.context/plans/`.
+- Store execution plans in `./plans/` (the repo-root `plans/` directory). Plans are committed so they can be referenced, continued, and pulled up across PRs.
 - Use dash-separated lowercase filenames for plans, for example `granulator-original-design-gap-plan.md`.
 - When writing an ExecPlan, follow `.agent/PLANS.md` and keep the plan self-contained.
 

--- a/plans/stereo-support-plan.md
+++ b/plans/stereo-support-plan.md
@@ -1,0 +1,131 @@
+# Stereo Support for libgooey — Multi-Pass Foundation
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds. It must be maintained in accordance with `.agent/PLANS.md` (repository root).
+
+
+## Purpose / Big Picture
+
+libgooey was mono end-to-end: every `Instrument::tick` and `Effect::process` returns a single `f32`, both engines (the native `Engine` in `src/engine/mod.rs` and the FFI `GooeyEngine` in `src/ffi.rs`) sum to one mono sample, and the output layers duplicated that sample to every hardware channel. There was no stereo "currency" anywhere, so any future stereo feature (per-instrument panning, stereo reverb/delay/width) would require a cross-cutting refactor.
+
+This work introduces a stereo **foundation** so those features become local changes later. After Pass 1, the engine produces a two-channel `StereoFrame` at a single conversion point (the "stereo seam"), the native CPAL output writes true left/right, and the iOS-facing FFI (`gooey_engine_render`) writes **interleaved stereo** (`frames * 2` floats, laid out `[L, R, L, R, ...]`). The signal path is still mono, so left and right are currently identical — but every consumer now treats output as stereo, which is what makes later passes cheap.
+
+You can see it working by running `cargo test --test ffi_stereo` (asserts the buffer is `frames * 2`, that L == R for the mono path, and that a triggered kick produces audio on both channels) and by inspecting `include/gooey.h` for `#define GOOEY_OUTPUT_CHANNELS 2` and the interleaved-stereo contract on `gooey_engine_render`.
+
+
+## Progress
+
+- [x] (2026-06-10) Pass 1, Step 0: fast-forwarded `origin/main` (5 upstream PRs incl. FFI master-gain stage); re-verified green baseline.
+- [x] (2026-06-10) Pass 1, Step 1: added `StereoFrame { l, r }` with `mono()`/`downmix()` in `src/frame.rs`; registered + re-exported in `src/lib.rs`.
+- [x] (2026-06-10) Pass 1, Step 2: added `Engine::tick_stereo` seam in `src/engine/mod.rs` (mono `tick` untouched).
+- [x] (2026-06-10) Pass 1, Step 3: native CPAL output writes true L/R in `src/engine/engine_output.rs` (new `write_stereo_frame` helper; viz buffer gets the downmix).
+- [x] (2026-06-10) Pass 1, Step 4: `GooeyEngine::render` writes interleaved stereo (`chunks_mut(2)`, both lanes zeroed on silence/arm); `resolve_pending_arm` now receives the frame count; `gooey_engine_render` slices `frames * 2`; added `GOOEY_OUTPUT_CHANNELS`.
+- [x] (2026-06-10) Pass 1, Step 5: updated all 9 FFI integration tests to the `frames * 2` buffer contract; added `tests/ffi_stereo.rs`; `StereoFrame` unit tests live in `src/frame.rs`.
+- [x] (2026-06-10) Pass 1, Step 6: regenerated `include/gooey.h` (cbindgen); audited callers — only `gooey_engine_render` drives `GooeyEngine::render`; offline bounce stays mono (see Decision Log).
+- [x] (2026-06-10) Pass 1, Step 7: this ExecPlan persisted.
+- [ ] Pass 2: per-instrument pan (see roadmap).
+- [ ] Pass 3: stereo-native effects (see roadmap).
+
+The foundation shipped in two commits on branch `bhurlow/libgooey-stereo-support` (PR #201): first the native-side foundation (StereoFrame + CPAL + `tick_stereo`), then the FFI interleaving + test updates.
+
+
+## Surprises & Discoveries
+
+- Observation: The `frames * 2` contract change touched **nine** integration test files, not the two named in the original plan. Every FFI test allocated a `frames`-length (mono) buffer; with the new contract each would have been a half-size out-of-bounds write.
+  Evidence: `rg "gooey_engine_render" tests/` matched `channel_instrument_swap`, `effect_order`, `ffi_gain_staging`, `ffi_granulator`, `instrument_gain`, `mute_solo`, `sequencer_armed_start`, `sequencer_triggers_enabled`, `volume_zero_mute`.
+- Observation: No test indexes the audio buffer positionally (only whole-buffer peak/energy and element-wise comparisons), so simply doubling each buffer to `frames * 2` preserves every assertion — L == R means peaks, sums, and per-index comparisons are unchanged.
+  Evidence: `rg "buffer\[|audio\[|\.get\(" tests/` → no matches.
+- Observation: Two call sites passed `buffer.len()` as the frame count (`effect_order.rs`, `ffi_granulator.rs`); under the new contract that would request `2 * buffer.len()` samples. Fixed by passing an explicit frame count.
+- Observation: `clippy --all-targets --all-features` already fails on the post-merge baseline because some examples use a stale `HiHat2` API (`amp_decay`, `set_open`, `closed_default`). Pre-existing, unrelated to stereo; library + tests are clippy-clean.
+  Evidence: stashing all stereo changes and rerunning clippy reproduced the example errors.
+
+
+## Decision Log
+
+- Decision: Ship stereo in passes; Pass 1 is I/O foundation only (StereoFrame currency + interleaved FFI/CPAL output, L == R), with instruments and effects untouched.
+  Rationale: User chose this scope explicitly; it de-risks the cross-cutting work and integrates to iOS immediately.
+  Date/Author: 2026-06-10, Brian (via planning Q&A).
+- Decision: Replace `gooey_engine_render` to write interleaved stereo (`frames * 2`) rather than adding a parallel `_stereo` function.
+  Rationale: Single consumer (the user's iOS app), single clean path; the user updates the Swift call site against the regenerated header.
+  Date/Author: 2026-06-10, Brian (via planning Q&A).
+- Decision: Keep changes in this repo only (FFI, header, tests); the Swift call site is wired up by the user in the separate app repo.
+  Rationale: The iOS app is not in this repository; libgooey ships as `libgooey.a` + `include/gooey.h`.
+  Date/Author: 2026-06-10, Brian (via planning Q&A).
+- Decision: Leave the offline bounce (`bounce.rs` / `gooey_engine_bounce_to_buffer`) mono for now.
+  Rationale: Bounce is a separate offline path driven by the mono `Engine::tick`; it remains internally consistent and its tests pass. Stereo-ifying bounce is deferred to a later pass to keep Pass 1 focused on the realtime/iOS path.
+  Date/Author: 2026-06-10, Claude.
+
+
+## Context and Orientation
+
+There are two distinct engines. The native `Engine` (`src/engine/mod.rs`) owns a `HashMap` of instruments and is driven by CPAL via `src/engine/engine_output.rs`. The FFI `GooeyEngine` (`src/ffi.rs`) is a separate, self-contained struct with a fixed array of channels, driven by the host (iOS) through `gooey_engine_render`. They do not share a render loop.
+
+The "stereo seam" is the single line where the mono signal becomes two channels: `StereoFrame::mono(output)` (`src/frame.rs`). In the native engine it lives in `Engine::tick_stereo`; in the FFI engine it lives at the end of the per-frame loop in `GooeyEngine::render`. "Interleaved stereo" means one frame occupies two consecutive buffer slots, `[left, right]`.
+
+`include/gooey.h` is generated by cbindgen from `src/ffi.rs` during `cargo build` (`build.rs`); never hand-edit it.
+
+
+## Plan of Work (as executed)
+
+In `src/frame.rs` (new), define `StereoFrame { pub l: f32, pub r: f32 }` with `mono(x) -> {l:x, r:x}` and `downmix() -> 0.5*(l+r)`; register `pub mod frame;` + `pub use frame::StereoFrame;` in `src/lib.rs`.
+
+In `src/engine/mod.rs`, add `pub fn tick_stereo(&mut self, t: f64) -> StereoFrame { StereoFrame::mono(self.tick(t)) }`.
+
+In `src/engine/engine_output.rs`, replace the "copy to all channels" loop in both `process_frame` and `process_frame_no_viz` with `engine_guard.tick_stereo(...)` + `Self::write_stereo_frame(frame, stereo)`. The helper writes the downmix for 1 channel, L/R for ≥2 channels, and fills any extra surround channels with the downmix. The visualization buffer receives `stereo.downmix()`.
+
+In `src/ffi.rs`: import `StereoFrame`; in `GooeyEngine::render` compute `frame_count = buffer.len() / 2`, pass it to `resolve_pending_arm`, iterate `buffer.chunks_mut(2)`, `frame.fill(0.0)` for pre-fire silence, and at the seam write `frame[0] = stereo.l; frame.get_mut(1) = stereo.r`. In `gooey_engine_render`, size both slices `frames * 2` and update the doc. Add `pub const GOOEY_OUTPUT_CHANNELS: u32 = 2;`.
+
+In `tests/`, resize every FFI render buffer to `frames * 2`, replace the two `buffer.len()`-as-frames call sites with explicit frame counts, and add `tests/ffi_stereo.rs`.
+
+
+## Validation and Acceptance
+
+Run from the repo root:
+
+    cargo build                       # regenerates include/gooey.h
+    cargo test                        # expect all suites pass, incl. tests/ffi_stereo.rs (3 tests)
+    cargo fmt --all -- --check        # expect exit 0
+    cargo clippy --lib --tests --all-features   # expect warnings only (no errors)
+
+Acceptance (behavior):
+- `cargo test --test ffi_stereo` passes: render fills exactly `frames * 2`, L == R per frame, a triggered kick is audible on both channels, and a correctly sized buffer does not set the engine error flag.
+- `include/gooey.h` contains `#define GOOEY_OUTPUT_CHANNELS 2` and documents the interleaved `frames * 2` contract on `gooey_engine_render`.
+
+Known/pre-existing: `cargo clippy --all-targets --all-features` and `cargo build --example kick` fail on stale examples (outdated `HiHat2` API) that predate this work.
+
+
+## Idempotence and Recovery
+
+All steps are additive and re-runnable. `StereoFrame::mono` keeps L == R, so the change is behavior-preserving for current mono content — if a regression appears, the seam is the single place to inspect. The merge was a clean fast-forward; re-running `cargo build` regenerates the header deterministically.
+
+
+## Pass 2 / Pass 3 Roadmap (why the seam is shaped this way)
+
+Pass 2 — Per-instrument pan: add a per-channel pan `SmoothedParam` to `GooeyEngine` (and the native `Engine`), replace `StereoFrame::mono(output)` at the seam with a per-channel panned sum into a stereo bus, expose `gooey_engine_set_channel_pan(channel, pan)`, and add left/right output peak meters. Only the seam and a few FFI setters change.
+
+Pass 3 — Stereo-native effects: widen the `Effect` trait with `fn process_stereo(&self, StereoFrame) -> StereoFrame` (effects gain per-channel state), enabling stereo reverb/delay/ping-pong and width. The Pass 1 output boundary (FFI interleave, CPAL write, tests) is reused unchanged.
+
+
+## Interfaces and Dependencies
+
+In `src/frame.rs`:
+
+    pub struct StereoFrame { pub l: f32, pub r: f32 }
+    impl StereoFrame {
+        pub const fn mono(x: f32) -> Self;
+        pub fn downmix(self) -> f32;
+    }
+
+In `src/engine/mod.rs`:
+
+    impl Engine { pub fn tick_stereo(&mut self, current_time: f64) -> StereoFrame; }
+
+In `src/ffi.rs` (C ABI, reflected in `include/gooey.h`):
+
+    pub const GOOEY_OUTPUT_CHANNELS: u32 = 2;
+    // buffer must hold `frames * GOOEY_OUTPUT_CHANNELS` interleaved [L, R] floats
+    pub unsafe extern "C" fn gooey_engine_render(engine: *mut GooeyEngine, buffer: *mut f32, frames: u32);
+
+
+## Outcomes & Retrospective
+
+Pass 1 complete. libgooey now emits interleaved stereo from the FFI and true L/R from CPAL, with a single seam (`StereoFrame::mono`) as the only mono→stereo conversion point. The main lesson: the realtime FFI buffer contract is exercised by far more tests than expected (nine files), but because no test indexes audio positionally, the migration reduced to a mechanical buffer-size doubling plus two explicit frame-count fixes. The offline bounce remains mono and is the most likely first follow-up if stereo export is needed.

--- a/src/engine/engine_output.rs
+++ b/src/engine/engine_output.rs
@@ -1,4 +1,5 @@
 use super::Engine;
+use crate::frame::StereoFrame;
 #[cfg(feature = "native")]
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
@@ -388,19 +389,15 @@ impl EngineOutput {
             let current_sample = start_sample + frame_index as u64;
             let current_time = current_sample as f64 / sample_rate;
 
-            // Call engine.tick() to generate audio
-            let audio_sample = engine_guard.tick(current_time);
-            let value: SampleType = SampleType::from_sample(audio_sample);
+            // Call engine.tick_stereo() to generate a stereo frame
+            let stereo = engine_guard.tick_stereo(current_time);
 
-            // Capture audio sample for visualization
+            // Capture audio for visualization (mono downmix; one value per sample)
             if let Some(buffer) = audio_buffer {
-                buffer.push(audio_sample);
+                buffer.push(stereo.downmix());
             }
 
-            // Copy the same value to all channels
-            for sample in frame.iter_mut() {
-                *sample = value;
-            }
+            Self::write_stereo_frame(frame, stereo);
         }
     }
 
@@ -433,13 +430,37 @@ impl EngineOutput {
             let current_sample = start_sample + frame_index as u64;
             let current_time = current_sample as f64 / sample_rate;
 
-            // Call engine.tick() to generate audio
-            let audio_sample = engine_guard.tick(current_time);
-            let value: SampleType = SampleType::from_sample(audio_sample);
+            // Call engine.tick_stereo() to generate a stereo frame
+            let stereo = engine_guard.tick_stereo(current_time);
 
-            // Copy the same value to all channels
-            for sample in frame.iter_mut() {
-                *sample = value;
+            Self::write_stereo_frame(frame, stereo);
+        }
+    }
+
+    /// Write a stereo frame into one device frame (a slice of `num_channels`
+    /// interleaved samples).
+    ///
+    /// - 1 channel: the mono downmix.
+    /// - 2+ channels: left to channel 0, right to channel 1; any further
+    ///   channels (surround layouts) receive the mono downmix.
+    fn write_stereo_frame<SampleType>(frame: &mut [SampleType], stereo: StereoFrame)
+    where
+        SampleType: Sample + FromSample<f32>,
+    {
+        match frame.len() {
+            0 => {}
+            1 => {
+                frame[0] = SampleType::from_sample(stereo.downmix());
+            }
+            _ => {
+                frame[0] = SampleType::from_sample(stereo.l);
+                frame[1] = SampleType::from_sample(stereo.r);
+                if frame.len() > 2 {
+                    let fill = SampleType::from_sample(stereo.downmix());
+                    for sample in &mut frame[2..] {
+                        *sample = fill;
+                    }
+                }
             }
         }
     }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,4 +1,5 @@
 use crate::effects::{Effect, SoftLimiter};
+use crate::frame::StereoFrame;
 use crate::utils::SmoothedParam;
 use std::collections::{HashMap, VecDeque};
 
@@ -338,6 +339,17 @@ impl Engine {
         }
 
         output
+    }
+
+    /// Generate one stereo frame of audio at the given time.
+    ///
+    /// This is the native engine's "stereo seam": the signal path is mono, so
+    /// the mono [`Engine::tick`] output is placed equally on both channels via
+    /// [`StereoFrame::mono`]. Output sinks (CPAL device, offline bounce) call
+    /// this to drive true two-channel output. Future per-instrument panning or
+    /// stereo effects only need to change what this method returns.
+    pub fn tick_stereo(&mut self, current_time: f64) -> StereoFrame {
+        StereoFrame::mono(self.tick(current_time))
     }
 
     pub fn sample_rate(&self) -> f32 {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -9,6 +9,7 @@ use crate::effects::{
 };
 use crate::engine::lfo::{Lfo, MusicalDivision};
 use crate::engine::{Instrument, Sequencer, SequencerBlendSetting, SequencerStepSettings};
+use crate::frame::StereoFrame;
 use crate::instruments::{
     BassConfig, BassSynth, Granulator, HiHat2, HiHat2Config, KickConfig, KickDrum, PolySynth,
     PolySynthConfig, SampleBuffer, SnareConfig, SnareDrum, Tom2, Tom2Config,
@@ -905,9 +906,17 @@ impl GooeyEngine {
         }
     }
 
+    /// Render audio into an interleaved stereo `buffer` of `buffer.len() / 2`
+    /// frames. Each frame occupies two consecutive slots: `[left, right]`. The
+    /// signal path is mono, so left and right are currently identical (see the
+    /// "stereo seam" near the end of the per-frame loop), but the engine writes
+    /// two-channel output so hosts (and future stereo features) consume stereo.
     fn render(&mut self, buffer: &mut [f32]) {
         // Clear pending MIDI events from previous render pass
         self.pending_midi_events.clear();
+
+        // Number of stereo frames this buffer holds (two slots per frame).
+        let frame_count = buffer.len() / 2;
 
         // Resolve any host-time-armed start against this buffer's host clock.
         // Possible outcomes:
@@ -917,7 +926,7 @@ impl GooeyEngine {
         // When the arm fires later than this buffer, we zero the whole
         // buffer below and leave `pending_arm_host_time` staged so the next
         // render re-evaluates against its own host time.
-        let arm_state = self.resolve_pending_arm(buffer.len());
+        let arm_state = self.resolve_pending_arm(frame_count);
         let mut arm_fires_at: Option<u32> = match arm_state {
             ArmResolution::FiresAt(n) => Some(n),
             ArmResolution::SilentBuffer => {
@@ -963,14 +972,14 @@ impl GooeyEngine {
         }
 
         let mut sample_offset: u32 = 0;
-        for sample in buffer.iter_mut() {
+        for frame in buffer.chunks_mut(2) {
             // Pre-fire portion of an armed start: emit silence and skip all
             // per-sample work (no sequencer ticks, no instrument ticks, no
             // LFO ticks, no time advance) so the engine stays exactly where
             // it was at arm time.
             if let Some(fire_at) = arm_fires_at {
                 if sample_offset < fire_at {
-                    *sample = 0.0;
+                    frame.fill(0.0);
                     sample_offset += 1;
                     continue;
                 }
@@ -1109,10 +1118,18 @@ impl GooeyEngine {
             }
 
             // Optional limiter (always last when enabled)
-            if self.limiter_enabled {
-                *sample = self.limiter.process(output);
+            let mono_out = if self.limiter_enabled {
+                self.limiter.process(output)
             } else {
-                *sample = output;
+                output
+            };
+
+            // Stereo seam: the signal path is mono, so place the mono sample on
+            // both channels and write the frame interleaved as [left, right].
+            let stereo = StereoFrame::mono(mono_out);
+            frame[0] = stereo.l;
+            if let Some(right) = frame.get_mut(1) {
+                *right = stereo.r;
             }
 
             self.current_time += sample_period;
@@ -1699,19 +1716,27 @@ pub unsafe extern "C" fn gooey_engine_free(engine: *mut GooeyEngine) {
 // Audio rendering
 // =============================================================================
 
-/// Render audio samples into the provided buffer
+/// Number of interleaved output channels produced by `gooey_engine_render`.
+/// The render buffer must hold `frames * GOOEY_OUTPUT_CHANNELS` floats.
+pub const GOOEY_OUTPUT_CHANNELS: u32 = 2;
+
+/// Render interleaved stereo audio into the provided buffer
 ///
 /// This is the main audio callback function. Call this from your audio thread
-/// to generate audio samples.
+/// to generate audio samples. Output is two-channel: the buffer holds `frames`
+/// stereo frames laid out as interleaved `[left, right]` pairs, so the caller
+/// must provide `frames * GOOEY_OUTPUT_CHANNELS` (`frames * 2`) floats. The
+/// signal path is currently mono, so left and right are identical, but callers
+/// should always treat the buffer as stereo.
 ///
 /// # Arguments
 /// * `engine` - Pointer to a GooeyEngine
-/// * `buffer` - Pointer to a buffer of floats to fill with audio
-/// * `frames` - Number of frames (samples) to render
+/// * `buffer` - Pointer to a buffer of floats to fill with interleaved L/R audio
+/// * `frames` - Number of stereo frames to render
 ///
 /// # Safety
 /// - `engine` must be a valid pointer returned by `gooey_engine_new`
-/// - `buffer` must point to at least `frames` floats of allocated memory
+/// - `buffer` must point to at least `frames * 2` floats of allocated memory
 #[no_mangle]
 pub unsafe extern "C" fn gooey_engine_render(
     engine: *mut GooeyEngine,
@@ -1723,7 +1748,7 @@ pub unsafe extern "C" fn gooey_engine_render(
     }
 
     let engine_ref = &mut *engine;
-    let buffer_slice = slice::from_raw_parts_mut(buffer, frames as usize);
+    let buffer_slice = slice::from_raw_parts_mut(buffer, frames as usize * 2);
 
     // If engine is already in error state, output silence
     if engine_ref.error_occurred.load(Ordering::Relaxed) {
@@ -1757,8 +1782,8 @@ pub unsafe extern "C" fn gooey_engine_render(
         engine_ref.error_message = Some(c_msg);
         engine_ref.error_occurred.store(true, Ordering::Release);
 
-        // Zero the output buffer
-        let buffer_slice = slice::from_raw_parts_mut(buffer, frames as usize);
+        // Zero the output buffer (interleaved stereo: frames * 2 floats)
+        let buffer_slice = slice::from_raw_parts_mut(buffer, frames as usize * 2);
         for sample in buffer_slice.iter_mut() {
             *sample = 0.0;
         }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,0 +1,61 @@
+//! Stereo audio frame: the engine's output currency.
+//!
+//! libgooey's instruments and effects are mono (one `f32` per sample). This
+//! type is the single place the signal becomes two-channel — the "stereo seam".
+//! Today the seam produces dual-mono frames via [`StereoFrame::mono`] (left ==
+//! right), but the rest of the output path (CPAL device write, FFI interleaved
+//! buffer, tests) already treats the signal as stereo. Future work that adds
+//! per-instrument panning or stereo effects only has to change how frames are
+//! produced, not how they are consumed.
+
+/// A single stereo sample: a left and a right channel value.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct StereoFrame {
+    pub l: f32,
+    pub r: f32,
+}
+
+impl StereoFrame {
+    /// Build a frame from a single mono sample, placing it equally on both
+    /// channels. This is the "stereo seam": the one conversion point from the
+    /// mono signal path to the stereo output path.
+    pub const fn mono(x: f32) -> Self {
+        Self { l: x, r: x }
+    }
+
+    /// Collapse the frame to a single mono sample (average of both channels).
+    /// Used when the output device has a single channel and when feeding the
+    /// visualization buffer, which expects one value per sample.
+    pub fn downmix(self) -> f32 {
+        0.5 * (self.l + self.r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mono_places_sample_on_both_channels() {
+        let f = StereoFrame::mono(0.42);
+        assert_eq!(f.l, 0.42);
+        assert_eq!(f.r, 0.42);
+    }
+
+    #[test]
+    fn downmix_of_a_mono_frame_is_the_original_sample() {
+        let x = -0.3;
+        assert_eq!(StereoFrame::mono(x).downmix(), x);
+    }
+
+    #[test]
+    fn downmix_averages_the_two_channels() {
+        let f = StereoFrame { l: 1.0, r: 0.0 };
+        assert_eq!(f.downmix(), 0.5);
+    }
+
+    #[test]
+    fn default_is_silence() {
+        assert_eq!(StereoFrame::default(), StereoFrame { l: 0.0, r: 0.0 });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod max_curve;
 pub mod effects;
 pub mod engine;
 pub mod ffi;
+pub mod frame;
 pub mod gen;
 pub mod instruments;
 pub mod music;
@@ -16,6 +17,8 @@ pub mod sequencer;
 pub mod utils;
 
 pub mod bounce;
+
+pub use frame::StereoFrame;
 
 // Visualization module (optional)
 #[cfg(feature = "visualization")]

--- a/tests/channel_instrument_swap.rs
+++ b/tests/channel_instrument_swap.rs
@@ -85,7 +85,7 @@ fn test_swap_produces_audio() {
 
         // Trigger channel 0 (now a tom)
         gooey_engine_trigger_channel(engine, 0);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
 
         let has_audio = buffer.iter().any(|&s| s.abs() > 0.001);
@@ -152,7 +152,7 @@ fn test_trigger_channel_api() {
 
         // Trigger via channel API
         gooey_engine_trigger_channel_with_velocity(engine, 0, 0.8);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
 
         let has_audio = buffer.iter().any(|&s| s.abs() > 0.001);
@@ -178,7 +178,7 @@ fn test_set_channel_param() {
 
         // Trigger and verify audio
         gooey_engine_trigger_channel(engine, 0);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
 
         let has_audio = buffer.iter().any(|&s| s.abs() > 0.001);
@@ -199,7 +199,7 @@ fn test_backward_compat_param_setter() {
         // Default: channel 0 = kick. set_kick_param should work
         gooey_engine_set_kick_param(engine, KICK_PARAM_VOLUME, 0.8);
         gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
         let has_audio = buffer.iter().any(|&s| s.abs() > 0.001);
         assert!(
@@ -231,7 +231,7 @@ fn test_duplicate_instrument_types() {
         // Trigger both channels, both should produce audio
         gooey_engine_trigger_channel(engine, 0);
         gooey_engine_trigger_channel(engine, 2);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
 
         let has_audio = buffer.iter().any(|&s| s.abs() > 0.001);

--- a/tests/effect_order.rs
+++ b/tests/effect_order.rs
@@ -250,8 +250,10 @@ fn reordering_changes_audio_output() {
         assert!(ok);
 
         gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
-        let mut buffer = vec![0.0f32; 16_384];
-        gooey_engine_render(engine, buffer.as_mut_ptr(), buffer.len() as u32);
+        let frames = 16_384u32;
+        // Interleaved stereo: two output samples per frame.
+        let mut buffer = vec![0.0f32; frames as usize * 2];
+        gooey_engine_render(engine, buffer.as_mut_ptr(), frames);
 
         gooey_engine_free(engine);
         buffer

--- a/tests/ffi_gain_staging.rs
+++ b/tests/ffi_gain_staging.rs
@@ -7,7 +7,8 @@ const RENDER_FRAMES: usize = 4_096;
 const SETTLE_FRAMES: usize = 16_384;
 
 unsafe fn render(engine: *mut GooeyEngine, frames: usize) -> Vec<f32> {
-    let mut buffer = vec![0.0_f32; frames];
+    // Interleaved stereo: GOOEY_OUTPUT_CHANNELS (2) output samples per frame.
+    let mut buffer = vec![0.0_f32; frames * GOOEY_OUTPUT_CHANNELS as usize];
     gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
     buffer
 }

--- a/tests/ffi_granulator.rs
+++ b/tests/ffi_granulator.rs
@@ -186,8 +186,9 @@ fn trigger_and_render_produces_finite_nonzero_audio() {
         gooey_engine_granulator_snap_params(engine);
         gooey_engine_granulator_trigger(engine, 1.0);
 
-        let frames = 22_050usize; // ~0.5 seconds
-        let mut buffer = vec![0.0_f32; frames];
+        // ~0.5 seconds; interleaved stereo means two output samples per frame.
+        let frames = 22_050usize;
+        let mut buffer = vec![0.0_f32; frames * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
 
         let max_abs = buffer.iter().fold(0.0_f32, |acc, s| {
@@ -217,8 +218,10 @@ fn active_grain_count_rises_after_trigger() {
         gooey_engine_granulator_snap_params(engine);
         gooey_engine_granulator_trigger(engine, 1.0);
 
-        let mut buffer = vec![0.0_f32; 4096];
-        gooey_engine_render(engine, buffer.as_mut_ptr(), buffer.len() as u32);
+        let frames = 4096u32;
+        // Interleaved stereo: two output samples per frame.
+        let mut buffer = vec![0.0_f32; frames as usize * 2];
+        gooey_engine_render(engine, buffer.as_mut_ptr(), frames);
 
         assert!(
             gooey_engine_granulator_active_grain_count(engine) > 0,

--- a/tests/ffi_stereo.rs
+++ b/tests/ffi_stereo.rs
@@ -1,0 +1,83 @@
+//! Integration tests for the interleaved stereo output contract of
+//! `gooey_engine_render`.
+//!
+//! The engine writes two-channel interleaved output: each frame occupies two
+//! consecutive buffer slots laid out as `[left, right]`, so a host must
+//! allocate `frames * GOOEY_OUTPUT_CHANNELS` floats. The internal signal path
+//! is currently mono, so left and right are identical (the "stereo seam"
+//! duplicates the mono sample onto both channels), but callers must always
+//! treat the buffer as stereo.
+
+use gooey::ffi::*;
+
+const SAMPLE_RATE: f32 = 44_100.0;
+
+#[test]
+fn output_channel_count_is_two() {
+    assert_eq!(GOOEY_OUTPUT_CHANNELS, 2);
+}
+
+#[test]
+fn render_fills_an_interleaved_stereo_buffer_without_error() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        let frames = 1024usize;
+        let mut buffer = vec![0.0_f32; frames * GOOEY_OUTPUT_CHANNELS as usize];
+
+        // A correctly sized buffer must render without tripping the error flag
+        // (which a panic across the FFI boundary would set).
+        gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+
+        assert!(
+            !gooey_engine_has_error(engine),
+            "render must not set the engine error flag for a correctly sized buffer"
+        );
+        assert_eq!(buffer.len(), frames * 2, "buffer holds frames * 2 samples");
+        assert!(
+            buffer.iter().all(|s| s.is_finite()),
+            "all rendered samples must be finite"
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn left_and_right_match_and_both_carry_audio_for_the_mono_path() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        let frames = 2048usize;
+        let mut buffer = vec![0.0_f32; frames * 2];
+
+        gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
+        gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+
+        // The kick must produce audible output.
+        let peak = buffer.iter().fold(0.0_f32, |acc, s| acc.max(s.abs()));
+        assert!(
+            peak > 0.001,
+            "expected audible kick output, peak was {peak}"
+        );
+
+        // Every frame's left sample equals its right sample (mono signal path),
+        // and audio must be present on both channels.
+        let mut both_channels_audible = false;
+        for frame in buffer.chunks_exact(2) {
+            assert_eq!(
+                frame[0], frame[1],
+                "left and right must be identical for the mono signal path"
+            );
+            if frame[0].abs() > 0.001 {
+                both_channels_audible = true;
+            }
+        }
+        assert!(
+            both_channels_audible,
+            "expected non-zero audio on both the left and right channels"
+        );
+
+        gooey_engine_free(engine);
+    }
+}

--- a/tests/instrument_gain.rs
+++ b/tests/instrument_gain.rs
@@ -35,7 +35,7 @@ fn test_gain_zero_silences_instrument() {
 
         // Trigger kick with default gain - should have audio
         gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
         let has_audio_before = buffer.iter().any(|&s| s.abs() > 0.001);
 
@@ -67,7 +67,7 @@ fn test_gain_reduces_level() {
 
         // Render kick at full gain
         gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
-        let mut buffer_full = vec![0.0f32; 1024];
+        let mut buffer_full = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer_full.as_mut_ptr(), 1024);
         let peak_full: f32 = buffer_full.iter().map(|s| s.abs()).fold(0.0, f32::max);
 
@@ -75,7 +75,7 @@ fn test_gain_reduces_level() {
         let engine2 = gooey_engine_new(44100.0);
         gooey_engine_set_instrument_gain(engine2, INSTRUMENT_KICK, 0.5);
         // Let smoothing settle
-        let mut buffer_half = vec![0.0f32; 1024];
+        let mut buffer_half = vec![0.0f32; 1024 * 2];
         for _ in 0..10 {
             gooey_engine_render(engine2, buffer_half.as_mut_ptr(), 1024);
         }
@@ -128,7 +128,7 @@ fn test_gain_with_mute() {
         gooey_engine_set_instrument_mute(engine, INSTRUMENT_KICK, true);
 
         gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         for _ in 0..10 {
             gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
         }

--- a/tests/mute_solo.rs
+++ b/tests/mute_solo.rs
@@ -29,7 +29,7 @@ fn test_mute_silences_instrument() {
 
         // Trigger kick and render - should have audio
         gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
         let has_audio_before_mute = buffer.iter().any(|&s| s.abs() > 0.001);
 
@@ -62,7 +62,7 @@ fn test_solo_isolates_instrument() {
 
         // Trigger snare (not soloed) and let gain smoothing settle
         gooey_engine_trigger_instrument(engine, INSTRUMENT_SNARE);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         for _ in 0..10 {
             gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
         }
@@ -88,7 +88,7 @@ fn test_solo_allows_soloed_instrument() {
 
         // Trigger kick (soloed)
         gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
 
         // Soloed instrument should produce audio
@@ -112,7 +112,7 @@ fn test_solo_overrides_mute() {
         gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
 
         // Render - should have audio (solo overrides mute)
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
         let has_audio = buffer.iter().any(|&s| s.abs() > 0.001);
 
@@ -141,7 +141,7 @@ fn test_multiple_solos() {
         gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
         gooey_engine_trigger_instrument(engine, INSTRUMENT_SNARE);
 
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
 
         // Should have audio from both
@@ -167,7 +167,7 @@ fn test_unmute_restores_audio() {
 
         // Trigger kick
         gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
 
         let has_audio = buffer.iter().any(|&s| s.abs() > 0.001);
@@ -188,7 +188,7 @@ fn test_unsolo_restores_other_instruments() {
 
         // Now trigger snare (which was silenced when kick was soloed)
         gooey_engine_trigger_instrument(engine, INSTRUMENT_SNARE);
-        let mut buffer = vec![0.0f32; 1024];
+        let mut buffer = vec![0.0f32; 1024 * 2];
         gooey_engine_render(engine, buffer.as_mut_ptr(), 1024);
 
         let has_audio = buffer.iter().any(|&s| s.abs() > 0.001);

--- a/tests/sequencer_armed_start.rs
+++ b/tests/sequencer_armed_start.rs
@@ -32,7 +32,8 @@ unsafe fn drain_midi(engine: *mut gooey::ffi::GooeyEngine) -> Vec<(u32, u32)> {
 
 /// Render one buffer of `BUF_FRAMES` samples and return the buffer.
 unsafe fn render_buf(engine: *mut gooey::ffi::GooeyEngine) -> Vec<f32> {
-    let mut buffer = vec![0.0_f32; BUF_FRAMES];
+    // Interleaved stereo: two output samples per frame.
+    let mut buffer = vec![0.0_f32; BUF_FRAMES * 2];
     gooey_engine_render(engine, buffer.as_mut_ptr(), BUF_FRAMES as u32);
     buffer
 }
@@ -170,9 +171,9 @@ fn set_beat_position_does_not_fire_intermediate_steps() {
         // if it fired them).
         gooey_engine_sequencer_set_beat_position(engine, 2.5);
 
-        // Render one sample without starting — set_beat_position alone
-        // must never produce triggers.
-        let mut sample = [0.0_f32; 1];
+        // Render one frame without starting — set_beat_position alone
+        // must never produce triggers. Interleaved stereo: 1 frame = 2 samples.
+        let mut sample = [0.0_f32; 2];
         gooey_engine_render(engine, sample.as_mut_ptr(), 1);
         let events = drain_midi(engine);
         assert!(

--- a/tests/sequencer_triggers_enabled.rs
+++ b/tests/sequencer_triggers_enabled.rs
@@ -21,7 +21,8 @@ const SILENCE: f32 = 0.001;
 
 /// Render `frames` samples and return the buffer.
 unsafe fn render_n(engine: *mut gooey::ffi::GooeyEngine, frames: usize) -> Vec<f32> {
-    let mut buffer = vec![0.0_f32; frames];
+    // Interleaved stereo: two output samples per frame.
+    let mut buffer = vec![0.0_f32; frames * 2];
     gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
     buffer
 }

--- a/tests/volume_zero_mute.rs
+++ b/tests/volume_zero_mute.rs
@@ -9,7 +9,7 @@ unsafe fn assert_volume_zero_silences(
     param_setter: unsafe fn(*mut GooeyEngine, u32, f32),
 ) {
     let engine = gooey_engine_new(44100.0);
-    let mut buffer = vec![0.0f32; 1024];
+    let mut buffer = vec![0.0f32; 1024 * 2];
 
     // First, verify the instrument produces audio at default volume
     gooey_engine_trigger_instrument(engine, instrument);
@@ -54,7 +54,7 @@ unsafe fn assert_volume_zero_silences_mid_playback(
     param_setter: unsafe fn(*mut GooeyEngine, u32, f32),
 ) {
     let engine = gooey_engine_new(44100.0);
-    let mut buffer = vec![0.0f32; 1024];
+    let mut buffer = vec![0.0f32; 1024 * 2];
 
     // Trigger at full volume and verify audio is produced
     gooey_engine_trigger_instrument(engine, instrument);


### PR DESCRIPTION
Introduces a stereo **foundation** so future panning/stereo effects become local changes instead of another cross-cutting refactor. A new `StereoFrame` type is the engine's output currency, converted from the mono signal at a single "stereo seam" (`StereoFrame::mono`); the native CPAL path now writes true left/right, and `gooey_engine_render` writes **interleaved stereo** — the buffer holds `frames * GOOEY_OUTPUT_CHANNELS` (`frames * 2`) `[L, R]` floats, advertised in the generated `include/gooey.h`. The signal path is still mono so left and right are currently identical, but every consumer (iOS host, CPAL, tests) now treats output as stereo. All nine FFI integration tests were migrated to the `frames * 2` buffer contract and a new `tests/ffi_stereo.rs` asserts the length/L==R/both-channels-audible behavior. The offline bounce stays mono for now; per-instrument pan and stereo-native effects are planned follow-up passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)