### PR TITLE
Make global effects stereo-aware (Pass 3: foundation + ping-pong delay)

### DIFF
--- a/examples/delay.rs
+++ b/examples/delay.rs
@@ -70,6 +70,9 @@ impl DelayControl {
     fn set_filter_cutoff(&self, cutoff: f32) {
         unsafe { &*self.ptr }.set_filter_cutoff(cutoff);
     }
+    fn set_pingpong(&self, on: bool) {
+        unsafe { &*self.ptr }.set_pingpong(on);
+    }
 }
 
 // Parameter indices
@@ -108,6 +111,7 @@ struct DelayState {
     mix: f32,
     filter_cutoff: f32,
     running: bool,
+    pingpong: bool,
 }
 
 fn make_bar(normalized: f32, width: usize) -> String {
@@ -121,9 +125,10 @@ fn render_display(state: &DelayState, selected: usize) {
     print!("\x1b[2J\x1b[H\x1b[?7l");
 
     print!("=== Delay Lab ===\r\n");
-    print!("SPACE=start/stop Q=quit ↑↓=sel ←→=adj []=fine\r\n");
+    print!("SPACE=start/stop P=pingpong Q=quit ↑↓=sel ←→=adj []=fine\r\n");
     let status = if state.running { "RUNNING" } else { "STOPPED" };
-    print!("Status: {}\r\n", status);
+    let pingpong = if state.pingpong { "ON" } else { "OFF" };
+    print!("Status: {}    Ping-pong: {} (headphones!)\r\n", status, pingpong);
     print!("\r\n");
 
     // BPM
@@ -242,6 +247,7 @@ fn main() -> anyhow::Result<()> {
         mix: 0.4,
         filter_cutoff: 8000.0,
         running: false,
+        pingpong: false,
     };
     let mut selected: usize = 0;
     let mut needs_redraw = true;
@@ -331,6 +337,13 @@ fn main() -> anyhow::Result<()> {
                                 state.running = true;
                             }
                         }
+                        needs_redraw = true;
+                    }
+
+                    // Toggle ping-pong (echoes bounce left/right)
+                    KeyCode::Char('p') | KeyCode::Char('P') => {
+                        state.pingpong = !state.pingpong;
+                        delay_control.set_pingpong(state.pingpong);
                         needs_redraw = true;
                     }
 

--- a/examples/delay.rs
+++ b/examples/delay.rs
@@ -128,7 +128,10 @@ fn render_display(state: &DelayState, selected: usize) {
     print!("SPACE=start/stop P=pingpong Q=quit ↑↓=sel ←→=adj []=fine\r\n");
     let status = if state.running { "RUNNING" } else { "STOPPED" };
     let pingpong = if state.pingpong { "ON" } else { "OFF" };
-    print!("Status: {}    Ping-pong: {} (headphones!)\r\n", status, pingpong);
+    print!(
+        "Status: {}    Ping-pong: {} (headphones!)\r\n",
+        status, pingpong
+    );
     print!("\r\n");
 
     // BPM

--- a/examples/tilt_filter.rs
+++ b/examples/tilt_filter.rs
@@ -18,8 +18,9 @@ use crossterm::{
 use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 
-use gooey::effects::TiltFilterEffect;
+use gooey::effects::{Effect, TiltFilterEffect};
 use gooey::engine::{Engine, EngineOutput, Instrument, Sequencer};
+use gooey::frame::StereoFrame;
 use gooey::instruments::{KickConfig, KickDrum};
 
 struct SharedKick(Arc<Mutex<KickDrum>>);
@@ -42,9 +43,15 @@ impl Instrument for SharedKick {
 /// Wrapper to share the TiltFilterEffect via Arc while implementing Effect
 struct SharedTilt(Arc<TiltFilterEffect>);
 
-impl gooey::effects::Effect for SharedTilt {
+impl Effect for SharedTilt {
     fn process(&self, input: f32) -> f32 {
         self.0.process(input)
+    }
+
+    /// Forward to the inner effect's stereo path so each channel keeps its own
+    /// filter state (the inner TiltFilterEffect holds per-channel state).
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        self.0.process_stereo(input)
     }
 }
 

--- a/plans/stereo-effects-plan.md
+++ b/plans/stereo-effects-plan.md
@@ -1,0 +1,127 @@
+# Stereo Effects for libgooey — Pass 3 (Foundation + Ping-Pong Showcase)
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds. It must be maintained in accordance with `.agent/PLANS.md` (repository root). It continues the stereo effort begun in `plans/stereo-support-plan.md` (Pass 1).
+
+
+## Purpose / Big Picture
+
+libgooey shipped a stereo **foundation** in Pass 1 (`plans/stereo-support-plan.md`): a `StereoFrame { l, r }` currency, a single "stereo seam" (`StereoFrame::mono(x)` — the one place the mono signal path becomes two channels), interleaved FFI output, and true left/right from the native CPAL device. But that seam sits **after** the global effects chain in both engines, so every effect still only ever processes one mono sample — left and right are byte-identical.
+
+Pass 3 makes the effects themselves stereo-aware. After this change a user can hear a genuinely stereo effect: enabling the delay's new **ping-pong** mode makes echoes bounce between the left and right speakers. The work has two layers:
+
+1. **Foundation** — widen the `Effect` trait with a `process_stereo` method, move the seam to *before* the effects chain, and give every stateful effect genuine per-channel DSP state. Like Pass 1, this is behavior-preserving: with mono input (left == right) and identical per-channel state, the output stays left == right.
+2. **Showcase** — make the delay genuinely stereo with an opt-in ping-pong mode (echoes alternate channels, producing audible left != right), proving the path end to end.
+
+This applies to **both** engines: the FFI `GooeyEngine` (the iOS/host path driven by `gooey_engine_render`) and the native `Engine` (the desktop CPAL path). The offline mono `bounce` path stays mono and untouched.
+
+You can see it working by running `cargo test --test stereo_effects`: with ping-pong off, an enabled effect keeps left == right for mono content; with ping-pong on, a triggered impulse makes left and right diverge.
+
+
+## Progress
+
+- [x] (2026-06-15) Step 1: widened the `Effect` trait with `process_stereo` (default impl, documented as stateless-only) in `src/effects/mod.rs`.
+- [x] (2026-06-15) Step 2: per-channel state refactor for the 5 stateful effects + compressor (`[State; 2]` + extracted `process_one`/`process_inner` + `process_stereo` override; `reset()` clears both channels). All 64 effect unit tests stay green.
+- [x] (2026-06-15) Step 3: moved the stereo seam before the effects chain in both engines (FFI `GooeyEngine::render`; native `Engine::tick_stereo` via a new `render_pre_effects` split keeping mono `tick()` byte-identical).
+- [x] (2026-06-15) Step 4: ping-pong delay showcase — `DelayEffect` split into `step_read`/`step_write`, cross-channel feedback, dry injected left-only, `pingpong_target` atomic + `set_pingpong`/`get_pingpong`.
+- [x] (2026-06-15) Step 5: FFI `DELAY_PARAM_PINGPONG = 4` const + set/get dispatch; `cargo build` regenerated `include/gooey.h` (const present, `GOOEY_OUTPUT_CHANNELS` still 2).
+- [x] (2026-06-15) Step 6: added `tests/stereo_effects.rs` (3 tests: per-effect L==R foundation, ping-pong L≠R divergence, ping-pong-off dual-mono). Existing `ffi_stereo`, `effect_order`, `ffi_gain_staging`, `bounce` suites stay green.
+- [x] (2026-06-15) Step 7: full validation — `cargo test` all suites pass; `cargo fmt --all -- --check` clean; `cargo clippy --lib --tests` introduced zero new warnings; `cargo build --example kick --features native,crossterm` builds.
+
+
+## Surprises & Discoveries
+
+- Observation: A genuinely-stereo ping-pong with a *centered (mono)* input cannot diverge by symmetric crossed feedback alone — swapping L↔R is a symmetry of the system when inputs are equal, so the channels would stay identical forever.
+  Resolution: the dry input is injected only into the LEFT delay line (the right buffer is fed solely by the crossed feedback). That asymmetry is what makes the echoes bounce L→R→L from a centered impulse. Implemented via `step_write`'s separate `dry_input` (for the wet/dry output mix, kept on both channels so the dry stays centered) and `inject_input` (buffer injection, left-only in ping-pong).
+- Observation: the delay's per-sample DSP had to be split into a read phase (`step_read`: advance smoothers + feedback-path filter, produce the tap) and a write phase (`step_write`: inject + feedback + buffer write). The split is safe because reads happen at `write_index - delay` and writes at `write_index` — different buffer slots — so computing both channels' taps before either write does not corrupt the buffers.
+- Observation: clippy on `--lib --tests` is NOT clean on the current baseline (drifted since Pass 1: `Envelope`/`EngineOutput` Default impls, `seq_triggers` index loops, the relocated `saved_global_freq` contains_key+insert, the untouched `EFFECT_LIMITER` match arm). None of these are in this change; this work added zero new warnings.
+
+
+## Decision Log
+
+- Decision: Scope Pass 3 as foundation + one genuinely-stereo showcase effect (ping-pong delay), across both engines.
+  Rationale: User chose this explicitly; the foundation de-risks the cross-cutting trait change while the showcase proves audible stereo end to end.
+  Date/Author: 2026-06-15, Brian (via planning Q&A).
+- Decision: Keep mono `Engine::tick()` and the offline bounce byte-identical; introduce a `render_pre_effects` helper and run effects in stereo only inside `tick_stereo`.
+  Rationale: `bounce.rs`, `tests/bounce.rs`, and `examples/bounce.rs` depend on mono `tick()`. The split isolates the stereo change to the realtime path.
+  Date/Author: 2026-06-15, Claude.
+- Decision: The `Effect::process_stereo` default impl (call `process` per channel) is correct only for stateless effects; every stateful effect overrides it with genuine per-channel state.
+  Rationale: The default double-advances a single shared state per frame, corrupting filters/delays. Only `SoftLimiter`/`BrickWallLimiter` are stateless.
+  Date/Author: 2026-06-15, Claude.
+- Decision: The compressor sidechain detector stays mono, duplicated to both channels via `StereoFrame::mono`.
+  Rationale: The sidechain source (`channel_outs[sc]`) is a single mono per-instrument sample; both channels should receive matching gain reduction.
+  Date/Author: 2026-06-15, Claude.
+
+
+## Context and Orientation
+
+There are two engines. The native `Engine` (`src/engine/mod.rs`) owns a `HashMap` of instruments and a `global_effects: Vec<Box<dyn Effect>>`, driven by CPAL via `src/engine/engine_output.rs`. The FFI `GooeyEngine` (`src/ffi.rs`) is a self-contained struct with concrete effect fields (`delay`, `reverb`, `saturation`, `compressor`, `lowpass_filter`, `tilt_filter`, `limiter`), each paired with a `*_enabled: bool`, plus a reorderable `effect_order: [u32; 6]`. It is driven by the host through `gooey_engine_render`.
+
+The `Effect` trait (`src/effects/mod.rs`) is `fn process(&self, input: f32) -> f32` — note `&self`; effects use interior mutability. Every **stateful** effect follows one pattern: tunable parameters live in `AtomicU32` fields (lock-free, shared across both channels), and per-sample DSP state (delay lines, filter memory, envelope followers, smoothers) lives in `state: UnsafeCell<XxxState>` with `unsafe impl Send/Sync`. `process()` does `let state = unsafe { &mut *self.state.get() };` and runs the DSP. The stateful effects are `TubeSaturation`, `LowpassFilterEffect`, `TiltFilterEffect`, `DelayEffect` (also has `process_with_sidechain` — no, that is the compressor), `TubeCompressor` (has `process_with_sidechain`), and `SpringReverbEffect`. The **stateless** effects are `SoftLimiter` and `BrickWallLimiter` (`src/effects/limiter.rs`): pure functions of input + immutable fields.
+
+`StereoFrame` (`src/frame.rs`): `{ l: f32, r: f32 }`, with `mono(x) -> {l:x, r:x}` and `downmix() -> 0.5*(l+r)`. `include/gooey.h` is generated by cbindgen on `cargo build` — never hand-edit.
+
+
+## Plan of Work
+
+### Step 1 — Widen the `Effect` trait (`src/effects/mod.rs`)
+
+Import `crate::frame::StereoFrame`. Add a default-provided `process_stereo(&self, StereoFrame) -> StereoFrame` whose default body calls `process` once per channel. Document loudly that the default is correct only for stateless effects (it advances shared state twice per frame); every stateful effect must override it. The two limiters keep the default.
+
+### Step 2 — Per-channel state refactor (5 stateful effects + compressor)
+
+Uniform mechanical pattern per effect:
+
+1. `state: UnsafeCell<XxxState>` becomes `state: UnsafeCell<[XxxState; 2]>`, duplicating per-channel DSP state and the `SmoothedParam` smoothers (both channels read the same atomics, so with equal input they stay bit-identical).
+2. Extract the current `process()` body into a private `fn process_one(&self, state: &mut XxxState, input: f32) -> f32`.
+3. `process()` runs `process_one` on `states[0]` only (mono path byte-identical to today). `process_stereo()` runs it on `states[0]` for left and `states[1]` for right.
+4. `reset()` clears both array elements.
+
+Per-effect notes: `TubeSaturation` has two independent `Oversampler`s + DC blockers, and its NaN-path reset must be scoped to the passed-in channel state. `TiltFilterEffect` has two `StateVariableFilterTpt` instances. `SpringReverbEffect` doubles to 12 allpass buffers (~21 KB, acceptable). `TubeCompressor` gets `[CompressorState; 2]`, an extracted `process_inner(&mut CompressorState, input, sidechain)`, and a new `process_stereo_with_sidechain(StereoFrame, StereoFrame) -> StereoFrame`; its `Effect::process_stereo` runs per channel with `sidechain == input`. `DelayEffect` is handled in Step 4.
+
+### Step 3 — Move the seam before the effects chain
+
+FFI `GooeyEngine::render`: keep the pre-fire silence path (`frame.fill(0.0); continue;`). After `output *= self.master_gain.tick();`, build `let mut stereo = StereoFrame::mono(output);`, run each enabled effect as `stereo = self.<effect>.process_stereo(stereo);` (compressor uses `process_stereo_with_sidechain(stereo, StereoFrame::mono(channel_outs[sc]))` when a sidechain is set, else `process_stereo`), then limiter, then `frame[0] = stereo.l; if let Some(r) = frame.get_mut(1) { *r = stereo.r; }`.
+
+Native `Engine`: factor the pre-effects work (instrument sum + LFO/sequencer/trigger + master gain) into `fn render_pre_effects(&mut self, t: f64) -> f32`. `tick()` = `render_pre_effects` + mono `process` loop (unchanged behavior). `tick_stereo()` = `StereoFrame::mono(render_pre_effects(t))` then `process_stereo` loop.
+
+### Step 4 — Ping-pong delay showcase (`src/effects/delay.rs`)
+
+`state` becomes `UnsafeCell<[DelayState; 2]>`. Add `pingpong_target: AtomicU32` (0=off default) + `set_pingpong`/`get_pingpong`. Generalize the write-back line `let write_sample = input + filtered_delay * feedback;` so the feedback tap can be the partner channel's `filtered_delay`. `process()` (mono) uses `states[0]` with its own tap (byte-identical). `process_stereo()`: ping-pong off = independent dual-mono (left == right for mono input); ping-pong on = compute each channel's filtered tap, then write left's buffer with right's tap and vice versa, so echoes alternate channels (audible left != right). `reset()` clears both.
+
+### Step 5 — FFI surface (`src/ffi.rs`)
+
+Add `pub const DELAY_PARAM_PINGPONG: u32 = 4;` near the delay param constants, wire it into the `EFFECT_DELAY` arms of `gooey_engine_set_global_effect_param` (`set_pingpong(value >= 0.5)`) and `..._get_...`. No new FFI function. `GOOEY_OUTPUT_CHANNELS` stays 2. `cargo build` regenerates `include/gooey.h`.
+
+### Step 6 — Tests (`tests/stereo_effects.rs`, new)
+
+Foundation: enable each reorderable effect (ping-pong off), trigger a kick, render `frames*2`, assert `frame[0] == frame[1]` for every frame. Showcase: enable delay only, set `DELAY_PARAM_PINGPONG = 1.0`, high feedback, mix = 1.0, trigger an impulse, render across >= 2 delay periods, assert some frames have `(l - r).abs() > epsilon` plus finiteness/stability. Existing suites (`ffi_stereo`, `effect_order`, `ffi_gain_staging`, `bounce`, per-effect unit tests) must stay green.
+
+
+## Validation and Acceptance
+
+Run from the repo root:
+
+    cargo build                                            # regenerates include/gooey.h
+    cargo test --verbose                                   # all suites incl. tests/stereo_effects.rs
+    cargo build --example kick --features native,crossterm # examples typecheck
+    cargo fmt --all -- --check
+    cargo clippy --all-targets --all-features              # pre-existing example failures unrelated
+
+Acceptance (behavior):
+- Foundation: with ping-pong off and any/all effects enabled, the FFI render keeps `frame[0] == frame[1]` for mono content; mono `tick()` and bounce outputs are unchanged.
+- Showcase: with `DELAY_PARAM_PINGPONG = 1` and an impulse, left and right diverge on echo frames and stay finite/stable.
+- `include/gooey.h` contains `DELAY_PARAM_PINGPONG`; `GOOEY_OUTPUT_CHANNELS` is still 2.
+
+
+## Idempotence and Recovery
+
+All steps are additive. The per-channel refactor preserves mono behavior (mono `process` uses `states[0]` only), so a regression localizes to either the seam move or a specific effect's `process_stereo`. `cargo build` regenerates the header deterministically.
+
+
+## Outcomes & Retrospective
+
+Pass 3 complete. The `Effect` trait now carries `process_stereo`, the stereo seam moved ahead of the effects chain in both engines, and all six stateful effects (lowpass, tilt, saturation, reverb, delay, compressor) hold genuine per-channel state. The foundation is behavior-preserving: with mono content and no stereo behavior engaged, left == right (verified per-effect in `tests/stereo_effects.rs`). The showcase — the delay's ping-pong mode — makes a centered impulse audibly bounce between channels (verified by the L≠R divergence test), exposed to iOS through `DELAY_PARAM_PINGPONG` with no new FFI function.
+
+The mono `Engine::tick()` and the offline bounce stayed byte-identical via the `render_pre_effects` split, so nothing downstream of them changed. The main lesson mirrors the ping-pong discovery: a stereo *plumbing* foundation is cheap and symmetry-preserving, but producing *audible* stereo from mono content requires an intentional asymmetry (here, left-only dry injection in ping-pong) — symmetric processing of equal inputs can never diverge.
+
+What remains for future passes: stereo decorrelation for the reverb (its two tanks currently share allpass lengths, so reverb stays dual-mono even when engaged), per-instrument pan (Pass 2 in `plans/stereo-support-plan.md`), and a stereo offline bounce (still mono by design).

--- a/plans/stereo-effects-plan.md
+++ b/plans/stereo-effects-plan.md
@@ -47,6 +47,9 @@ You can see it working by running `cargo test --test stereo_effects`: with ping-
 - Decision: The `Effect::process_stereo` default impl (call `process` per channel) is correct only for stateless effects; every stateful effect overrides it with genuine per-channel state.
   Rationale: The default double-advances a single shared state per frame, corrupting filters/delays. Only `SoftLimiter`/`BrickWallLimiter` are stateless.
   Date/Author: 2026-06-15, Claude.
+- Decision (revised): Make `Effect::process_stereo` REQUIRED (remove the default) instead of relying on a defaulted impl.
+  Rationale: Code review flagged that the default lets any `process`-only `Effect` reached through the `dyn Effect` chain (e.g. the `examples/tilt_filter.rs` `SharedTilt` wrapper, which forwards only `process`) silently run both channels through one internal state back-to-back under `Engine::tick_stereo` — the right channel ends up one state-update ahead of the left. Requiring the method turns that mistake into a compile error. Implemented `process_stereo` for the two stateless limiters (independent per-channel `process`) and forwarded `SharedTilt` to the inner `TiltFilterEffect::process_stereo`.
+  Date/Author: 2026-06-15, Claude (responding to review).
 - Decision: The compressor sidechain detector stays mono, duplicated to both channels via `StereoFrame::mono`.
   Rationale: The sidechain source (`channel_outs[sc]`) is a single mono per-instrument sample; both channels should receive matching gain reduction.
   Date/Author: 2026-06-15, Claude.

--- a/plans/stereo-support-plan.md
+++ b/plans/stereo-support-plan.md
@@ -23,7 +23,7 @@ You can see it working by running `cargo test --test ffi_stereo` (asserts the bu
 - [x] (2026-06-10) Pass 1, Step 6: regenerated `include/gooey.h` (cbindgen); audited callers — only `gooey_engine_render` drives `GooeyEngine::render`; offline bounce stays mono (see Decision Log).
 - [x] (2026-06-10) Pass 1, Step 7: this ExecPlan persisted.
 - [ ] Pass 2: per-instrument pan (see roadmap).
-- [ ] Pass 3: stereo-native effects (see roadmap).
+- [x] (2026-06-15) Pass 3: stereo-native effects — `Effect::process_stereo`, seam moved before the chain, per-channel state for all stateful effects, ping-pong delay showcase. See `plans/stereo-effects-plan.md`.
 
 The foundation shipped in two commits on branch `bhurlow/libgooey-stereo-support` (PR #201): first the native-side foundation (StereoFrame + CPAL + `tick_stereo`), then the FFI interleaving + test updates.
 

--- a/src/effects/compressor.rs
+++ b/src/effects/compressor.rs
@@ -1,4 +1,5 @@
 use crate::effects::Effect;
+use crate::frame::StereoFrame;
 use crate::utils::smoother::SmoothedParam;
 use std::cell::UnsafeCell;
 use std::f32::consts::FRAC_2_PI;
@@ -30,7 +31,10 @@ struct CompressorState {
 }
 
 pub struct TubeCompressor {
-    state: UnsafeCell<CompressorState>,
+    // Per-channel state (index 0 = mono/left, index 1 = right). The mono
+    // `process`/`process_with_sidechain` paths use only index 0, so their
+    // behavior is unchanged.
+    state: UnsafeCell<[CompressorState; 2]>,
 
     threshold_target: AtomicU32,
     ratio_target: AtomicU32,
@@ -58,19 +62,21 @@ impl TubeCompressor {
         let release_ms = release_ms.clamp(5.0, 1000.0);
         let mix = mix.clamp(0.0, 1.0);
 
+        let make_state = || CompressorState {
+            threshold_smoothed: SmoothedParam::new(threshold_db, -60.0, 0.0, sample_rate, 30.0),
+            ratio_smoothed: SmoothedParam::new(ratio, 1.0, 20.0, sample_rate, 30.0),
+            attack_smoothed: SmoothedParam::new(attack_ms, 0.1, 100.0, sample_rate, 30.0),
+            release_smoothed: SmoothedParam::new(release_ms, 5.0, 1000.0, sample_rate, 30.0),
+            mix_smoothed: SmoothedParam::new(mix, 0.0, 1.0, sample_rate, 30.0),
+            envelope: 0.0,
+            gain_smoothed: 1.0,
+            dc_x1: 0.0,
+            dc_y1: 0.0,
+            sample_rate,
+        };
+
         Self {
-            state: UnsafeCell::new(CompressorState {
-                threshold_smoothed: SmoothedParam::new(threshold_db, -60.0, 0.0, sample_rate, 30.0),
-                ratio_smoothed: SmoothedParam::new(ratio, 1.0, 20.0, sample_rate, 30.0),
-                attack_smoothed: SmoothedParam::new(attack_ms, 0.1, 100.0, sample_rate, 30.0),
-                release_smoothed: SmoothedParam::new(release_ms, 5.0, 1000.0, sample_rate, 30.0),
-                mix_smoothed: SmoothedParam::new(mix, 0.0, 1.0, sample_rate, 30.0),
-                envelope: 0.0,
-                gain_smoothed: 1.0,
-                dc_x1: 0.0,
-                dc_y1: 0.0,
-                sample_rate,
-            }),
+            state: UnsafeCell::new([make_state(), make_state()]),
             threshold_target: AtomicU32::new(threshold_db.to_bits()),
             ratio_target: AtomicU32::new(ratio.to_bits()),
             attack_target: AtomicU32::new(attack_ms.to_bits()),
@@ -115,13 +121,12 @@ impl TubeCompressor {
         output
     }
 
-    /// Core processing: input is the audio to compress, sidechain drives the detector
-    fn process_inner(&self, input: f32, sidechain: f32) -> f32 {
+    /// Core processing: input is the audio to compress, sidechain drives the
+    /// detector. Operates on the supplied per-channel state.
+    fn process_inner(&self, state: &mut CompressorState, input: f32, sidechain: f32) -> f32 {
         if !input.is_finite() || !sidechain.is_finite() {
             return 0.0;
         }
-
-        let state = unsafe { &mut *self.state.get() };
 
         // Read targets and update smoothers
         let threshold_target = f32::from_bits(self.threshold_target.load(Ordering::Relaxed));
@@ -201,10 +206,26 @@ impl TubeCompressor {
         output
     }
 
-    /// Process with an external sidechain signal.
+    /// Process with an external sidechain signal (mono path).
     /// The envelope follower tracks `sidechain` while gain reduction is applied to `input`.
     pub fn process_with_sidechain(&self, input: f32, sidechain: f32) -> f32 {
-        self.process_inner(input, sidechain)
+        let states = unsafe { &mut *self.state.get() };
+        self.process_inner(&mut states[0], input, sidechain)
+    }
+
+    /// Process a stereo frame with an external stereo sidechain signal.
+    /// Each channel's detector tracks its own sidechain value. When the engine's
+    /// sidechain source is mono, the same value is supplied on both channels.
+    pub fn process_stereo_with_sidechain(
+        &self,
+        input: StereoFrame,
+        sidechain: StereoFrame,
+    ) -> StereoFrame {
+        let states = unsafe { &mut *self.state.get() };
+        StereoFrame {
+            l: self.process_inner(&mut states[0], input.l, sidechain.l),
+            r: self.process_inner(&mut states[1], input.r, sidechain.r),
+        }
     }
 
     // Parameter setters (thread-safe, called from control thread)
@@ -261,17 +282,29 @@ impl TubeCompressor {
     }
 
     pub fn reset(&self) {
-        let state = unsafe { &mut *self.state.get() };
-        state.envelope = 0.0;
-        state.gain_smoothed = 1.0;
-        state.dc_x1 = 0.0;
-        state.dc_y1 = 0.0;
+        let states = unsafe { &mut *self.state.get() };
+        for state in states.iter_mut() {
+            state.envelope = 0.0;
+            state.gain_smoothed = 1.0;
+            state.dc_x1 = 0.0;
+            state.dc_y1 = 0.0;
+        }
     }
 }
 
 impl Effect for TubeCompressor {
     fn process(&self, input: f32) -> f32 {
-        self.process_inner(input, input)
+        let states = unsafe { &mut *self.state.get() };
+        self.process_inner(&mut states[0], input, input)
+    }
+
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        // No external sidechain: each channel is its own detector.
+        let states = unsafe { &mut *self.state.get() };
+        StereoFrame {
+            l: self.process_inner(&mut states[0], input.l, input.l),
+            r: self.process_inner(&mut states[1], input.r, input.r),
+        }
     }
 }
 

--- a/src/effects/delay.rs
+++ b/src/effects/delay.rs
@@ -5,6 +5,7 @@
 //! path so each repetition gets progressively darker, like a classic filter delay.
 
 use crate::effects::Effect;
+use crate::frame::StereoFrame;
 use crate::utils::smoother::SmoothedParam;
 use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -131,9 +132,10 @@ struct DelayState {
 pub struct DelayEffect {
     sample_rate: f32,
 
-    // Mutable state wrapped in UnsafeCell for interior mutability
+    // Per-channel mutable state (index 0 = mono/left, index 1 = right). The mono
+    // `process` path uses only index 0, so its behavior is unchanged.
     // SAFETY: This is only accessed from the audio thread during process()
-    state: UnsafeCell<DelayState>,
+    state: UnsafeCell<[DelayState; 2]>,
 
     // Atomic parameters for lock-free updates from control thread
     timing_target: AtomicU32,
@@ -141,6 +143,20 @@ pub struct DelayEffect {
     feedback_target: AtomicU32,
     mix_target: AtomicU32,
     filter_cutoff_target: AtomicU32,
+    // Ping-pong mode (0 = off: independent dual-mono delay; 1 = on: feedback
+    // crosses channels so echoes bounce left/right).
+    pingpong_target: AtomicU32,
+}
+
+/// Values produced by the per-sample read phase ([`DelayEffect::step_read`]) and
+/// consumed by the write phase ([`DelayEffect::step_write`]).
+struct DelayStep {
+    /// The filtered delayed sample (the wet tap heard on this channel).
+    filtered_delay: f32,
+    /// Smoothed feedback amount for this sample.
+    feedback: f32,
+    /// Smoothed wet/dry mix for this sample.
+    mix: f32,
 }
 
 // SAFETY: The UnsafeCell is only accessed from a single audio thread
@@ -174,49 +190,68 @@ impl DelayEffect {
         // Allocate buffer for maximum delay time
         let buffer_size = (sample_rate * MAX_DELAY_TIME) as usize + 1;
 
+        // Build one channel's worth of state. Both channels read the same atomic
+        // targets, so duplicating the smoothers is fine — with equal input they
+        // converge identically.
+        let make_state = || DelayState {
+            buffer: vec![0.0; buffer_size],
+            write_index: 0,
+            filter_z1: 0.0,
+            filter_z2: 0.0,
+            previous_timing: timing.to_timing_constant(),
+            // Use 50ms smoothing for delay time to avoid zipper noise
+            time_smoothed: SmoothedParam::new(time, 0.0, MAX_DELAY_TIME, sample_rate, 50.0),
+            // Use 30ms smoothing for feedback and mix
+            feedback_smoothed: SmoothedParam::new(feedback_clamped, 0.0, 0.95, sample_rate, 30.0),
+            mix_smoothed: SmoothedParam::new(mix_clamped, 0.0, 1.0, sample_rate, 30.0),
+            filter_cutoff_smoothed: SmoothedParam::new(
+                cutoff_clamped,
+                MIN_FILTER_CUTOFF,
+                MAX_FILTER_CUTOFF,
+                sample_rate,
+                30.0,
+            ),
+        };
+
         Self {
             sample_rate,
-            state: UnsafeCell::new(DelayState {
-                buffer: vec![0.0; buffer_size],
-                write_index: 0,
-                filter_z1: 0.0,
-                filter_z2: 0.0,
-                previous_timing: timing.to_timing_constant(),
-                // Use 50ms smoothing for delay time to avoid zipper noise
-                time_smoothed: SmoothedParam::new(time, 0.0, MAX_DELAY_TIME, sample_rate, 50.0),
-                // Use 30ms smoothing for feedback and mix
-                feedback_smoothed: SmoothedParam::new(
-                    feedback_clamped,
-                    0.0,
-                    0.95,
-                    sample_rate,
-                    30.0,
-                ),
-                mix_smoothed: SmoothedParam::new(mix_clamped, 0.0, 1.0, sample_rate, 30.0),
-                filter_cutoff_smoothed: SmoothedParam::new(
-                    cutoff_clamped,
-                    MIN_FILTER_CUTOFF,
-                    MAX_FILTER_CUTOFF,
-                    sample_rate,
-                    30.0,
-                ),
-            }),
+            state: UnsafeCell::new([make_state(), make_state()]),
             timing_target: AtomicU32::new(timing.to_timing_constant()),
             bpm_target: AtomicU32::new(bpm.to_bits()),
             feedback_target: AtomicU32::new(feedback_clamped.to_bits()),
             mix_target: AtomicU32::new(mix_clamped.to_bits()),
             filter_cutoff_target: AtomicU32::new(cutoff_clamped.to_bits()),
+            pingpong_target: AtomicU32::new(0),
         }
     }
 
-    /// Reset delay state (clear buffer and filter)
+    /// Reset delay state (clear buffer and filter) on all channels
     pub fn reset(&self) {
         // SAFETY: Called from main thread when delay is not processing
-        let state = unsafe { &mut *self.state.get() };
-        state.buffer.fill(0.0);
-        state.write_index = 0;
-        state.filter_z1 = 0.0;
-        state.filter_z2 = 0.0;
+        let states = unsafe { &mut *self.state.get() };
+        for state in states.iter_mut() {
+            state.buffer.fill(0.0);
+            state.write_index = 0;
+            state.filter_z1 = 0.0;
+            state.filter_z2 = 0.0;
+        }
+    }
+
+    /// Enable or disable ping-pong mode (thread-safe).
+    ///
+    /// When on, the delay feedback crosses channels: the left buffer is fed from
+    /// the right channel's delayed tap and vice versa, and the dry input is
+    /// injected only into the left delay line — so echoes alternate between the
+    /// left and right speakers. When off, each channel runs an independent
+    /// delay (identical output for mono input).
+    pub fn set_pingpong(&self, on: bool) {
+        self.pingpong_target
+            .store(if on { 1 } else { 0 }, Ordering::Relaxed);
+    }
+
+    /// Get current ping-pong mode (true = on).
+    pub fn get_pingpong(&self) -> bool {
+        self.pingpong_target.load(Ordering::Relaxed) != 0
     }
 
     /// Get current timing division constant
@@ -276,16 +311,14 @@ impl DelayEffect {
     }
 }
 
-impl Effect for DelayEffect {
-    fn process(&self, input: f32) -> f32 {
-        // SAFETY: We use UnsafeCell for interior mutability. This is safe because:
-        // 1. The audio thread is the only thread that calls process()
-        // 2. Parameter updates via atomics are lock-free and don't conflict
-        let state = unsafe { &mut *self.state.get() };
-
-        // NaN/infinity protection at input - treat invalid input as silence
-        let input = if input.is_finite() { input } else { 0.0 };
-
+impl DelayEffect {
+    /// Per-sample read phase for one channel: read the atomic targets, advance
+    /// the smoothers and the feedback-path filter, and produce the filtered
+    /// delayed tap. This does NOT write the delay buffer, so a caller can decide
+    /// (per ping-pong mode) which channel's tap feeds which buffer before the
+    /// write phase runs. Reads happen at `write_index - delay`, writes happen at
+    /// `write_index`, so the read and write phases touch different buffer slots.
+    fn step_read(&self, state: &mut DelayState) -> DelayStep {
         // Read atomic targets and compute delay time from timing + BPM
         let timing_const = self.timing_target.load(Ordering::Relaxed);
         let bpm = f32::from_bits(self.bpm_target.load(Ordering::Relaxed));
@@ -358,14 +391,35 @@ impl Effect for DelayEffect {
             state.filter_z2 = 0.0;
         }
 
+        DelayStep {
+            filtered_delay,
+            feedback,
+            mix,
+        }
+    }
+
+    /// Per-sample write phase for one channel.
+    ///
+    /// `inject_input` is mixed into the delay line (driving the echoes);
+    /// `feedback_tap` is the filtered delayed sample fed back at `step.feedback`
+    /// (normally this channel's own tap, or the partner channel's in ping-pong).
+    /// `dry_input` is the dry signal used in the wet/dry output mix.
+    fn step_write(
+        &self,
+        state: &mut DelayState,
+        dry_input: f32,
+        inject_input: f32,
+        step: &DelayStep,
+        feedback_tap: f32,
+    ) -> f32 {
+        let buffer_len = state.buffer.len();
+
         // Write input plus filtered feedback to delay line
-        let write_sample = input + filtered_delay * feedback;
+        let write_sample = inject_input + feedback_tap * step.feedback;
 
         // Flush denormals and NaN protection
         let write_sample = if write_sample.is_finite() && write_sample.abs() > DENORMAL_THRESHOLD {
             write_sample
-        } else if write_sample.is_finite() {
-            0.0
         } else {
             0.0
         };
@@ -374,14 +428,66 @@ impl Effect for DelayEffect {
         state.write_index = (state.write_index + 1) % buffer_len;
 
         // Mix dry and wet (filtered) signals
-        let output = input * (1.0 - mix) + filtered_delay * mix;
+        let output = dry_input * (1.0 - step.mix) + step.filtered_delay * step.mix;
 
         // Final NaN protection
         if !output.is_finite() {
-            return input;
+            return dry_input;
         }
 
         output
+    }
+
+    /// Process one sample through a single channel's delay (own feedback path).
+    fn process_one(&self, state: &mut DelayState, input: f32) -> f32 {
+        // NaN/infinity protection at input - treat invalid input as silence
+        let input = if input.is_finite() { input } else { 0.0 };
+        let step = self.step_read(state);
+        let tap = step.filtered_delay;
+        self.step_write(state, input, input, &step, tap)
+    }
+}
+
+impl Effect for DelayEffect {
+    fn process(&self, input: f32) -> f32 {
+        // SAFETY: We use UnsafeCell for interior mutability. This is safe because:
+        // 1. The audio thread is the only thread that calls process()
+        // 2. Parameter updates via atomics are lock-free and don't conflict
+        let states = unsafe { &mut *self.state.get() };
+        self.process_one(&mut states[0], input)
+    }
+
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        // SAFETY: see process(); each channel owns its own delay line.
+        let states = unsafe { &mut *self.state.get() };
+
+        if !self.get_pingpong() {
+            // Independent dual-mono delay: identical output for mono input.
+            return StereoFrame {
+                l: self.process_one(&mut states[0], input.l),
+                r: self.process_one(&mut states[1], input.r),
+            };
+        }
+
+        // Ping-pong: read both channels' taps first (read phase touches only the
+        // delayed slots), then write each buffer with the PARTNER channel's tap.
+        // The dry input is injected only into the left delay line, so an echo
+        // first appears on the left, then bounces to the right, and so on.
+        let l_in = if input.l.is_finite() { input.l } else { 0.0 };
+        let r_in = if input.r.is_finite() { input.r } else { 0.0 };
+
+        let step_l = self.step_read(&mut states[0]);
+        let step_r = self.step_read(&mut states[1]);
+
+        let tap_l = step_l.filtered_delay;
+        let tap_r = step_r.filtered_delay;
+
+        // Left buffer: dry input + right's delayed tap. Right buffer: no direct
+        // input, fed only by left's delayed tap.
+        let out_l = self.step_write(&mut states[0], l_in, l_in, &step_l, tap_r);
+        let out_r = self.step_write(&mut states[1], r_in, 0.0, &step_r, tap_l);
+
+        StereoFrame { l: out_l, r: out_r }
     }
 }
 

--- a/src/effects/limiter.rs
+++ b/src/effects/limiter.rs
@@ -1,4 +1,5 @@
 use super::Effect;
+use crate::frame::StereoFrame;
 
 /// A brick wall limiter that prevents audio signals from exceeding a threshold
 pub struct BrickWallLimiter {
@@ -20,6 +21,14 @@ impl Effect for BrickWallLimiter {
             -self.threshold
         } else {
             input
+        }
+    }
+
+    /// Stateless: each channel is limited independently.
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        StereoFrame {
+            l: self.process(input.l),
+            r: self.process(input.r),
         }
     }
 }
@@ -57,5 +66,13 @@ impl SoftLimiter {
 impl Effect for SoftLimiter {
     fn process(&self, input: f32) -> f32 {
         (input * self.inv_threshold).tanh() * self.threshold
+    }
+
+    /// Stateless: each channel is limited independently.
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        StereoFrame {
+            l: self.process(input.l),
+            r: self.process(input.r),
+        }
     }
 }

--- a/src/effects/lowpass_filter.rs
+++ b/src/effects/lowpass_filter.rs
@@ -4,6 +4,7 @@
 //! Parameters are smoothed to prevent clicks/pops when adjusting cutoff and resonance.
 
 use crate::effects::Effect;
+use crate::frame::StereoFrame;
 use crate::utils::smoother::SmoothedParam;
 use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -30,9 +31,11 @@ struct FilterState {
 pub struct LowpassFilterEffect {
     sample_rate: f32,
 
-    // Mutable state wrapped in UnsafeCell for interior mutability
+    // Per-channel mutable state wrapped in UnsafeCell for interior mutability.
+    // Index 0 is the mono / left channel, index 1 is the right channel; the mono
+    // `process` path uses only index 0, so its behavior is unchanged.
     // SAFETY: This is only accessed from the audio thread during process()
-    state: UnsafeCell<FilterState>,
+    state: UnsafeCell<[FilterState; 2]>,
 
     // Atomic parameters for lock-free updates from control thread
     // Uses bit representation of f32 for atomic operations
@@ -56,27 +59,20 @@ impl LowpassFilterEffect {
         let cutoff_clamped = cutoff_freq.clamp(20.0, 20000.0);
         let resonance_clamped = resonance.clamp(0.0, 0.95);
 
+        // Build one channel's worth of state. Both channels read the same atomic
+        // targets, so duplicating the smoothers is fine — with equal input they
+        // converge identically.
+        let make_state = || FilterState {
+            // Use 30ms smoothing for filter parameters (longer than typical 15ms for smoother sweeps)
+            cutoff_smoothed: SmoothedParam::new(cutoff_clamped, 20.0, 20000.0, sample_rate, 30.0),
+            resonance_smoothed: SmoothedParam::new(resonance_clamped, 0.0, 0.95, sample_rate, 30.0),
+            stage1: 0.0,
+            stage2: 0.0,
+        };
+
         Self {
             sample_rate,
-            state: UnsafeCell::new(FilterState {
-                // Use 30ms smoothing for filter parameters (longer than typical 15ms for smoother sweeps)
-                cutoff_smoothed: SmoothedParam::new(
-                    cutoff_clamped,
-                    20.0,
-                    20000.0,
-                    sample_rate,
-                    30.0,
-                ),
-                resonance_smoothed: SmoothedParam::new(
-                    resonance_clamped,
-                    0.0,
-                    0.95,
-                    sample_rate,
-                    30.0,
-                ),
-                stage1: 0.0,
-                stage2: 0.0,
-            }),
+            state: UnsafeCell::new([make_state(), make_state()]),
             cutoff_target: AtomicU32::new(cutoff_clamped.to_bits()),
             resonance_target: AtomicU32::new(resonance_clamped.to_bits()),
         }
@@ -93,9 +89,11 @@ impl LowpassFilterEffect {
     /// Reset filter state (call when enabling filter or after NaN detection)
     pub fn reset(&self) {
         // SAFETY: Called from main thread when filter is not processing
-        let state = unsafe { &mut *self.state.get() };
-        state.stage1 = 0.0;
-        state.stage2 = 0.0;
+        let states = unsafe { &mut *self.state.get() };
+        for state in states.iter_mut() {
+            state.stage1 = 0.0;
+            state.stage2 = 0.0;
+        }
     }
 
     /// Get current cutoff frequency
@@ -123,13 +121,12 @@ impl LowpassFilterEffect {
     }
 }
 
-impl Effect for LowpassFilterEffect {
-    fn process(&self, input: f32) -> f32 {
-        // SAFETY: We use UnsafeCell for interior mutability. This is safe because:
-        // 1. The audio thread is the only thread that calls process()
-        // 2. Parameter updates via atomics are lock-free and don't conflict
-        let state = unsafe { &mut *self.state.get() };
-
+impl LowpassFilterEffect {
+    /// Process one sample through a single channel's filter state.
+    ///
+    /// All per-sample DSP lives here so both the mono `process` and the stereo
+    /// `process_stereo` can drive it with the correct per-channel state.
+    fn process_one(&self, state: &mut FilterState, input: f32) -> f32 {
         // Read atomic targets and update smoothers
         let cutoff_target = f32::from_bits(self.cutoff_target.load(Ordering::Relaxed));
         let resonance_target = f32::from_bits(self.resonance_target.load(Ordering::Relaxed));
@@ -194,6 +191,25 @@ impl Effect for LowpassFilterEffect {
         }
 
         output
+    }
+}
+
+impl Effect for LowpassFilterEffect {
+    fn process(&self, input: f32) -> f32 {
+        // SAFETY: We use UnsafeCell for interior mutability. This is safe because:
+        // 1. The audio thread is the only thread that calls process()
+        // 2. Parameter updates via atomics are lock-free and don't conflict
+        let states = unsafe { &mut *self.state.get() };
+        self.process_one(&mut states[0], input)
+    }
+
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        // SAFETY: see process(); each channel owns its own filter state.
+        let states = unsafe { &mut *self.state.get() };
+        StereoFrame {
+            l: self.process_one(&mut states[0], input.l),
+            r: self.process_one(&mut states[1], input.r),
+        }
     }
 }
 

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -22,23 +22,25 @@ use crate::frame::StereoFrame;
 
 /// Trait that all global effects must implement
 pub trait Effect: Send {
-    /// Process a single audio sample through the effect
+    /// Process a single audio sample through the effect (mono path).
     fn process(&self, input: f32) -> f32;
 
     /// Process one stereo frame (a left/right sample pair) through the effect.
     ///
-    /// IMPORTANT: the default implementation calls [`Effect::process`] once per
-    /// channel. That is correct ONLY for STATELESS effects (those whose output
-    /// depends solely on the current input and immutable parameters, e.g. the
-    /// limiters). For any effect with per-sample DSP state (delay lines, filter
-    /// memory, envelope followers, smoothers) the default is WRONG: it advances
-    /// that single shared state TWICE per frame, interleaving the left and right
-    /// channels into one history. Every stateful effect MUST override this with
-    /// genuine per-channel state (typically `UnsafeCell<[State; 2]>`).
-    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
-        StereoFrame {
-            l: self.process(input.l),
-            r: self.process(input.r),
-        }
-    }
+    /// This is REQUIRED (no default) on purpose. A default that simply calls
+    /// [`Effect::process`] once per channel is correct only for STATELESS
+    /// effects; for any effect with per-sample DSP state (delay lines, filter
+    /// memory, envelope followers, smoothers) it would advance that single
+    /// shared state TWICE per frame, interleaving left and right into one
+    /// history and silently corrupting the stereo image. Forcing every
+    /// implementor to write this method makes that mistake a compile error
+    /// rather than a runtime bug.
+    ///
+    /// - Stateful effects must keep genuine per-channel state (typically
+    ///   `UnsafeCell<[State; 2]>`) and run each channel through its own state.
+    /// - Stateless effects may simply process each channel independently:
+    ///   `StereoFrame { l: self.process(input.l), r: self.process(input.r) }`.
+    /// - Wrappers that delegate to an inner [`Effect`] should forward to the
+    ///   inner `process_stereo`.
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame;
 }

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -18,8 +18,27 @@ pub use self::saturation::*;
 pub use self::tilt_filter::*;
 pub use self::waveshaper::*;
 
+use crate::frame::StereoFrame;
+
 /// Trait that all global effects must implement
 pub trait Effect: Send {
     /// Process a single audio sample through the effect
     fn process(&self, input: f32) -> f32;
+
+    /// Process one stereo frame (a left/right sample pair) through the effect.
+    ///
+    /// IMPORTANT: the default implementation calls [`Effect::process`] once per
+    /// channel. That is correct ONLY for STATELESS effects (those whose output
+    /// depends solely on the current input and immutable parameters, e.g. the
+    /// limiters). For any effect with per-sample DSP state (delay lines, filter
+    /// memory, envelope followers, smoothers) the default is WRONG: it advances
+    /// that single shared state TWICE per frame, interleaving the left and right
+    /// channels into one history. Every stateful effect MUST override this with
+    /// genuine per-channel state (typically `UnsafeCell<[State; 2]>`).
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        StereoFrame {
+            l: self.process(input.l),
+            r: self.process(input.r),
+        }
+    }
 }

--- a/src/effects/reverb.rs
+++ b/src/effects/reverb.rs
@@ -7,6 +7,7 @@
 //! characteristic "sproingy" dispersion of a spring reverb.
 
 use crate::effects::Effect;
+use crate::frame::StereoFrame;
 use crate::utils::smoother::SmoothedParam;
 
 use std::cell::UnsafeCell;
@@ -56,7 +57,9 @@ struct ReverbState {
 }
 
 pub struct SpringReverbEffect {
-    state: UnsafeCell<ReverbState>,
+    // Per-channel state (index 0 = mono/left, index 1 = right). The mono
+    // `process` path uses only index 0, so its behavior is unchanged.
+    state: UnsafeCell<[ReverbState; 2]>,
     decay_target: AtomicU32,
     mix_target: AtomicU32,
     damping_target: AtomicU32,
@@ -74,23 +77,26 @@ impl SpringReverbEffect {
 
         let scale = sample_rate / 44100.0;
 
-        let allpasses = std::array::from_fn(|i| {
-            let len = ((ALLPASS_DELAYS_44100[i] as f32) * scale).max(1.0) as usize;
-            AllpassFilter {
-                buffer: vec![0.0; len],
-                index: 0,
-            }
-        });
-
-        Self {
-            state: UnsafeCell::new(ReverbState {
+        let make_state = || {
+            let allpasses = std::array::from_fn(|i| {
+                let len = ((ALLPASS_DELAYS_44100[i] as f32) * scale).max(1.0) as usize;
+                AllpassFilter {
+                    buffer: vec![0.0; len],
+                    index: 0,
+                }
+            });
+            ReverbState {
                 allpasses,
                 feedback_sample: 0.0,
                 damping_filter_state: 0.0,
                 decay_smoothed: SmoothedParam::new_normalized(decay, sample_rate),
                 mix_smoothed: SmoothedParam::new_normalized(mix, sample_rate),
                 damping_smoothed: SmoothedParam::new_normalized(damping, sample_rate),
-            }),
+            }
+        };
+
+        Self {
+            state: UnsafeCell::new([make_state(), make_state()]),
             decay_target: AtomicU32::new(decay.to_bits()),
             mix_target: AtomicU32::new(mix.to_bits()),
             damping_target: AtomicU32::new(damping.to_bits()),
@@ -124,24 +130,22 @@ impl SpringReverbEffect {
         f32::from_bits(self.damping_target.load(Ordering::Relaxed))
     }
 
-    /// Reset reverb state (clear allpass buffers and feedback path)
+    /// Reset reverb state (clear allpass buffers and feedback path) on all channels
     pub fn reset(&self) {
         // SAFETY: Called from main thread when reverb is not processing
-        let state = unsafe { &mut *self.state.get() };
-        for ap in state.allpasses.iter_mut() {
-            ap.buffer.fill(0.0);
-            ap.index = 0;
+        let states = unsafe { &mut *self.state.get() };
+        for state in states.iter_mut() {
+            for ap in state.allpasses.iter_mut() {
+                ap.buffer.fill(0.0);
+                ap.index = 0;
+            }
+            state.feedback_sample = 0.0;
+            state.damping_filter_state = 0.0;
         }
-        state.feedback_sample = 0.0;
-        state.damping_filter_state = 0.0;
     }
-}
 
-impl Effect for SpringReverbEffect {
-    fn process(&self, input: f32) -> f32 {
-        // SAFETY: process() is only called from the audio thread
-        let state = unsafe { &mut *self.state.get() };
-
+    /// Process one sample through a single channel's reverb state.
+    fn process_one(&self, state: &mut ReverbState, input: f32) -> f32 {
         let input = if input.is_finite() { input } else { 0.0 };
 
         // Update smoothed parameters from atomic targets
@@ -195,6 +199,23 @@ impl Effect for SpringReverbEffect {
             result
         } else {
             input
+        }
+    }
+}
+
+impl Effect for SpringReverbEffect {
+    fn process(&self, input: f32) -> f32 {
+        // SAFETY: process() is only called from the audio thread
+        let states = unsafe { &mut *self.state.get() };
+        self.process_one(&mut states[0], input)
+    }
+
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        // SAFETY: see process(); each channel owns its own reverb tank.
+        let states = unsafe { &mut *self.state.get() };
+        StereoFrame {
+            l: self.process_one(&mut states[0], input.l),
+            r: self.process_one(&mut states[1], input.r),
         }
     }
 }

--- a/src/effects/saturation.rs
+++ b/src/effects/saturation.rs
@@ -6,6 +6,7 @@
 //! generation for a more analog sound than simple tanh.
 
 use crate::effects::Effect;
+use crate::frame::StereoFrame;
 use crate::utils::oversampler::{Oversampler, OversamplingMode};
 use crate::utils::smoother::SmoothedParam;
 use std::cell::UnsafeCell;
@@ -41,8 +42,9 @@ struct SaturationState {
 /// - Built-in DC blocking
 /// - Smooth parameter transitions
 pub struct TubeSaturation {
-    // Mutable state wrapped in UnsafeCell for interior mutability
-    state: UnsafeCell<SaturationState>,
+    // Per-channel mutable state (index 0 = mono/left, index 1 = right). The mono
+    // `process` path uses only index 0, so its behavior is unchanged.
+    state: UnsafeCell<[SaturationState; 2]>,
 
     // Atomic parameters for lock-free updates from control thread
     drive_target: AtomicU32,
@@ -68,15 +70,17 @@ impl TubeSaturation {
         let warmth_clamped = warmth.clamp(0.0, 1.0);
         let mix_clamped = mix.clamp(0.0, 1.0);
 
+        let make_state = || SaturationState {
+            drive_smoothed: SmoothedParam::new(drive_clamped, 0.0, 1.0, sample_rate, 30.0),
+            warmth_smoothed: SmoothedParam::new(warmth_clamped, 0.0, 1.0, sample_rate, 30.0),
+            mix_smoothed: SmoothedParam::new(mix_clamped, 0.0, 1.0, sample_rate, 30.0),
+            dc_x1: 0.0,
+            dc_y1: 0.0,
+            oversampler: Oversampler::default(),
+        };
+
         Self {
-            state: UnsafeCell::new(SaturationState {
-                drive_smoothed: SmoothedParam::new(drive_clamped, 0.0, 1.0, sample_rate, 30.0),
-                warmth_smoothed: SmoothedParam::new(warmth_clamped, 0.0, 1.0, sample_rate, 30.0),
-                mix_smoothed: SmoothedParam::new(mix_clamped, 0.0, 1.0, sample_rate, 30.0),
-                dc_x1: 0.0,
-                dc_y1: 0.0,
-                oversampler: Oversampler::default(),
-            }),
+            state: UnsafeCell::new([make_state(), make_state()]),
             drive_target: AtomicU32::new(drive_clamped.to_bits()),
             warmth_target: AtomicU32::new(warmth_clamped.to_bits()),
             mix_target: AtomicU32::new(mix_clamped.to_bits()),
@@ -184,24 +188,26 @@ impl TubeSaturation {
         OversamplingMode::from_u8(self.oversampling_mode_target.load(Ordering::Relaxed))
     }
 
-    /// Reset internal state (DC blocker)
+    /// Reset internal state (DC blocker) on all channels
     pub fn reset(&self) {
-        let state = unsafe { &mut *self.state.get() };
-        state.dc_x1 = 0.0;
-        state.dc_y1 = 0.0;
-        state.oversampler.reset();
+        let states = unsafe { &mut *self.state.get() };
+        for state in states.iter_mut() {
+            state.dc_x1 = 0.0;
+            state.dc_y1 = 0.0;
+            state.oversampler.reset();
+        }
     }
-}
 
-impl Effect for TubeSaturation {
-    fn process(&self, input: f32) -> f32 {
-        // NaN/infinity protection at input
+    /// Process one sample through a single channel's saturation state.
+    fn process_one(&self, state: &mut SaturationState, input: f32) -> f32 {
+        // NaN/infinity protection at input — scoped to this channel's state so a
+        // NaN on one side does not wipe the other channel's history.
         if !input.is_finite() {
-            self.reset();
+            state.dc_x1 = 0.0;
+            state.dc_y1 = 0.0;
+            state.oversampler.reset();
             return 0.0;
         }
-
-        let state = unsafe { &mut *self.state.get() };
 
         // Read targets and update smoothers
         let drive_target = f32::from_bits(self.drive_target.load(Ordering::Relaxed));
@@ -246,6 +252,21 @@ impl Effect for TubeSaturation {
         }
 
         output
+    }
+}
+
+impl Effect for TubeSaturation {
+    fn process(&self, input: f32) -> f32 {
+        let states = unsafe { &mut *self.state.get() };
+        self.process_one(&mut states[0], input)
+    }
+
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        let states = unsafe { &mut *self.state.get() };
+        StereoFrame {
+            l: self.process_one(&mut states[0], input.l),
+            r: self.process_one(&mut states[1], input.r),
+        }
     }
 }
 

--- a/src/effects/tilt_filter.rs
+++ b/src/effects/tilt_filter.rs
@@ -1,5 +1,6 @@
 use crate::effects::Effect;
 use crate::filters::state_variable_tpt::StateVariableFilterTpt;
+use crate::frame::StereoFrame;
 use crate::utils::smoother::SmoothedParam;
 use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -25,7 +26,9 @@ struct TiltFilterState {
 /// - Below 0.5 = lowpass, getting darker toward 0.0
 /// - Above 0.5 = highpass, getting brighter toward 1.0
 pub struct TiltFilterEffect {
-    state: UnsafeCell<TiltFilterState>,
+    // Per-channel state (index 0 = mono/left, index 1 = right). The mono
+    // `process` path uses only index 0, leaving its behavior unchanged.
+    state: UnsafeCell<[TiltFilterState; 2]>,
     cutoff_target: AtomicU32,
     resonance_target: AtomicU32,
 }
@@ -40,18 +43,14 @@ impl TiltFilterEffect {
         let default_cutoff: f32 = 0.5;
         let default_resonance: f32 = 0.0;
 
+        let make_state = || TiltFilterState {
+            cutoff_smoothed: SmoothedParam::new(default_cutoff, 0.0, 1.0, sample_rate, 30.0),
+            resonance_smoothed: SmoothedParam::new(default_resonance, 0.0, 1.0, sample_rate, 30.0),
+            svf: StateVariableFilterTpt::new(sample_rate, 1000.0, 0.5),
+        };
+
         Self {
-            state: UnsafeCell::new(TiltFilterState {
-                cutoff_smoothed: SmoothedParam::new(default_cutoff, 0.0, 1.0, sample_rate, 30.0),
-                resonance_smoothed: SmoothedParam::new(
-                    default_resonance,
-                    0.0,
-                    1.0,
-                    sample_rate,
-                    30.0,
-                ),
-                svf: StateVariableFilterTpt::new(sample_rate, 1000.0, 0.5),
-            }),
+            state: UnsafeCell::new([make_state(), make_state()]),
             cutoff_target: AtomicU32::new(default_cutoff.to_bits()),
             resonance_target: AtomicU32::new(default_resonance.to_bits()),
         }
@@ -78,15 +77,14 @@ impl TiltFilterEffect {
     }
 
     pub fn reset(&self) {
-        let state = unsafe { &mut *self.state.get() };
-        state.svf.reset();
+        let states = unsafe { &mut *self.state.get() };
+        for state in states.iter_mut() {
+            state.svf.reset();
+        }
     }
-}
 
-impl Effect for TiltFilterEffect {
-    fn process(&self, input: f32) -> f32 {
-        let state = unsafe { &mut *self.state.get() };
-
+    /// Process one sample through a single channel's filter state.
+    fn process_one(&self, state: &mut TiltFilterState, input: f32) -> f32 {
         // Read atomic targets and update smoothers
         let cutoff_target = f32::from_bits(self.cutoff_target.load(Ordering::Relaxed));
         let resonance_target = f32::from_bits(self.resonance_target.load(Ordering::Relaxed));
@@ -138,6 +136,21 @@ impl Effect for TiltFilterEffect {
         }
 
         output
+    }
+}
+
+impl Effect for TiltFilterEffect {
+    fn process(&self, input: f32) -> f32 {
+        let states = unsafe { &mut *self.state.get() };
+        self.process_one(&mut states[0], input)
+    }
+
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        let states = unsafe { &mut *self.state.get() };
+        StereoFrame {
+            l: self.process_one(&mut states[0], input.l),
+            r: self.process_one(&mut states[1], input.r),
+        }
     }
 }
 

--- a/src/engine/engine_output.rs
+++ b/src/engine/engine_output.rs
@@ -17,7 +17,6 @@ pub struct EngineOutput {
     stream: Option<Stream>,
     device: Option<Device>,
     config: Option<StreamConfig>,
-    sample_format: Option<cpal::SampleFormat>,
     sample_rate: f32,
     is_active: bool,
     start_time: Option<Instant>,
@@ -36,7 +35,6 @@ impl EngineOutput {
             stream: None,
             device: None,
             config: None,
-            sample_format: None,
             sample_rate: 44100.0,
             is_active: false,
             start_time: None,
@@ -151,9 +149,7 @@ impl EngineOutput {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Config not initialized"))?;
 
-        let sample_format = self
-            .sample_format
-            .ok_or_else(|| anyhow::anyhow!("Sample format not initialized"))?;
+        let supported_config = device.default_output_config()?;
         let sample_counter = self.sample_counter.clone();
         let overrun_counter = self.overrun_counter.clone();
 
@@ -163,7 +159,7 @@ impl EngineOutput {
         #[cfg(not(feature = "visualization"))]
         let audio_buffer: Option<()> = None;
 
-        let stream = match sample_format {
+        let stream = match supported_config.sample_format() {
             cpal::SampleFormat::I8 => Self::make_stream::<i8>(
                 device,
                 config,
@@ -266,71 +262,14 @@ impl EngineOutput {
 
         println!("Output device: {}", device.name()?);
 
-        let default_config = device.default_output_config()?;
-        println!("Default output config: {:?}", default_config);
+        let config = device.default_output_config()?;
+        println!("Default output config: {:?}", config);
 
-        // Some interfaces (notably multi-channel Thunderbolt/USB devices)
-        // advertise a many-channel default (e.g. 8ch) that CoreAudio then
-        // refuses to open, surfacing as `DeviceNotAvailable`. Prefer a stereo
-        // configuration the device actually lists, so left/right map cleanly to
-        // outputs 1-2. A device whose default is already mono/stereo is left
-        // untouched, so the common built-in-speaker path is unchanged.
-        let chosen = Self::choose_output_config(&device, &default_config);
-        if chosen.channels() != default_config.channels()
-            || chosen.sample_rate() != default_config.sample_rate()
-        {
-            println!("Using output config: {:?}", chosen);
-        }
-
-        self.sample_rate = chosen.sample_rate().0 as f32;
-        self.sample_format = Some(chosen.sample_format());
-        self.config = Some(chosen.config());
+        self.sample_rate = config.sample_rate().0 as f32;
         self.device = Some(device);
+        self.config = Some(config.into());
 
         Ok(())
-    }
-
-    /// Pick an output configuration the device will actually open.
-    ///
-    /// If the default config is already mono or stereo it is used as-is.
-    /// Otherwise we look through the device's supported configurations for a
-    /// stereo one at the default sample rate (preferring the default sample
-    /// format), falling back to the default config if none is found.
-    fn choose_output_config(
-        device: &Device,
-        default_config: &cpal::SupportedStreamConfig,
-    ) -> cpal::SupportedStreamConfig {
-        if default_config.channels() <= 2 {
-            return default_config.clone();
-        }
-
-        let target_rate = default_config.sample_rate();
-        let default_fmt = default_config.sample_format();
-
-        if let Ok(ranges) = device.supported_output_configs() {
-            let stereo: Vec<cpal::SupportedStreamConfigRange> =
-                ranges.filter(|r| r.channels() == 2).collect();
-
-            // Realize a range at the target sample rate when supported, else at
-            // its own maximum rate.
-            let realize = |r: &cpal::SupportedStreamConfigRange| {
-                r.try_with_sample_rate(target_rate)
-                    .or_else(|| Some((*r).with_max_sample_rate()))
-            };
-
-            // Prefer a stereo range matching the default sample format, then any
-            // stereo range.
-            if let Some(cfg) = stereo
-                .iter()
-                .filter(|r| r.sample_format() == default_fmt)
-                .find_map(&realize)
-                .or_else(|| stereo.iter().find_map(&realize))
-            {
-                return cfg;
-            }
-        }
-
-        default_config.clone()
     }
 
     /// Create a typed stream for the given sample format

--- a/src/engine/engine_output.rs
+++ b/src/engine/engine_output.rs
@@ -17,6 +17,7 @@ pub struct EngineOutput {
     stream: Option<Stream>,
     device: Option<Device>,
     config: Option<StreamConfig>,
+    sample_format: Option<cpal::SampleFormat>,
     sample_rate: f32,
     is_active: bool,
     start_time: Option<Instant>,
@@ -35,6 +36,7 @@ impl EngineOutput {
             stream: None,
             device: None,
             config: None,
+            sample_format: None,
             sample_rate: 44100.0,
             is_active: false,
             start_time: None,
@@ -149,7 +151,9 @@ impl EngineOutput {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Config not initialized"))?;
 
-        let supported_config = device.default_output_config()?;
+        let sample_format = self
+            .sample_format
+            .ok_or_else(|| anyhow::anyhow!("Sample format not initialized"))?;
         let sample_counter = self.sample_counter.clone();
         let overrun_counter = self.overrun_counter.clone();
 
@@ -159,7 +163,7 @@ impl EngineOutput {
         #[cfg(not(feature = "visualization"))]
         let audio_buffer: Option<()> = None;
 
-        let stream = match supported_config.sample_format() {
+        let stream = match sample_format {
             cpal::SampleFormat::I8 => Self::make_stream::<i8>(
                 device,
                 config,
@@ -262,14 +266,71 @@ impl EngineOutput {
 
         println!("Output device: {}", device.name()?);
 
-        let config = device.default_output_config()?;
-        println!("Default output config: {:?}", config);
+        let default_config = device.default_output_config()?;
+        println!("Default output config: {:?}", default_config);
 
-        self.sample_rate = config.sample_rate().0 as f32;
+        // Some interfaces (notably multi-channel Thunderbolt/USB devices)
+        // advertise a many-channel default (e.g. 8ch) that CoreAudio then
+        // refuses to open, surfacing as `DeviceNotAvailable`. Prefer a stereo
+        // configuration the device actually lists, so left/right map cleanly to
+        // outputs 1-2. A device whose default is already mono/stereo is left
+        // untouched, so the common built-in-speaker path is unchanged.
+        let chosen = Self::choose_output_config(&device, &default_config);
+        if chosen.channels() != default_config.channels()
+            || chosen.sample_rate() != default_config.sample_rate()
+        {
+            println!("Using output config: {:?}", chosen);
+        }
+
+        self.sample_rate = chosen.sample_rate().0 as f32;
+        self.sample_format = Some(chosen.sample_format());
+        self.config = Some(chosen.config());
         self.device = Some(device);
-        self.config = Some(config.into());
 
         Ok(())
+    }
+
+    /// Pick an output configuration the device will actually open.
+    ///
+    /// If the default config is already mono or stereo it is used as-is.
+    /// Otherwise we look through the device's supported configurations for a
+    /// stereo one at the default sample rate (preferring the default sample
+    /// format), falling back to the default config if none is found.
+    fn choose_output_config(
+        device: &Device,
+        default_config: &cpal::SupportedStreamConfig,
+    ) -> cpal::SupportedStreamConfig {
+        if default_config.channels() <= 2 {
+            return default_config.clone();
+        }
+
+        let target_rate = default_config.sample_rate();
+        let default_fmt = default_config.sample_format();
+
+        if let Ok(ranges) = device.supported_output_configs() {
+            let stereo: Vec<cpal::SupportedStreamConfigRange> =
+                ranges.filter(|r| r.channels() == 2).collect();
+
+            // Realize a range at the target sample rate when supported, else at
+            // its own maximum rate.
+            let realize = |r: &cpal::SupportedStreamConfigRange| {
+                r.try_with_sample_rate(target_rate)
+                    .or_else(|| Some((*r).with_max_sample_rate()))
+            };
+
+            // Prefer a stereo range matching the default sample format, then any
+            // stereo range.
+            if let Some(cfg) = stereo
+                .iter()
+                .filter(|r| r.sample_format() == default_fmt)
+                .find_map(&realize)
+                .or_else(|| stereo.iter().find_map(&realize))
+            {
+                return cfg;
+            }
+        }
+
+        default_config.clone()
     }
 
     /// Create a typed stream for the given sample format

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -271,9 +271,12 @@ impl Engine {
             .push_back((name.to_string(), velocity.clamp(0.0, 1.0)));
     }
 
-    /// Generate one sample of audio at the given time
-    /// This is called by the audio output on every sample
-    pub fn tick(&mut self, current_time: f64) -> f32 {
+    /// Advance one sample and produce the mono mix BEFORE the global effects
+    /// chain: process LFOs and sequencers, fire queued triggers, sum the
+    /// instruments, and apply the master gain. Both the mono [`Engine::tick`]
+    /// and the stereo [`Engine::tick_stereo`] build on this so the effects chain
+    /// can run either mono (for the offline bounce) or stereo (for realtime).
+    fn render_pre_effects(&mut self, current_time: f64) -> f32 {
         // Process LFOs and apply modulation
         for lfo in &mut self.lfos {
             let lfo_value = lfo.tick();
@@ -333,6 +336,17 @@ impl Engine {
         // Apply master gain before effects
         output *= self.master_gain.tick();
 
+        output
+    }
+
+    /// Generate one mono sample of audio at the given time.
+    ///
+    /// This is the offline / mono path (used by the audio output's mono fallback
+    /// and the offline bounce). It runs the global effects chain mono, leaving
+    /// its behavior unchanged from before stereo effects were introduced.
+    pub fn tick(&mut self, current_time: f64) -> f32 {
+        let mut output = self.render_pre_effects(current_time);
+
         // Apply global effects chain to the final output
         for effect in &self.global_effects {
             output = effect.process(output);
@@ -343,13 +357,20 @@ impl Engine {
 
     /// Generate one stereo frame of audio at the given time.
     ///
-    /// This is the native engine's "stereo seam": the signal path is mono, so
-    /// the mono [`Engine::tick`] output is placed equally on both channels via
-    /// [`StereoFrame::mono`]. Output sinks (CPAL device, offline bounce) call
-    /// this to drive true two-channel output. Future per-instrument panning or
-    /// stereo effects only need to change what this method returns.
+    /// This is the native engine's "stereo seam": the instrument mix is mono, so
+    /// it is placed on both channels via [`StereoFrame::mono`] BEFORE the global
+    /// effects chain, and each effect then processes true left/right through its
+    /// stereo-aware [`Effect::process_stereo`]. Output sinks (CPAL device) call
+    /// this to drive true two-channel output. For mono content with no stereo
+    /// effect engaged, the two channels stay identical.
     pub fn tick_stereo(&mut self, current_time: f64) -> StereoFrame {
-        StereoFrame::mono(self.tick(current_time))
+        let mut stereo = StereoFrame::mono(self.render_pre_effects(current_time));
+
+        for effect in &self.global_effects {
+            stereo = effect.process_stereo(stereo);
+        }
+
+        stereo
     }
 
     pub fn sample_rate(&self) -> f32 {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1086,47 +1086,56 @@ impl GooeyEngine {
             // Apply master headroom before the optional global effects.
             output *= self.master_gain.tick();
 
+            // Stereo seam: the instrument sum is mono, so place it on both
+            // channels here — BEFORE the effects chain — so each effect can
+            // process true left/right. Effects are stereo-aware (per-channel
+            // state); for mono content with no stereo effect engaged the two
+            // channels stay identical.
+            let mut stereo = StereoFrame::mono(output);
+
             // Apply global effects chain (order is user-configurable; limiter is always last)
             for &effect_id in &self.effect_order {
                 match effect_id {
                     EFFECT_SATURATION if self.saturation_enabled => {
-                        output = self.saturation.process(output);
+                        stereo = self.saturation.process_stereo(stereo);
                     }
                     EFFECT_LOWPASS_FILTER if self.lowpass_filter_enabled => {
-                        output = self.lowpass_filter.process(output);
+                        stereo = self.lowpass_filter.process_stereo(stereo);
                     }
                     EFFECT_TILT_FILTER if self.tilt_filter_enabled => {
-                        output = self.tilt_filter.process(output);
+                        stereo = self.tilt_filter.process_stereo(stereo);
                     }
                     EFFECT_DELAY if self.delay_enabled => {
-                        output = self.delay.process(output);
+                        stereo = self.delay.process_stereo(stereo);
                     }
                     EFFECT_COMPRESSOR if self.compressor_enabled => {
                         let sc = self.compressor_sidechain as usize;
-                        output = if sc < NUM_INSTRUMENTS {
-                            self.compressor
-                                .process_with_sidechain(output, channel_outs[sc])
+                        stereo = if sc < NUM_INSTRUMENTS {
+                            // The sidechain source is a mono per-instrument
+                            // sample; feed it to both detectors equally.
+                            self.compressor.process_stereo_with_sidechain(
+                                stereo,
+                                StereoFrame::mono(channel_outs[sc]),
+                            )
                         } else {
-                            self.compressor.process(output)
+                            self.compressor.process_stereo(stereo)
                         };
                     }
                     EFFECT_REVERB if self.reverb_enabled => {
-                        output = self.reverb.process(output);
+                        stereo = self.reverb.process_stereo(stereo);
                     }
                     _ => {}
                 }
             }
 
             // Optional limiter (always last when enabled)
-            let mono_out = if self.limiter_enabled {
-                self.limiter.process(output)
+            let stereo = if self.limiter_enabled {
+                self.limiter.process_stereo(stereo)
             } else {
-                output
+                stereo
             };
 
-            // Stereo seam: the signal path is mono, so place the mono sample on
-            // both channels and write the frame interleaved as [left, right].
-            let stereo = StereoFrame::mono(mono_out);
+            // Write the frame interleaved as [left, right].
             frame[0] = stereo.l;
             if let Some(right) = frame.get_mut(1) {
                 *right = stereo.r;
@@ -1349,6 +1358,9 @@ pub const DELAY_PARAM_FEEDBACK: u32 = 1;
 pub const DELAY_PARAM_MIX: u32 = 2;
 /// Delay parameter: filter cutoff in Hz (20-20000)
 pub const DELAY_PARAM_FILTER_CUTOFF: u32 = 3;
+/// Delay parameter: ping-pong mode (0.0 = off, >= 0.5 = on). When on, the delay
+/// feedback crosses channels so echoes bounce between left and right.
+pub const DELAY_PARAM_PINGPONG: u32 = 4;
 
 // =============================================================================
 // Delay timing constants (must match Swift DelayTiming enum)
@@ -2644,6 +2656,7 @@ pub unsafe extern "C" fn gooey_engine_load_bass_preset(engine: *mut GooeyEngine,
 ///   - DELAY_PARAM_FEEDBACK (1): 0.0-0.95
 ///   - DELAY_PARAM_MIX (2): 0.0-1.0
 ///   - DELAY_PARAM_FILTER_CUTOFF (3): 20-20000 Hz
+///   - DELAY_PARAM_PINGPONG (4): 0.0 = off, >= 0.5 = on
 /// - EFFECT_SATURATION (2):
 ///   - SATURATION_PARAM_DRIVE (0): 0.0-1.0
 ///   - SATURATION_PARAM_WARMTH (1): 0.0-1.0
@@ -2687,6 +2700,7 @@ pub unsafe extern "C" fn gooey_engine_set_global_effect_param(
             DELAY_PARAM_FEEDBACK => engine.delay.set_feedback(value),
             DELAY_PARAM_MIX => engine.delay.set_mix(value),
             DELAY_PARAM_FILTER_CUTOFF => engine.delay.set_filter_cutoff(value),
+            DELAY_PARAM_PINGPONG => engine.delay.set_pingpong(value >= 0.5),
             _ => {} // Unknown parameter, ignore
         },
         EFFECT_SATURATION => match param {
@@ -2759,6 +2773,13 @@ pub unsafe extern "C" fn gooey_engine_get_global_effect_param(
             DELAY_PARAM_FEEDBACK => engine.delay.get_feedback(),
             DELAY_PARAM_MIX => engine.delay.get_mix(),
             DELAY_PARAM_FILTER_CUTOFF => engine.delay.get_filter_cutoff(),
+            DELAY_PARAM_PINGPONG => {
+                if engine.delay.get_pingpong() {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
             _ => -1.0, // Unknown parameter
         },
         EFFECT_SATURATION => match param {

--- a/tests/stereo_effects.rs
+++ b/tests/stereo_effects.rs
@@ -1,0 +1,177 @@
+//! Integration tests for stereo-aware global effects (Pass 3).
+//!
+//! Two properties are asserted:
+//!
+//! 1. Foundation / behavior-preserving: every global effect now processes a
+//!    true left/right pair, but for mono content (the instrument mix is mono)
+//!    with no genuinely-stereo behavior engaged, the two channels stay
+//!    identical. This guards the per-channel-state refactor — a bug that lets
+//!    the two channel states drift would break `left == right`.
+//!
+//! 2. Showcase: the delay's ping-pong mode (DELAY_PARAM_PINGPONG) crosses the
+//!    feedback between channels, so a centered (mono) impulse produces audibly
+//!    different left and right output.
+
+use gooey::ffi::*;
+
+const SAMPLE_RATE: f32 = 44_100.0;
+
+/// The six reorderable global effects (the limiter is pinned last and tested
+/// implicitly). Each entry is `(effect_id, &[(param, value)])` — the params
+/// engage the effect strongly so it actually alters the signal.
+fn reorderable_effects() -> Vec<(u32, Vec<(u32, f32)>)> {
+    vec![
+        (
+            EFFECT_LOWPASS_FILTER,
+            vec![(FILTER_PARAM_CUTOFF, 2000.0), (FILTER_PARAM_RESONANCE, 0.5)],
+        ),
+        (
+            EFFECT_DELAY,
+            vec![
+                (DELAY_PARAM_FEEDBACK, 0.6),
+                (DELAY_PARAM_MIX, 0.7),
+                // ping-pong OFF (default) — the foundation must stay dual-mono
+                (DELAY_PARAM_PINGPONG, 0.0),
+            ],
+        ),
+        (
+            EFFECT_SATURATION,
+            vec![(SATURATION_PARAM_DRIVE, 0.8), (SATURATION_PARAM_MIX, 1.0)],
+        ),
+        (
+            EFFECT_COMPRESSOR,
+            vec![
+                (COMPRESSOR_PARAM_THRESHOLD, -20.0),
+                (COMPRESSOR_PARAM_RATIO, 8.0),
+                (COMPRESSOR_PARAM_MIX, 1.0),
+            ],
+        ),
+        (
+            EFFECT_TILT_FILTER,
+            vec![(TILT_PARAM_CUTOFF, 0.2), (TILT_PARAM_RESONANCE, 0.5)],
+        ),
+        (
+            EFFECT_REVERB,
+            vec![(REVERB_PARAM_DECAY, 0.7), (REVERB_PARAM_MIX, 0.8)],
+        ),
+    ]
+}
+
+#[test]
+fn each_effect_keeps_left_equal_right_for_mono_input() {
+    for (effect_id, params) in reorderable_effects() {
+        unsafe {
+            let engine = gooey_engine_new(SAMPLE_RATE);
+
+            gooey_engine_set_global_effect_enabled(engine, effect_id, true);
+            for (param, value) in &params {
+                gooey_engine_set_global_effect_param(engine, effect_id, *param, *value);
+            }
+
+            let frames = 4096usize;
+            let mut buffer = vec![0.0_f32; frames * 2];
+
+            gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
+            gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+
+            assert!(
+                !gooey_engine_has_error(engine),
+                "effect {effect_id}: render must not set the error flag"
+            );
+
+            let peak = buffer.iter().fold(0.0_f32, |acc, s| acc.max(s.abs()));
+            assert!(
+                peak > 0.001,
+                "effect {effect_id}: expected audible output, peak was {peak}"
+            );
+
+            for (i, frame) in buffer.chunks_exact(2).enumerate() {
+                assert_eq!(
+                    frame[0], frame[1],
+                    "effect {effect_id}: left != right at frame {i} for mono input ({} vs {})",
+                    frame[0], frame[1]
+                );
+            }
+
+            gooey_engine_free(engine);
+        }
+    }
+}
+
+#[test]
+fn ping_pong_delay_makes_left_and_right_diverge() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        gooey_engine_set_global_effect_enabled(engine, EFFECT_DELAY, true);
+        // Short timing so several echoes fit in the render window, high feedback
+        // and full wet so the bouncing echoes dominate, ping-pong ON.
+        gooey_engine_set_global_effect_param(engine, EFFECT_DELAY, DELAY_PARAM_TIMING, 4.0);
+        gooey_engine_set_global_effect_param(engine, EFFECT_DELAY, DELAY_PARAM_FEEDBACK, 0.85);
+        gooey_engine_set_global_effect_param(engine, EFFECT_DELAY, DELAY_PARAM_MIX, 1.0);
+        gooey_engine_set_global_effect_param(engine, EFFECT_DELAY, DELAY_PARAM_PINGPONG, 1.0);
+
+        // Render long enough to span multiple delay periods.
+        let frames = 32_768usize;
+        let mut buffer = vec![0.0_f32; frames * 2];
+
+        gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
+        gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+
+        assert!(
+            !gooey_engine_has_error(engine),
+            "render must not set the error flag"
+        );
+
+        // The output must stay finite and stable (high feedback must not blow up).
+        assert!(
+            buffer.iter().all(|s| s.is_finite() && s.abs() < 100.0),
+            "ping-pong delay output must stay finite and bounded"
+        );
+
+        // With crossed feedback and a centered impulse, left and right diverge:
+        // echoes appear on one channel before the other.
+        let max_diff = buffer
+            .chunks_exact(2)
+            .fold(0.0_f32, |acc, frame| acc.max((frame[0] - frame[1]).abs()));
+        assert!(
+            max_diff > 1e-4,
+            "ping-pong delay should make left and right diverge, max |L-R| was {max_diff}"
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn ping_pong_off_keeps_delay_dual_mono() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        gooey_engine_set_global_effect_enabled(engine, EFFECT_DELAY, true);
+        gooey_engine_set_global_effect_param(engine, EFFECT_DELAY, DELAY_PARAM_FEEDBACK, 0.85);
+        gooey_engine_set_global_effect_param(engine, EFFECT_DELAY, DELAY_PARAM_MIX, 1.0);
+        // Explicitly off.
+        gooey_engine_set_global_effect_param(engine, EFFECT_DELAY, DELAY_PARAM_PINGPONG, 0.0);
+        assert_eq!(
+            gooey_engine_get_global_effect_param(engine, EFFECT_DELAY, DELAY_PARAM_PINGPONG),
+            0.0,
+            "ping-pong should report off"
+        );
+
+        let frames = 8192usize;
+        let mut buffer = vec![0.0_f32; frames * 2];
+
+        gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
+        gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+
+        for (i, frame) in buffer.chunks_exact(2).enumerate() {
+            assert_eq!(
+                frame[0], frame[1],
+                "non-ping-pong delay must stay dual-mono at frame {i}"
+            );
+        }
+
+        gooey_engine_free(engine);
+    }
+}


### PR DESCRIPTION
Pass 3 of the stereo effort: the global effects chain is now stereo-aware. The `Effect` trait gains `process_stereo`, the stereo seam moves ahead of the effects chain in both the FFI `GooeyEngine` and the native `Engine`, and every stateful effect (lowpass, tilt, saturation, reverb, delay, compressor) now holds genuine per-channel state — the foundation is behavior-preserving, so mono content with no stereo behavior engaged keeps left == right. The showcase is the delay's opt-in ping-pong mode (crossed feedback with left-only dry injection), which makes a centered impulse bounce between channels and is exposed to iOS through the new `DELAY_PARAM_PINGPONG` param (no new FFI function; `GOOEY_OUTPUT_CHANNELS` stays 2). Mono `Engine::tick()` and the offline bounce stay byte-identical via a `render_pre_effects` split. Adds `tests/stereo_effects.rs` (per-effect L==R foundation, ping-pong L≠R divergence, ping-pong-off dual-mono) and the `plans/stereo-effects-plan.md` ExecPlan; full test suite is green with zero new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)