### PR TITLE
Decorrelate spring reverb into a genuinely stereo effect

### DIFF
--- a/plans/stereo-effects-plan.md
+++ b/plans/stereo-effects-plan.md
@@ -127,4 +127,6 @@ Pass 3 complete. The `Effect` trait now carries `process_stereo`, the stereo sea
 
 The mono `Engine::tick()` and the offline bounce stayed byte-identical via the `render_pre_effects` split, so nothing downstream of them changed. The main lesson mirrors the ping-pong discovery: a stereo *plumbing* foundation is cheap and symmetry-preserving, but producing *audible* stereo from mono content requires an intentional asymmetry (here, left-only dry injection in ping-pong) — symmetric processing of equal inputs can never diverge.
 
-What remains for future passes: stereo decorrelation for the reverb (its two tanks currently share allpass lengths, so reverb stays dual-mono even when engaged), per-instrument pan (Pass 2 in `plans/stereo-support-plan.md`), and a stereo offline bounce (still mono by design).
+Reverb stereo decorrelation has since landed (2026-06-15): the two tanks now use different per-channel allpass tables (`ALLPASS_DELAYS_44100_L`/`_R` in `src/effects/reverb.rs`), so a mono input produces genuinely different left and right — verified by `reverb_decorrelates_left_and_right` in `tests/stereo_effects.rs`. The left/mono table is unchanged, so the mono `process` path (bounce, `tick`) stays byte-identical.
+
+What remains for future passes: per-instrument pan (Pass 2 in `plans/stereo-support-plan.md`) and a stereo offline bounce (still mono by design).

--- a/src/effects/reverb.rs
+++ b/src/effects/reverb.rs
@@ -21,7 +21,18 @@ const NUM_ALLPASSES: usize = 6;
 
 /// Allpass delay lengths in samples at 44100 Hz (prime numbers, increasing size).
 /// Total round-trip ≈ 61ms, giving a natural spring bounce period.
-const ALLPASS_DELAYS_44100: [usize; NUM_ALLPASSES] = [131, 251, 389, 521, 617, 787];
+///
+/// The two channels use *different* prime tables so the reverb tanks
+/// decorrelate: fed the same mono signal, the left and right tails diverge,
+/// giving an audibly wider reverb. The left/mono table is unchanged from the
+/// original mono reverb — the mono `process` path (offline bounce, `tick`) runs
+/// only on channel 0, so its output stays byte-identical.
+const ALLPASS_DELAYS_44100_L: [usize; NUM_ALLPASSES] = [131, 251, 389, 521, 617, 787];
+
+/// Right-channel allpass delays: primes near the left values but none equal to
+/// their counterpart, keeping the same spring character (~61ms round-trip)
+/// while decorrelating the two tanks.
+const ALLPASS_DELAYS_44100_R: [usize; NUM_ALLPASSES] = [127, 263, 397, 541, 631, 797];
 
 /// Per-allpass feedback coefficients (decreasing slightly for longer delays
 /// to keep diffusion dense without ringing)
@@ -77,9 +88,9 @@ impl SpringReverbEffect {
 
         let scale = sample_rate / 44100.0;
 
-        let make_state = || {
+        let make_state = |delays: &[usize; NUM_ALLPASSES]| {
             let allpasses = std::array::from_fn(|i| {
-                let len = ((ALLPASS_DELAYS_44100[i] as f32) * scale).max(1.0) as usize;
+                let len = ((delays[i] as f32) * scale).max(1.0) as usize;
                 AllpassFilter {
                     buffer: vec![0.0; len],
                     index: 0,
@@ -96,7 +107,10 @@ impl SpringReverbEffect {
         };
 
         Self {
-            state: UnsafeCell::new([make_state(), make_state()]),
+            state: UnsafeCell::new([
+                make_state(&ALLPASS_DELAYS_44100_L),
+                make_state(&ALLPASS_DELAYS_44100_R),
+            ]),
             decay_target: AtomicU32::new(decay.to_bits()),
             mix_target: AtomicU32::new(mix.to_bits()),
             damping_target: AtomicU32::new(damping.to_bits()),

--- a/tests/stereo_effects.rs
+++ b/tests/stereo_effects.rs
@@ -50,10 +50,10 @@ fn reorderable_effects() -> Vec<(u32, Vec<(u32, f32)>)> {
             EFFECT_TILT_FILTER,
             vec![(TILT_PARAM_CUTOFF, 0.2), (TILT_PARAM_RESONANCE, 0.5)],
         ),
-        (
-            EFFECT_REVERB,
-            vec![(REVERB_PARAM_DECAY, 0.7), (REVERB_PARAM_MIX, 0.8)],
-        ),
+        // NOTE: the reverb is intentionally excluded here. Its two tanks use
+        // different per-channel allpass tables, so it decorrelates mono content
+        // into genuine L != R — verified separately by
+        // `reverb_decorrelates_left_and_right`.
     ]
 }
 
@@ -137,6 +137,51 @@ fn ping_pong_delay_makes_left_and_right_diverge() {
         assert!(
             max_diff > 1e-4,
             "ping-pong delay should make left and right diverge, max |L-R| was {max_diff}"
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn reverb_decorrelates_left_and_right() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        gooey_engine_set_global_effect_enabled(engine, EFFECT_REVERB, true);
+        // Long decay and plenty of wet so the decorrelated tails build up.
+        gooey_engine_set_global_effect_param(engine, EFFECT_REVERB, REVERB_PARAM_DECAY, 0.7);
+        gooey_engine_set_global_effect_param(engine, EFFECT_REVERB, REVERB_PARAM_MIX, 0.8);
+
+        // Render a generous window so the spring tails on both channels develop.
+        let frames = 32_768usize;
+        let mut buffer = vec![0.0_f32; frames * 2];
+
+        gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
+        gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+
+        assert!(
+            !gooey_engine_has_error(engine),
+            "render must not set the error flag"
+        );
+
+        let peak = buffer.iter().fold(0.0_f32, |acc, s| acc.max(s.abs()));
+        assert!(peak > 0.001, "expected audible output, peak was {peak}");
+
+        // The reverb tail must stay finite and bounded.
+        assert!(
+            buffer.iter().all(|s| s.is_finite() && s.abs() < 100.0),
+            "reverb output must stay finite and bounded"
+        );
+
+        // The two tanks use different allpass tables, so a mono input produces
+        // genuinely different left and right.
+        let max_diff = buffer
+            .chunks_exact(2)
+            .fold(0.0_f32, |acc, frame| acc.max((frame[0] - frame[1]).abs()));
+        assert!(
+            max_diff > 1e-4,
+            "reverb should decorrelate left and right, max |L-R| was {max_diff}"
         );
 
         gooey_engine_free(engine);


### PR DESCRIPTION
Completes the remaining stereo-processing work after the Pass 1/Pass 3 stereo migration: the spring reverb kept per-channel state but built both tanks from the same allpass delay table, so mono content produced byte-identical L/R. This gives the right channel its own prime delay table (`ALLPASS_DELAYS_44100_R`) so the two tanks decorrelate into an audibly wider reverb, while leaving the left/mono table unchanged so the mono `process` path (offline bounce, `tick`) stays byte-identical. Tests move reverb out of the L==R foundation set and add `reverb_decorrelates_left_and_right`, which asserts genuine L≠R divergence on mono content. No new params and no FFI change — the width is always-on. Per-instrument pan and a stereo offline bounce remain deferred to future passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)