### PR TITLE
Add 4-channel stereo loop mixer with per-channel effects + FFI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,5 +104,9 @@ name = "granulator"
 required-features = ["native", "crossterm", "bounce"]
 
 [[example]]
+name = "loop_mixer"
+required-features = ["native", "crossterm", "bounce"]
+
+[[example]]
 name = "antialias_validation"
 required-features = ["bounce"]

--- a/examples/loop_mixer.rs
+++ b/examples/loop_mixer.rs
@@ -1,0 +1,306 @@
+//! Loop Mixer - interactive CLI for the 4-channel stereo loop mixer.
+//!
+//! Loads up to four stereo loops, plays them simultaneously, and lets you submix
+//! them live: per-channel gain, mute/solo, loop window, varispeed, and arbitrary
+//! per-channel effects (filter / delay / reverb). This drives the same core
+//! `Mixer` that the `gooey_engine_loop_*` FFI controls.
+//!
+//! Run with (any subset of paths; missing channels get a generated demo loop):
+//! cargo run --example loop_mixer --features native,crossterm,bounce -- a.wav b.wav c.wav d.wav
+
+#[cfg(feature = "native")]
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyEvent},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
+};
+#[cfg(feature = "native")]
+use std::io::{self, Write};
+#[cfg(feature = "native")]
+use std::sync::{Arc, Mutex};
+#[cfg(feature = "native")]
+use std::time::{Duration, Instant};
+
+#[cfg(feature = "native")]
+use gooey::engine::{Engine, EngineOutput};
+#[cfg(feature = "native")]
+use gooey::ffi::{
+    DELAY_PARAM_MIX, EFFECT_DELAY, EFFECT_LOWPASS_FILTER, EFFECT_REVERB, FILTER_PARAM_CUTOFF,
+    REVERB_PARAM_MIX,
+};
+#[cfg(feature = "native")]
+use gooey::mixer::{StereoSampleBuffer, LOOP_CHANNEL_COUNT};
+
+#[cfg(feature = "native")]
+const SAMPLE_RATE: f32 = 44_100.0;
+
+/// Build a distinct 2-second stereo demo loop so the example runs with no args.
+/// Each channel gets a different root note and a gentle L/R detune so the stereo
+/// image is audible.
+#[cfg(feature = "native")]
+fn demo_loop(index: usize) -> StereoSampleBuffer {
+    // A minor-ish spread of roots across the four channels.
+    let roots = [110.0_f32, 146.83, 164.81, 220.0];
+    let root = roots[index % roots.len()];
+    let len = (SAMPLE_RATE * 2.0) as usize;
+    let mut left = Vec::with_capacity(len);
+    let mut right = Vec::with_capacity(len);
+    for i in 0..len {
+        let t = i as f32 / SAMPLE_RATE;
+        // Simple two-note arpeggio with an 8th-note amplitude pulse.
+        let note = if (t * 2.0).fract() < 0.5 {
+            root
+        } else {
+            root * 1.5
+        };
+        let pulse_phase = (t * 4.0).fract();
+        let env = if pulse_phase < 0.5 {
+            (std::f32::consts::PI * pulse_phase / 0.5).sin()
+        } else {
+            0.0
+        };
+        let detune = 1.003; // ~5 cents, for a wide stereo image
+        let l = (std::f32::consts::TAU * note * t).sin();
+        let r = (std::f32::consts::TAU * note * detune * t).sin();
+        left.push(l * env * 0.6);
+        right.push(r * env * 0.6);
+    }
+    StereoSampleBuffer::from_channels(left, right, SAMPLE_RATE)
+        .expect("generated demo loop is valid")
+}
+
+/// Load channel `index`'s loop from the CLI args, falling back to a demo loop.
+#[cfg(feature = "native")]
+fn load_channel(index: usize, paths: &[String]) -> (StereoSampleBuffer, String) {
+    if let Some(path) = paths.get(index) {
+        match StereoSampleBuffer::from_wav(path) {
+            Ok(buffer) => return (buffer, path.clone()),
+            Err(e) => eprintln!("ch{index}: failed to load {path}: {e} — using demo loop"),
+        }
+    }
+    (demo_loop(index), format!("demo loop {}", index + 1))
+}
+
+#[cfg(feature = "native")]
+fn effect_name(id: u32) -> &'static str {
+    match id {
+        EFFECT_LOWPASS_FILTER => "filter",
+        EFFECT_DELAY => "delay",
+        EFFECT_REVERB => "reverb",
+        _ => "fx",
+    }
+}
+
+/// The primary parameter (and its range) tweaked by the `k`/`l` knob for each
+/// effect type the example can add.
+#[cfg(feature = "native")]
+fn primary_param(effect_id: u32) -> (u32, f32, f32) {
+    match effect_id {
+        EFFECT_LOWPASS_FILTER => (FILTER_PARAM_CUTOFF, 200.0, 18_000.0),
+        EFFECT_DELAY => (DELAY_PARAM_MIX, 0.0, 1.0),
+        EFFECT_REVERB => (REVERB_PARAM_MIX, 0.0, 1.0),
+        _ => (0, 0.0, 1.0),
+    }
+}
+
+#[cfg(feature = "native")]
+fn bar(value: f32, width: usize) -> String {
+    let filled = ((value.clamp(0.0, 1.0)) * width as f32).round() as usize;
+    let mut s = String::with_capacity(width);
+    for i in 0..width {
+        s.push(if i < filled { '#' } else { '-' });
+    }
+    s
+}
+
+#[cfg(feature = "native")]
+fn render_display(engine: &Engine, names: &[String], selected: usize, knob: &[f32]) {
+    execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).unwrap();
+    let mixer = engine.mixer();
+    print!(
+        "=== Loop Mixer — {} stereo channels ===\r\n\r\n",
+        LOOP_CHANNEL_COUNT
+    );
+
+    for (ch, &knob_value) in knob.iter().enumerate().take(mixer.channel_count()) {
+        let c = mixer.channel(ch).unwrap();
+        let marker = if ch == selected { '>' } else { ' ' };
+        let play = if c.is_playing() { "PLAY" } else { "stop" };
+        let mute = if c.is_muted() { "M" } else { "." };
+        let solo = if c.is_soloed() { "S" } else { "." };
+        print!(
+            "{marker} ch{ch} [{play}] {mute}{solo}  {}\r\n",
+            names.get(ch).map(String::as_str).unwrap_or("")
+        );
+        print!(
+            "    gain [{}] {:.2}  speed {:+.2}  loop {:.2}-{:.2}  pos [{}]\r\n",
+            bar(c.gain() / 2.0, 16),
+            c.gain(),
+            c.speed(),
+            c.loop_start(),
+            c.loop_end(),
+            bar(c.position_normalized(), 16),
+        );
+        // Effect chain.
+        let fx_count = c.effects().len();
+        if fx_count == 0 {
+            print!("    fx: (none)\r\n");
+        } else {
+            let mut chain = String::new();
+            for slot in 0..fx_count {
+                if let Some(id) = c.effects().effect_type_at(slot) {
+                    if slot > 0 {
+                        chain.push_str(" -> ");
+                    }
+                    chain.push_str(effect_name(id));
+                }
+            }
+            print!("    fx: {chain}  (knob {:.0}%)\r\n", knob_value * 100.0);
+        }
+        print!("\r\n");
+    }
+
+    print!("Up/Down select  Left/Right gain  -/= speed  ,/. loop-start  ;/' loop-end\r\n");
+    print!("space play/stop  r restart  m mute  s solo\r\n");
+    print!("f +filter  d +delay  v +reverb  c clear-fx  k/l tweak last fx  q quit\r\n");
+    io::stdout().flush().unwrap();
+}
+
+#[cfg(feature = "native")]
+fn main() -> anyhow::Result<()> {
+    let paths: Vec<String> = std::env::args().skip(1).collect();
+
+    let mut engine = Engine::new(SAMPLE_RATE);
+    engine.set_master_gain(0.8);
+
+    let mut names = Vec::new();
+    for ch in 0..LOOP_CHANNEL_COUNT {
+        let (buffer, name) = load_channel(ch, &paths);
+        let mixer = engine.mixer_mut();
+        mixer.load(ch, buffer);
+        mixer.set_gain(ch, 0.6); // headroom for four simultaneous loops
+        mixer.set_playing(ch, true);
+        names.push(name);
+    }
+
+    let audio_engine = Arc::new(Mutex::new(engine));
+    let mut engine_output = EngineOutput::new();
+    engine_output.initialize(SAMPLE_RATE)?;
+    engine_output.create_stream_with_engine(audio_engine.clone())?;
+    engine_output.start()?;
+
+    let mut selected = 0usize;
+    let mut knob = vec![0.5f32; LOOP_CHANNEL_COUNT];
+    let mut needs_redraw = true;
+    let mut last_redraw = Instant::now();
+
+    execute!(io::stdout(), Clear(ClearType::All), cursor::Hide)?;
+    enable_raw_mode()?;
+
+    let result = loop {
+        if needs_redraw || last_redraw.elapsed() > Duration::from_millis(80) {
+            let engine = audio_engine.lock().unwrap();
+            render_display(&engine, &names, selected, &knob);
+            drop(engine);
+            needs_redraw = false;
+            last_redraw = Instant::now();
+        }
+
+        if event::poll(Duration::from_millis(16))? {
+            if let Event::Key(KeyEvent { code, .. }) = event::read()? {
+                let mut engine = audio_engine.lock().unwrap();
+                let mixer = engine.mixer_mut();
+                match code {
+                    KeyCode::Up => selected = selected.saturating_sub(1),
+                    KeyCode::Down => selected = (selected + 1).min(LOOP_CHANNEL_COUNT - 1),
+                    KeyCode::Left | KeyCode::Right => {
+                        let delta = if code == KeyCode::Left { -0.05 } else { 0.05 };
+                        let g = mixer.channel(selected).unwrap().gain();
+                        mixer.set_gain(selected, g + delta);
+                    }
+                    KeyCode::Char('-') | KeyCode::Char('=') => {
+                        let delta = if code == KeyCode::Char('-') {
+                            -0.05
+                        } else {
+                            0.05
+                        };
+                        let s = mixer.channel(selected).unwrap().speed();
+                        mixer.set_speed(selected, s + delta);
+                    }
+                    KeyCode::Char(',') | KeyCode::Char('.') => {
+                        let delta = if code == KeyCode::Char(',') {
+                            -0.02
+                        } else {
+                            0.02
+                        };
+                        let v = mixer.channel(selected).unwrap().loop_start();
+                        mixer.set_loop_start(selected, v + delta);
+                    }
+                    KeyCode::Char(';') | KeyCode::Char('\'') => {
+                        let delta = if code == KeyCode::Char(';') {
+                            -0.02
+                        } else {
+                            0.02
+                        };
+                        let v = mixer.channel(selected).unwrap().loop_end();
+                        mixer.set_loop_end(selected, v + delta);
+                    }
+                    KeyCode::Char(' ') => {
+                        let playing = mixer.channel(selected).unwrap().is_playing();
+                        mixer.set_playing(selected, !playing);
+                    }
+                    KeyCode::Char('r') => mixer.restart(selected),
+                    KeyCode::Char('m') => {
+                        let muted = mixer.channel(selected).unwrap().is_muted();
+                        mixer.set_muted(selected, !muted);
+                    }
+                    KeyCode::Char('s') => {
+                        let soloed = mixer.channel(selected).unwrap().is_soloed();
+                        mixer.set_soloed(selected, !soloed);
+                    }
+                    KeyCode::Char('f') => {
+                        mixer.effect_add(selected, EFFECT_LOWPASS_FILTER);
+                    }
+                    KeyCode::Char('d') => {
+                        mixer.effect_add(selected, EFFECT_DELAY);
+                    }
+                    KeyCode::Char('v') => {
+                        mixer.effect_add(selected, EFFECT_REVERB);
+                    }
+                    KeyCode::Char('c') => mixer.effect_clear(selected),
+                    KeyCode::Char('k') | KeyCode::Char('l') => {
+                        let delta = if code == KeyCode::Char('k') {
+                            -0.05
+                        } else {
+                            0.05
+                        };
+                        knob[selected] = (knob[selected] + delta).clamp(0.0, 1.0);
+                        let count = mixer.effect_count(selected);
+                        if count > 0 {
+                            let slot = count - 1;
+                            if let Some(id) = mixer.effect_type_at(selected, slot) {
+                                let (param, min, max) = primary_param(id);
+                                let value = min + knob[selected] * (max - min);
+                                mixer.effect_set_param(selected, slot, param, value);
+                            }
+                        }
+                    }
+                    KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => break Ok(()),
+                    _ => {}
+                }
+                needs_redraw = true;
+            }
+        }
+    };
+
+    execute!(io::stdout(), cursor::Show)?;
+    disable_raw_mode()?;
+    println!("\nQuitting...");
+    result
+}
+
+#[cfg(not(feature = "native"))]
+fn main() {
+    println!("This example requires the 'native' and 'crossterm' features.");
+}

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,5 +1,6 @@
 use crate::effects::{Effect, SoftLimiter};
 use crate::frame::StereoFrame;
+use crate::mixer::Mixer;
 use crate::utils::SmoothedParam;
 use std::collections::{HashMap, VecDeque};
 
@@ -96,6 +97,8 @@ pub struct Engine {
     master_gain: SmoothedParam,
     // Saved global frequency per instrument for restoring after per-step note overrides
     saved_global_freq: HashMap<String, f32>,
+    // Multi-channel stereo loop mixer summed into the master bus before global effects
+    mixer: Mixer,
 }
 
 impl Engine {
@@ -115,7 +118,19 @@ impl Engine {
             // Default of 0.25 provides headroom for mixing multiple instruments
             master_gain: SmoothedParam::new(0.25, 0.0, 2.0, sample_rate, 30.0),
             saved_global_freq: HashMap::new(),
+            mixer: Mixer::new(sample_rate),
         }
+    }
+
+    /// Shared access to the multi-channel loop mixer.
+    pub fn mixer(&self) -> &Mixer {
+        &self.mixer
+    }
+
+    /// Mutable access to the multi-channel loop mixer (load loops, set per-channel
+    /// gain/mute/solo/loop points/speed, and edit per-channel effect chains).
+    pub fn mixer_mut(&mut self) -> &mut Mixer {
+        &mut self.mixer
     }
 
     /// Set the global BPM and update all synced LFOs
@@ -125,6 +140,8 @@ impl Engine {
         for lfo in &mut self.lfos {
             lfo.set_bpm(bpm);
         }
+        // Seed BPM for any future note-synced per-channel loop effects.
+        self.mixer.set_bpm(bpm);
     }
 
     /// Get the global BPM
@@ -347,6 +364,9 @@ impl Engine {
     pub fn tick(&mut self, current_time: f64) -> f32 {
         let mut output = self.render_pre_effects(current_time);
 
+        // Sum the loop mixer into the master bus (downmixed for the mono path).
+        output += self.mixer.tick(self.sample_rate).downmix();
+
         // Apply global effects chain to the final output
         for effect in &self.global_effects {
             output = effect.process(output);
@@ -365,6 +385,10 @@ impl Engine {
     /// effect engaged, the two channels stay identical.
     pub fn tick_stereo(&mut self, current_time: f64) -> StereoFrame {
         let mut stereo = StereoFrame::mono(self.render_pre_effects(current_time));
+
+        // Sum the loop mixer (already stereo, with its own per-channel effects)
+        // into the master bus before the global effects + limiter.
+        stereo += self.mixer.tick(self.sample_rate);
 
         for effect in &self.global_effects {
             stereo = effect.process_stereo(stereo);

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -350,9 +350,9 @@ impl Engine {
             output += instrument.tick(current_time);
         }
 
-        // Apply master gain before effects
-        output *= self.master_gain.tick();
-
+        // NOTE: master gain is applied later in `tick`/`tick_stereo`, after the
+        // loop mixer is summed in, so the master fader scales loops too — not
+        // just the instrument sum.
         output
     }
 
@@ -366,6 +366,9 @@ impl Engine {
 
         // Sum the loop mixer into the master bus (downmixed for the mono path).
         output += self.mixer.tick(self.sample_rate).downmix();
+
+        // Apply master gain to the full mix (instruments + loops) before effects.
+        output *= self.master_gain.tick();
 
         // Apply global effects chain to the final output
         for effect in &self.global_effects {
@@ -387,8 +390,12 @@ impl Engine {
         let mut stereo = StereoFrame::mono(self.render_pre_effects(current_time));
 
         // Sum the loop mixer (already stereo, with its own per-channel effects)
-        // into the master bus before the global effects + limiter.
+        // into the master bus.
         stereo += self.mixer.tick(self.sample_rate);
+
+        // Apply master gain to the full mix (instruments + loops) before the
+        // global effects + limiter.
+        stereo = stereo.scaled(self.master_gain.tick());
 
         for effect in &self.global_effects {
             stereo = effect.process_stereo(stereo);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,6 +14,7 @@ use crate::instruments::{
     BassConfig, BassSynth, Granulator, HiHat2, HiHat2Config, KickConfig, KickDrum, PolySynth,
     PolySynthConfig, SampleBuffer, SnareConfig, SnareDrum, Tom2, Tom2Config,
 };
+use crate::mixer::{Mixer, StereoSampleBuffer};
 use crate::music::{apply_voicing, available_voicings, Key, NoteName, ScaleType, VoicingType};
 use crate::utils::{PresetBlender, SmoothedParam};
 use std::ffi::{c_char, c_void, CString};
@@ -661,6 +662,11 @@ pub struct GooeyEngine {
     // Mono granular instrument (sample buffer loaded by the host)
     granulator: Granulator,
 
+    // Multi-channel stereo loop mixer (4 channels, per-channel effects). Summed
+    // into the master bus before the global effects chain. The `gooey_engine_loop_*`
+    // FFI functions expose control over this.
+    mixer: Mixer,
+
     // When true, an external source (e.g. Ableton Link) owns the tempo.
     // The host should check this flag to decide whether local BPM changes
     // should be applied directly or routed through the external sync source.
@@ -843,6 +849,8 @@ impl GooeyEngine {
                 SampleBuffer::from_mono(vec![0.0_f32], 44_100.0)
                     .unwrap_or_else(|_| unreachable!("constant placeholder buffer is valid")),
             ),
+            // Multi-channel stereo loop mixer (empty until the host loads loops).
+            mixer: Mixer::new(sample_rate),
             // External sync (e.g. Ableton Link)
             link_enabled: AtomicBool::new(false),
             // Error state
@@ -1092,6 +1100,10 @@ impl GooeyEngine {
             // state); for mono content with no stereo effect engaged the two
             // channels stay identical.
             let mut stereo = StereoFrame::mono(output);
+
+            // Sum the loop mixer (already stereo, with its own per-channel
+            // effects) into the master bus before the global effects + limiter.
+            stereo += self.mixer.tick(self.sample_rate);
 
             // Apply global effects chain (order is user-configurable; limiter is always last)
             for &effect_id in &self.effect_order {
@@ -1559,6 +1571,9 @@ pub const INSTRUMENT_COUNT: u32 = 5;
 /// Internal usize version for array indexing
 const NUM_INSTRUMENTS: usize = INSTRUMENT_COUNT as usize;
 const DEFAULT_MASTER_GAIN: f32 = 0.25;
+
+/// Number of stereo loop-mixer channels (see `gooey_engine_loop_*`).
+pub const LOOP_CHANNEL_COUNT: u32 = crate::mixer::LOOP_CHANNEL_COUNT as u32;
 
 // =============================================================================
 // Preset blend constants
@@ -3002,6 +3017,9 @@ pub unsafe extern "C" fn gooey_engine_set_bpm(engine: *mut GooeyEngine, bpm: f32
     for lfo in &mut engine.lfos {
         lfo.set_bpm(bpm);
     }
+
+    // Seed BPM for any future note-synced per-channel loop effects.
+    engine.mixer.set_bpm(bpm);
 }
 
 /// Get the current BPM.
@@ -5283,6 +5301,317 @@ pub unsafe extern "C" fn gooey_engine_granulator_set_buffer(
             true
         }
         Err(_) => false,
+    }
+}
+
+// =============================================================================
+// Loop mixer: 4 stereo loop channels with per-channel effect chains
+// =============================================================================
+//
+// These functions control the engine's `Mixer` (see `src/mixer/`). Each channel
+// is a stereo loop player with its own gain fader, mute/solo, loop window,
+// varispeed, and an ordered chain of effects. The host decodes audio files and
+// passes raw interleaved f32 frames; the engine owns playback and mixing.
+//
+// `channel` is a 0-based index in `[0, LOOP_CHANNEL_COUNT)`; out-of-range
+// indices are ignored (or return a sensible default).
+
+/// Load (or replace) a loop channel's stereo buffer from interleaved f32 frames.
+///
+/// `samples` points to `frames * channels` interleaved values. A `channels`
+/// value of 1 duplicates the mono signal to both sides; 2+ uses channels 0/1 as
+/// left/right. Loading resets the channel's playhead to its loop start.
+///
+/// Returns `true` on success, `false` on a null/short pointer, bad channel
+/// index, or invalid buffer (zero length, non-finite samples, bad sample rate).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`. `samples`
+/// must point to at least `frames * channels` readable `f32` values.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_load(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    samples: *const f32,
+    frames: u32,
+    channels: u32,
+    sample_rate: f32,
+) -> bool {
+    if engine.is_null() || samples.is_null() || frames == 0 || channels == 0 {
+        return false;
+    }
+    let engine = &mut *engine;
+    let total = frames as usize * channels as usize;
+    let slice = slice::from_raw_parts(samples, total);
+    match StereoSampleBuffer::from_interleaved(slice, channels as usize, sample_rate) {
+        Ok(buffer) => engine.mixer.load(channel as usize, buffer),
+        Err(_) => false,
+    }
+}
+
+/// Start or stop playback of a loop channel.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_set_playing(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    playing: bool,
+) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.set_playing(channel as usize, playing);
+    }
+}
+
+/// Set a loop channel's fader gain (0.0 = silence, 1.0 = unity, up to 2.0).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_set_gain(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    gain: f32,
+) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.set_gain(channel as usize, gain);
+    }
+}
+
+/// Mute or unmute a loop channel (click-free, applied to the post-effect signal).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_set_mute(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    muted: bool,
+) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.set_muted(channel as usize, muted);
+    }
+}
+
+/// Solo or un-solo a loop channel. While any channel is soloed, only soloed
+/// channels are audible.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_set_solo(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    soloed: bool,
+) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.set_soloed(channel as usize, soloed);
+    }
+}
+
+/// Set a loop channel's loop start point as a normalized `[0, 1]` position in
+/// the buffer.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_set_start(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    normalized: f32,
+) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.set_loop_start(channel as usize, normalized);
+    }
+}
+
+/// Set a loop channel's loop end point as a normalized `[0, 1]` position in
+/// the buffer.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_set_end(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    normalized: f32,
+) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.set_loop_end(channel as usize, normalized);
+    }
+}
+
+/// Set a loop channel's playback speed (varispeed). 1.0 = normal, 0.5 = half
+/// speed/down an octave, negative = reverse. Clamped to `[-4, 4]`.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_set_speed(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    speed: f32,
+) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.set_speed(channel as usize, speed);
+    }
+}
+
+/// Restart a loop channel from its loop start point.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_restart(engine: *mut GooeyEngine, channel: u32) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.restart(channel as usize);
+    }
+}
+
+/// Get a loop channel's current playhead as a normalized `[0, 1]` position.
+/// Returns 0.0 for a null engine or empty/out-of-range channel.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_get_position(
+    engine: *const GooeyEngine,
+    channel: u32,
+) -> f32 {
+    match engine.as_ref() {
+        Some(engine) => engine
+            .mixer
+            .channel(channel as usize)
+            .map_or(0.0, |ch| ch.position_normalized()),
+        None => 0.0,
+    }
+}
+
+/// Append an effect (an `EFFECT_*` id) to a loop channel's chain. Returns the
+/// new effect's slot index, or -1 on failure (null engine, bad channel, or an
+/// effect id that is not a per-channel effect, e.g. the master limiter).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_effect_add(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    effect_id: u32,
+) -> i32 {
+    match engine.as_mut() {
+        Some(engine) => engine
+            .mixer
+            .effect_add(channel as usize, effect_id)
+            .map_or(-1, |slot| slot as i32),
+        None => -1,
+    }
+}
+
+/// Remove the effect at `slot` from a loop channel's chain. Returns `true` if an
+/// effect was removed.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_effect_remove(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    slot: u32,
+) -> bool {
+    match engine.as_mut() {
+        Some(engine) => engine.mixer.effect_remove(channel as usize, slot as usize),
+        None => false,
+    }
+}
+
+/// Move the effect at `slot` to `new_position` within a loop channel's chain.
+/// Returns `true` on success.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_effect_move(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    slot: u32,
+    new_position: u32,
+) -> bool {
+    match engine.as_mut() {
+        Some(engine) => {
+            engine
+                .mixer
+                .effect_move(channel as usize, slot as usize, new_position as usize)
+        }
+        None => false,
+    }
+}
+
+/// Remove all effects from a loop channel's chain.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_effect_clear(engine: *mut GooeyEngine, channel: u32) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.effect_clear(channel as usize);
+    }
+}
+
+/// Set a parameter (`*_PARAM_*` id) on the effect at `slot` of a loop channel.
+/// Parameter ids and value ranges match `gooey_engine_set_global_effect_param`.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_effect_set_param(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    slot: u32,
+    param: u32,
+    value: f32,
+) {
+    if let Some(engine) = engine.as_ref() {
+        engine
+            .mixer
+            .effect_set_param(channel as usize, slot as usize, param, value);
+    }
+}
+
+/// Return the number of effects in a loop channel's chain (0 for a null engine
+/// or out-of-range channel).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_effect_count(
+    engine: *const GooeyEngine,
+    channel: u32,
+) -> u32 {
+    match engine.as_ref() {
+        Some(engine) => engine.mixer.effect_count(channel as usize) as u32,
+        None => 0,
+    }
+}
+
+/// Return the `EFFECT_*` id of the effect at `slot` of a loop channel, or -1 if
+/// the engine is null or the channel/slot is out of range.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_effect_type_at(
+    engine: *const GooeyEngine,
+    channel: u32,
+    slot: u32,
+) -> i32 {
+    match engine.as_ref() {
+        Some(engine) => engine
+            .mixer
+            .effect_type_at(channel as usize, slot as usize)
+            .map_or(-1, |id| id as i32),
+        None => -1,
     }
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1091,9 +1091,6 @@ impl GooeyEngine {
             // Mix in granulator output
             output += self.granulator.tick(self.current_time);
 
-            // Apply master headroom before the optional global effects.
-            output *= self.master_gain.tick();
-
             // Stereo seam: the instrument sum is mono, so place it on both
             // channels here — BEFORE the effects chain — so each effect can
             // process true left/right. Effects are stereo-aware (per-channel
@@ -1102,8 +1099,13 @@ impl GooeyEngine {
             let mut stereo = StereoFrame::mono(output);
 
             // Sum the loop mixer (already stereo, with its own per-channel
-            // effects) into the master bus before the global effects + limiter.
+            // effects) into the master bus.
             stereo += self.mixer.tick(self.sample_rate);
+
+            // Apply master headroom to the full mix (instruments + loops) before
+            // the optional global effects + limiter, so the master fader scales
+            // loops too.
+            stereo = stereo.scaled(self.master_gain.tick());
 
             // Apply global effects chain (order is user-configurable; limiter is always last)
             for &effect_id in &self.effect_order {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -29,6 +29,44 @@ impl StereoFrame {
     pub fn downmix(self) -> f32 {
         0.5 * (self.l + self.r)
     }
+
+    /// Scale both channels by a single gain factor.
+    #[inline]
+    pub fn scaled(self, gain: f32) -> Self {
+        Self {
+            l: self.l * gain,
+            r: self.r * gain,
+        }
+    }
+}
+
+impl std::ops::Add for StereoFrame {
+    type Output = StereoFrame;
+
+    #[inline]
+    fn add(self, rhs: StereoFrame) -> StereoFrame {
+        StereoFrame {
+            l: self.l + rhs.l,
+            r: self.r + rhs.r,
+        }
+    }
+}
+
+impl std::ops::AddAssign for StereoFrame {
+    #[inline]
+    fn add_assign(&mut self, rhs: StereoFrame) {
+        self.l += rhs.l;
+        self.r += rhs.r;
+    }
+}
+
+impl std::ops::Mul<f32> for StereoFrame {
+    type Output = StereoFrame;
+
+    #[inline]
+    fn mul(self, gain: f32) -> StereoFrame {
+        self.scaled(gain)
+    }
 }
 
 #[cfg(test)]

--- a/src/instruments/granulator.rs
+++ b/src/instruments/granulator.rs
@@ -7,7 +7,7 @@
 
 use crate::effects::Waveshaper;
 use crate::engine::{Instrument, Modulatable};
-use crate::utils::SmoothedParam;
+use crate::utils::{cubic_interpolate, SmoothedParam};
 use std::sync::Arc;
 
 const MAX_GRAINS: usize = 64;
@@ -834,15 +834,6 @@ fn raised_sine_window(phase: f32, shape: f32) -> f32 {
         .sin()
         .max(0.0)
         .powf(shape)
-}
-
-#[inline]
-fn cubic_interpolate(p0: f32, p1: f32, p2: f32, p3: f32, t: f32) -> f32 {
-    let a0 = -0.5 * p0 + 1.5 * p1 - 1.5 * p2 + 0.5 * p3;
-    let a1 = p0 - 2.5 * p1 + 2.0 * p2 - 0.5 * p3;
-    let a2 = -0.5 * p0 + 0.5 * p2;
-    let a3 = p1;
-    ((a0 * t + a1) * t + a2) * t + a3
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ffi;
 pub mod frame;
 pub mod gen;
 pub mod instruments;
+pub mod mixer;
 pub mod music;
 pub mod sequencer;
 pub mod utils;

--- a/src/mixer/effect_chain.rs
+++ b/src/mixer/effect_chain.rs
@@ -1,0 +1,305 @@
+//! Per-channel effect chain for loop mixer channels.
+//!
+//! Each loop channel owns an ordered chain of [`ChannelEffect`]s so the user
+//! can put *any* effect on *any* channel (the mixer's headline requirement).
+//! [`ChannelEffect`] is a small enum over the existing effect types — mirroring
+//! the `ChannelInstrument` pattern in `ffi.rs` — so parameter dispatch stays
+//! typed (no `dyn Any` downcasting) while reusing the exact `EFFECT_*` /
+//! `*_PARAM_*` constants and per-effect setters already exported by the FFI.
+
+use crate::effects::{
+    DelayEffect, DelayTiming, Effect, LowpassFilterEffect, SpringReverbEffect, TiltFilterEffect,
+    TubeCompressor, TubeSaturation,
+};
+use crate::ffi::{
+    COMPRESSOR_PARAM_ATTACK, COMPRESSOR_PARAM_MIX, COMPRESSOR_PARAM_RATIO,
+    COMPRESSOR_PARAM_RELEASE, COMPRESSOR_PARAM_THRESHOLD, DELAY_PARAM_FEEDBACK,
+    DELAY_PARAM_FILTER_CUTOFF, DELAY_PARAM_MIX, DELAY_PARAM_PINGPONG, DELAY_PARAM_TIMING,
+    EFFECT_COMPRESSOR, EFFECT_DELAY, EFFECT_LOWPASS_FILTER, EFFECT_REVERB, EFFECT_SATURATION,
+    EFFECT_TILT_FILTER, FILTER_PARAM_CUTOFF, FILTER_PARAM_RESONANCE, REVERB_PARAM_DAMPING,
+    REVERB_PARAM_DECAY, REVERB_PARAM_MIX, SATURATION_PARAM_DRIVE, SATURATION_PARAM_MIX,
+    SATURATION_PARAM_WARMTH, TILT_PARAM_CUTOFF, TILT_PARAM_RESONANCE,
+};
+use crate::frame::StereoFrame;
+
+/// A single effect on a loop channel. The variants intentionally match the
+/// reorderable `EFFECT_*` ids used everywhere else in the engine.
+///
+/// The variants are kept inline (not boxed) on purpose: an effect is created
+/// only when the user adds one, but its `process_stereo` runs in the per-sample
+/// audio loop, so keeping the DSP state contiguous in the channel's `Vec`
+/// avoids a pointer chase on the hot path. This mirrors `ChannelInstrument` in
+/// `ffi.rs`, which likewise stores its synths inline.
+#[allow(clippy::large_enum_variant)]
+pub enum ChannelEffect {
+    Filter(LowpassFilterEffect),
+    Delay(DelayEffect),
+    Saturation(TubeSaturation),
+    Compressor(TubeCompressor),
+    Tilt(TiltFilterEffect),
+    Reverb(SpringReverbEffect),
+}
+
+impl ChannelEffect {
+    /// Construct an effect from its `EFFECT_*` id with musically useful initial
+    /// values (all adjustable afterwards via [`Self::set_param`]). `bpm` seeds
+    /// the delay's note-synced time. Returns `None` for unknown / non-channel
+    /// ids (e.g. the master limiter).
+    pub fn from_id(effect_id: u32, sample_rate: f32, bpm: f32) -> Option<Self> {
+        match effect_id {
+            EFFECT_LOWPASS_FILTER => Some(Self::Filter(LowpassFilterEffect::new(
+                sample_rate,
+                20_000.0,
+                0.0,
+            ))),
+            EFFECT_DELAY => Some(Self::Delay(DelayEffect::new(
+                sample_rate,
+                DelayTiming::Quarter,
+                bpm,
+                0.3,
+                0.3,
+                8_000.0,
+            ))),
+            EFFECT_SATURATION => Some(Self::Saturation(TubeSaturation::new(
+                sample_rate,
+                0.3,
+                0.4,
+                0.5,
+            ))),
+            EFFECT_COMPRESSOR => Some(Self::Compressor(TubeCompressor::new(
+                sample_rate,
+                -12.0,
+                4.0,
+                5.0,
+                100.0,
+                0.5,
+            ))),
+            EFFECT_TILT_FILTER => Some(Self::Tilt(TiltFilterEffect::new(sample_rate))),
+            EFFECT_REVERB => Some(Self::Reverb(SpringReverbEffect::new(
+                sample_rate,
+                0.5,
+                0.3,
+                0.5,
+            ))),
+            _ => None,
+        }
+    }
+
+    /// The `EFFECT_*` id for this effect.
+    pub fn effect_type(&self) -> u32 {
+        match self {
+            Self::Filter(_) => EFFECT_LOWPASS_FILTER,
+            Self::Delay(_) => EFFECT_DELAY,
+            Self::Saturation(_) => EFFECT_SATURATION,
+            Self::Compressor(_) => EFFECT_COMPRESSOR,
+            Self::Tilt(_) => EFFECT_TILT_FILTER,
+            Self::Reverb(_) => EFFECT_REVERB,
+        }
+    }
+
+    /// Process one stereo frame through this effect.
+    #[inline]
+    pub fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        match self {
+            Self::Filter(e) => e.process_stereo(input),
+            Self::Delay(e) => e.process_stereo(input),
+            Self::Saturation(e) => e.process_stereo(input),
+            Self::Compressor(e) => e.process_stereo(input),
+            Self::Tilt(e) => e.process_stereo(input),
+            Self::Reverb(e) => e.process_stereo(input),
+        }
+    }
+
+    /// Set a parameter by its effect-specific `*_PARAM_*` id. Mirrors the
+    /// global-effect dispatch in `gooey_engine_set_global_effect_param`.
+    pub fn set_param(&self, param: u32, value: f32) {
+        match self {
+            Self::Filter(e) => match param {
+                FILTER_PARAM_CUTOFF => e.set_cutoff_freq(value),
+                FILTER_PARAM_RESONANCE => e.set_resonance(value),
+                _ => {}
+            },
+            Self::Delay(e) => match param {
+                DELAY_PARAM_TIMING => {
+                    if let Some(timing) = DelayTiming::from_timing_constant(value as u32) {
+                        e.set_timing(timing);
+                    }
+                }
+                DELAY_PARAM_FEEDBACK => e.set_feedback(value),
+                DELAY_PARAM_MIX => e.set_mix(value),
+                DELAY_PARAM_FILTER_CUTOFF => e.set_filter_cutoff(value),
+                DELAY_PARAM_PINGPONG => e.set_pingpong(value >= 0.5),
+                _ => {}
+            },
+            Self::Saturation(e) => match param {
+                SATURATION_PARAM_DRIVE => e.set_drive(value),
+                SATURATION_PARAM_WARMTH => e.set_warmth(value),
+                SATURATION_PARAM_MIX => e.set_mix(value),
+                _ => {}
+            },
+            Self::Compressor(e) => match param {
+                COMPRESSOR_PARAM_THRESHOLD => e.set_threshold(value),
+                COMPRESSOR_PARAM_RATIO => e.set_ratio(value),
+                COMPRESSOR_PARAM_ATTACK => e.set_attack(value),
+                COMPRESSOR_PARAM_RELEASE => e.set_release(value),
+                COMPRESSOR_PARAM_MIX => e.set_mix(value),
+                _ => {}
+            },
+            Self::Tilt(e) => match param {
+                TILT_PARAM_CUTOFF => e.set_cutoff(value),
+                TILT_PARAM_RESONANCE => e.set_resonance(value),
+                _ => {}
+            },
+            Self::Reverb(e) => match param {
+                REVERB_PARAM_DECAY => e.set_decay(value),
+                REVERB_PARAM_MIX => e.set_mix(value),
+                REVERB_PARAM_DAMPING => e.set_damping(value),
+                _ => {}
+            },
+        }
+    }
+
+    /// Clear internal DSP state (delay lines, filter memory, envelopes).
+    pub fn reset(&self) {
+        match self {
+            Self::Filter(e) => e.reset(),
+            Self::Delay(e) => e.reset(),
+            Self::Saturation(e) => e.reset(),
+            Self::Compressor(e) => e.reset(),
+            Self::Tilt(e) => e.reset(),
+            Self::Reverb(e) => e.reset(),
+        }
+    }
+}
+
+/// An ordered, runtime-editable chain of per-channel effects.
+#[derive(Default)]
+pub struct EffectChain {
+    effects: Vec<ChannelEffect>,
+}
+
+impl EffectChain {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Process a stereo frame through the whole chain, in order.
+    #[inline]
+    pub fn process(&self, mut frame: StereoFrame) -> StereoFrame {
+        for effect in &self.effects {
+            frame = effect.process_stereo(frame);
+        }
+        frame
+    }
+
+    /// Append an effect by id. Returns the slot index of the new effect, or
+    /// `None` if the id is not a valid channel effect.
+    pub fn add(&mut self, effect_id: u32, sample_rate: f32, bpm: f32) -> Option<usize> {
+        let effect = ChannelEffect::from_id(effect_id, sample_rate, bpm)?;
+        self.effects.push(effect);
+        Some(self.effects.len() - 1)
+    }
+
+    /// Remove the effect at `slot`. Returns `false` if out of range.
+    pub fn remove(&mut self, slot: usize) -> bool {
+        if slot < self.effects.len() {
+            self.effects.remove(slot);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Move the effect at `slot` to `new_position` (clamped to the chain end),
+    /// preserving the relative order of the others. Returns `false` if `slot`
+    /// is out of range.
+    pub fn move_effect(&mut self, slot: usize, new_position: usize) -> bool {
+        if slot >= self.effects.len() {
+            return false;
+        }
+        let effect = self.effects.remove(slot);
+        let dest = new_position.min(self.effects.len());
+        self.effects.insert(dest, effect);
+        true
+    }
+
+    pub fn clear(&mut self) {
+        self.effects.clear();
+    }
+
+    /// Set a parameter on the effect at `slot`.
+    pub fn set_param(&self, slot: usize, param: u32, value: f32) {
+        if let Some(effect) = self.effects.get(slot) {
+            effect.set_param(param, value);
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.effects.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.effects.is_empty()
+    }
+
+    /// The `EFFECT_*` id of the effect at `slot`, for UI / FFI getters.
+    pub fn effect_type_at(&self, slot: usize) -> Option<u32> {
+        self.effects.get(slot).map(ChannelEffect::effect_type)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SR: f32 = 44_100.0;
+
+    #[test]
+    fn add_reports_slot_and_type() {
+        let mut chain = EffectChain::new();
+        assert_eq!(chain.add(EFFECT_DELAY, SR, 120.0), Some(0));
+        assert_eq!(chain.add(EFFECT_REVERB, SR, 120.0), Some(1));
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain.effect_type_at(0), Some(EFFECT_DELAY));
+        assert_eq!(chain.effect_type_at(1), Some(EFFECT_REVERB));
+    }
+
+    #[test]
+    fn unknown_effect_id_is_rejected() {
+        let mut chain = EffectChain::new();
+        assert_eq!(chain.add(9999, SR, 120.0), None);
+        assert!(chain.is_empty());
+    }
+
+    #[test]
+    fn move_effect_reorders() {
+        let mut chain = EffectChain::new();
+        chain.add(EFFECT_LOWPASS_FILTER, SR, 120.0);
+        chain.add(EFFECT_DELAY, SR, 120.0);
+        chain.add(EFFECT_REVERB, SR, 120.0);
+        // Move reverb (slot 2) to the front.
+        assert!(chain.move_effect(2, 0));
+        assert_eq!(chain.effect_type_at(0), Some(EFFECT_REVERB));
+        assert_eq!(chain.effect_type_at(1), Some(EFFECT_LOWPASS_FILTER));
+        assert_eq!(chain.effect_type_at(2), Some(EFFECT_DELAY));
+    }
+
+    #[test]
+    fn remove_and_clear() {
+        let mut chain = EffectChain::new();
+        chain.add(EFFECT_DELAY, SR, 120.0);
+        chain.add(EFFECT_REVERB, SR, 120.0);
+        assert!(chain.remove(0));
+        assert_eq!(chain.effect_type_at(0), Some(EFFECT_REVERB));
+        assert!(!chain.remove(5));
+        chain.clear();
+        assert!(chain.is_empty());
+    }
+
+    #[test]
+    fn empty_chain_is_passthrough() {
+        let chain = EffectChain::new();
+        let f = StereoFrame { l: 0.5, r: -0.25 };
+        assert_eq!(chain.process(f), f);
+    }
+}

--- a/src/mixer/effect_chain.rs
+++ b/src/mixer/effect_chain.rs
@@ -159,6 +159,14 @@ impl ChannelEffect {
         }
     }
 
+    /// Update the tempo for note-synced effects. Only the delay's clocked timing
+    /// depends on BPM; the other effects ignore it.
+    pub fn set_bpm(&self, bpm: f32) {
+        if let Self::Delay(e) = self {
+            e.set_bpm(bpm);
+        }
+    }
+
     /// Clear internal DSP state (delay lines, filter memory, envelopes).
     pub fn reset(&self) {
         match self {
@@ -231,6 +239,13 @@ impl EffectChain {
     pub fn set_param(&self, slot: usize, param: u32, value: f32) {
         if let Some(effect) = self.effects.get(slot) {
             effect.set_param(param, value);
+        }
+    }
+
+    /// Re-tempo every note-synced effect in the chain (currently the delay).
+    pub fn set_bpm(&self, bpm: f32) {
+        for effect in &self.effects {
+            effect.set_bpm(bpm);
         }
     }
 

--- a/src/mixer/loop_channel.rs
+++ b/src/mixer/loop_channel.rs
@@ -1,0 +1,275 @@
+//! A single stereo loop-player channel: buffer playback with loop start/end,
+//! speed, a click-free gain fader, mute/solo intent, and its own effect chain.
+//!
+//! The playback cursor advances by `speed * (source_sr / engine_sr)` per output
+//! sample. The `source_sr / engine_sr` term handles sample-rate conversion via
+//! the buffer's cubic interpolation; `speed` is the user varispeed control. This
+//! is the hook for the future tempo-warp phase — warping simply multiplies the
+//! advance by `engine_bpm / source_bpm` (see the plan's "Tempo warping" phase).
+
+use crate::frame::StereoFrame;
+use crate::mixer::effect_chain::EffectChain;
+use crate::mixer::stereo_buffer::StereoSampleBuffer;
+use crate::utils::SmoothedParam;
+
+/// Smoothing time for the user gain fader and the mute/solo gate (ms).
+const FADER_SMOOTH_MS: f32 = 15.0;
+/// Maximum varispeed magnitude (forward or reverse).
+const MAX_SPEED: f32 = 4.0;
+/// Maximum user fader gain (allows a little boost above unity).
+const MAX_GAIN: f32 = 2.0;
+
+pub struct LoopChannel {
+    buffer: Option<StereoSampleBuffer>,
+    /// Playback position in source frames (fractional).
+    cursor: f64,
+    /// Loop window as normalized positions in `[0, 1]` of the buffer length.
+    loop_start: f32,
+    loop_end: f32,
+    playing: bool,
+    speed: f32,
+    /// User fader.
+    gain: SmoothedParam,
+    /// Mute/solo gate (0 = silent, 1 = audible), set by the owning [`Mixer`].
+    active_gain: SmoothedParam,
+    muted: bool,
+    soloed: bool,
+    effects: EffectChain,
+}
+
+impl LoopChannel {
+    pub fn new(sample_rate: f32) -> Self {
+        Self {
+            buffer: None,
+            cursor: 0.0,
+            loop_start: 0.0,
+            loop_end: 1.0,
+            playing: false,
+            speed: 1.0,
+            gain: SmoothedParam::new(1.0, 0.0, MAX_GAIN, sample_rate, FADER_SMOOTH_MS),
+            active_gain: SmoothedParam::new(1.0, 0.0, 1.0, sample_rate, FADER_SMOOTH_MS),
+            muted: false,
+            soloed: false,
+            effects: EffectChain::new(),
+        }
+    }
+
+    // --- Playback ---------------------------------------------------------
+
+    /// Generate the next stereo sample. The mute/solo gate is applied to the
+    /// post-effect (wet) signal so muting fades a channel's full output — including
+    /// effect tails — rather than chopping the dry input.
+    pub fn tick(&mut self, engine_sample_rate: f32) -> StereoFrame {
+        let dry = if self.playing {
+            match &self.buffer {
+                Some(buffer) if !buffer.is_empty() => {
+                    let frame = buffer.read_interpolated(self.cursor);
+                    self.advance(engine_sample_rate);
+                    frame
+                }
+                _ => StereoFrame::default(),
+            }
+        } else {
+            StereoFrame::default()
+        };
+
+        // Advance the gain smoothers every sample so their timeline is stable
+        // regardless of whether the channel is currently playing.
+        let gained = dry.scaled(self.gain.tick());
+        let wet = self.effects.process(gained);
+        wet.scaled(self.active_gain.tick())
+    }
+
+    /// Advance the cursor by one output sample, wrapping inside the loop window.
+    /// Handles forward and reverse (negative `speed`) playback.
+    fn advance(&mut self, engine_sample_rate: f32) {
+        let Some(buffer) = &self.buffer else {
+            return;
+        };
+        let len = buffer.len() as f64;
+        let (lo, hi) = self.loop_bounds(len);
+        let span = (hi - lo).max(1.0);
+
+        let ratio = buffer.sample_rate() as f64 / engine_sample_rate.max(1.0) as f64;
+        self.cursor += self.speed as f64 * ratio;
+
+        if self.cursor >= hi {
+            self.cursor = lo + (self.cursor - lo).rem_euclid(span);
+        } else if self.cursor < lo {
+            // rem_euclid keeps the offset in [0, span); mirror it back from hi.
+            self.cursor = hi - (lo - self.cursor).rem_euclid(span);
+        }
+    }
+
+    /// Resolve the normalized loop window to `[lo, hi)` frame positions.
+    fn loop_bounds(&self, len: f64) -> (f64, f64) {
+        let a = (self.loop_start as f64 * len).clamp(0.0, len);
+        let b = (self.loop_end as f64 * len).clamp(0.0, len);
+        (a.min(b), a.max(b))
+    }
+
+    // --- Setters ----------------------------------------------------------
+
+    /// Load (or replace) this channel's loop and reset the cursor to the loop start.
+    pub fn set_buffer(&mut self, buffer: StereoSampleBuffer) {
+        let len = buffer.len() as f64;
+        self.buffer = Some(buffer);
+        let (lo, _) = self.loop_bounds(len);
+        self.cursor = lo;
+    }
+
+    pub fn set_playing(&mut self, playing: bool) {
+        self.playing = playing;
+    }
+
+    pub fn set_gain(&mut self, gain: f32) {
+        self.gain.set_target(gain.clamp(0.0, MAX_GAIN));
+    }
+
+    pub fn set_loop_start(&mut self, normalized: f32) {
+        self.loop_start = normalized.clamp(0.0, 1.0);
+    }
+
+    pub fn set_loop_end(&mut self, normalized: f32) {
+        self.loop_end = normalized.clamp(0.0, 1.0);
+    }
+
+    pub fn set_speed(&mut self, speed: f32) {
+        self.speed = speed.clamp(-MAX_SPEED, MAX_SPEED);
+    }
+
+    pub fn set_muted(&mut self, muted: bool) {
+        self.muted = muted;
+    }
+
+    pub fn set_soloed(&mut self, soloed: bool) {
+        self.soloed = soloed;
+    }
+
+    /// Restart playback from the loop start.
+    pub fn restart(&mut self) {
+        if let Some(buffer) = &self.buffer {
+            let (lo, _) = self.loop_bounds(buffer.len() as f64);
+            self.cursor = lo;
+        }
+    }
+
+    /// Set the mute/solo gate target. Called by the [`Mixer`] each block once
+    /// the cross-channel solo state is known.
+    pub(crate) fn set_active(&mut self, audible: bool) {
+        self.active_gain.set_target(if audible { 1.0 } else { 0.0 });
+    }
+
+    // --- Getters ----------------------------------------------------------
+
+    pub fn has_buffer(&self) -> bool {
+        self.buffer.as_ref().is_some_and(|b| !b.is_empty())
+    }
+
+    pub fn is_playing(&self) -> bool {
+        self.playing
+    }
+
+    pub fn gain(&self) -> f32 {
+        self.gain.target()
+    }
+
+    pub fn is_muted(&self) -> bool {
+        self.muted
+    }
+
+    pub fn is_soloed(&self) -> bool {
+        self.soloed
+    }
+
+    pub fn speed(&self) -> f32 {
+        self.speed
+    }
+
+    pub fn loop_start(&self) -> f32 {
+        self.loop_start
+    }
+
+    pub fn loop_end(&self) -> f32 {
+        self.loop_end
+    }
+
+    /// Current playhead as a normalized `[0, 1]` position in the buffer (0 if
+    /// no buffer is loaded).
+    pub fn position_normalized(&self) -> f32 {
+        match &self.buffer {
+            Some(buffer) if buffer.len() > 1 => (self.cursor / (buffer.len() as f64)) as f32,
+            _ => 0.0,
+        }
+    }
+
+    /// Mutable access to the per-channel effect chain.
+    pub fn effects_mut(&mut self) -> &mut EffectChain {
+        &mut self.effects
+    }
+
+    /// Shared access to the per-channel effect chain.
+    pub fn effects(&self) -> &EffectChain {
+        &self.effects
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SR: f32 = 44_100.0;
+
+    fn ramp_buffer(frames: usize) -> StereoSampleBuffer {
+        let left: Vec<f32> = (0..frames).map(|i| i as f32).collect();
+        let right = left.clone();
+        StereoSampleBuffer::from_channels(left, right, SR).unwrap()
+    }
+
+    #[test]
+    fn silent_until_playing() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_buffer(ramp_buffer(100));
+        // Not playing yet.
+        assert_eq!(ch.tick(SR), StereoFrame::default());
+    }
+
+    #[test]
+    fn cursor_wraps_within_loop_window() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_buffer(ramp_buffer(10));
+        ch.set_loop_start(0.0);
+        ch.set_loop_end(0.5); // window = frames [0, 5)
+        ch.set_playing(true);
+        // Run well past the window; cursor must always stay < 5.
+        for _ in 0..50 {
+            ch.tick(SR);
+            assert!(ch.position_normalized() < 0.5 + 1e-3);
+        }
+    }
+
+    #[test]
+    fn set_buffer_starts_at_loop_start() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_loop_start(0.5);
+        ch.set_loop_end(1.0);
+        ch.set_buffer(ramp_buffer(100));
+        // cursor should be at 0.5 * 100 = 50.
+        assert!((ch.position_normalized() - 0.5).abs() < 1e-3);
+    }
+
+    #[test]
+    fn reverse_playback_stays_in_window() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_buffer(ramp_buffer(20));
+        ch.set_loop_start(0.25);
+        ch.set_loop_end(0.75);
+        ch.set_speed(-1.0);
+        ch.set_playing(true);
+        for _ in 0..100 {
+            ch.tick(SR);
+            let p = ch.position_normalized();
+            assert!((0.25..0.75 + 1e-2).contains(&p), "pos {p} out of window");
+        }
+    }
+}

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -1,0 +1,256 @@
+//! Multi-channel stereo loop mixer — the core of libgooey's "library owns the
+//! audio channels" model.
+//!
+//! A [`Mixer`] owns a fixed set of [`LoopChannel`]s, each a stereo loop player
+//! with its own gain fader, mute/solo, loop window, varispeed, and an arbitrary
+//! per-channel [`EffectChain`]. Both the native [`crate::engine::Engine`] and the
+//! FFI `GooeyEngine` embed a `Mixer`; the FFI layer simply exposes control over
+//! it. The mixer sums its channels into a single stereo frame that the host
+//! engine adds to its master bus before the global effects + limiter.
+
+pub mod effect_chain;
+pub mod loop_channel;
+pub mod stereo_buffer;
+
+pub use effect_chain::{ChannelEffect, EffectChain};
+pub use loop_channel::LoopChannel;
+pub use stereo_buffer::StereoSampleBuffer;
+
+use crate::frame::StereoFrame;
+
+/// Number of loop channels in the mixer.
+pub const LOOP_CHANNEL_COUNT: usize = 4;
+
+/// Default tempo used to seed note-synced per-channel effects (e.g. delay) until
+/// the host engine pushes its own BPM via [`Mixer::set_bpm`].
+const DEFAULT_BPM: f32 = 120.0;
+
+pub struct Mixer {
+    channels: Vec<LoopChannel>,
+    sample_rate: f32,
+    bpm: f32,
+}
+
+impl Mixer {
+    /// Create a mixer with [`LOOP_CHANNEL_COUNT`] empty channels.
+    pub fn new(sample_rate: f32) -> Self {
+        let channels = (0..LOOP_CHANNEL_COUNT)
+            .map(|_| LoopChannel::new(sample_rate))
+            .collect();
+        Self {
+            channels,
+            sample_rate,
+            bpm: DEFAULT_BPM,
+        }
+    }
+
+    /// Sum all channels into one stereo frame, honoring mute/solo: if any channel
+    /// is soloed, only soloed channels sound; otherwise all un-muted channels do.
+    pub fn tick(&mut self, engine_sample_rate: f32) -> StereoFrame {
+        let any_solo = self.channels.iter().any(LoopChannel::is_soloed);
+        let mut out = StereoFrame::default();
+        for channel in &mut self.channels {
+            let audible = if any_solo {
+                channel.is_soloed()
+            } else {
+                !channel.is_muted()
+            };
+            channel.set_active(audible);
+            out += channel.tick(engine_sample_rate);
+        }
+        out
+    }
+
+    /// Update the tempo used when creating new note-synced per-channel effects.
+    pub fn set_bpm(&mut self, bpm: f32) {
+        self.bpm = bpm;
+    }
+
+    pub fn channel_count(&self) -> usize {
+        self.channels.len()
+    }
+
+    pub fn channel(&self, index: usize) -> Option<&LoopChannel> {
+        self.channels.get(index)
+    }
+
+    pub fn channel_mut(&mut self, index: usize) -> Option<&mut LoopChannel> {
+        self.channels.get_mut(index)
+    }
+
+    // --- Channel control (bounds-checked, FFI-friendly) -------------------
+
+    pub fn load(&mut self, channel: usize, buffer: StereoSampleBuffer) -> bool {
+        match self.channels.get_mut(channel) {
+            Some(ch) => {
+                ch.set_buffer(buffer);
+                true
+            }
+            None => false,
+        }
+    }
+
+    pub fn set_playing(&mut self, channel: usize, playing: bool) {
+        if let Some(ch) = self.channels.get_mut(channel) {
+            ch.set_playing(playing);
+        }
+    }
+
+    pub fn set_gain(&mut self, channel: usize, gain: f32) {
+        if let Some(ch) = self.channels.get_mut(channel) {
+            ch.set_gain(gain);
+        }
+    }
+
+    pub fn set_muted(&mut self, channel: usize, muted: bool) {
+        if let Some(ch) = self.channels.get_mut(channel) {
+            ch.set_muted(muted);
+        }
+    }
+
+    pub fn set_soloed(&mut self, channel: usize, soloed: bool) {
+        if let Some(ch) = self.channels.get_mut(channel) {
+            ch.set_soloed(soloed);
+        }
+    }
+
+    pub fn set_loop_start(&mut self, channel: usize, normalized: f32) {
+        if let Some(ch) = self.channels.get_mut(channel) {
+            ch.set_loop_start(normalized);
+        }
+    }
+
+    pub fn set_loop_end(&mut self, channel: usize, normalized: f32) {
+        if let Some(ch) = self.channels.get_mut(channel) {
+            ch.set_loop_end(normalized);
+        }
+    }
+
+    pub fn set_speed(&mut self, channel: usize, speed: f32) {
+        if let Some(ch) = self.channels.get_mut(channel) {
+            ch.set_speed(speed);
+        }
+    }
+
+    pub fn restart(&mut self, channel: usize) {
+        if let Some(ch) = self.channels.get_mut(channel) {
+            ch.restart();
+        }
+    }
+
+    // --- Per-channel effects ----------------------------------------------
+
+    /// Append an effect to a channel. Returns the new effect's slot index, or
+    /// `None` for a bad channel index or unknown effect id.
+    pub fn effect_add(&mut self, channel: usize, effect_id: u32) -> Option<usize> {
+        let (sample_rate, bpm) = (self.sample_rate, self.bpm);
+        self.channels
+            .get_mut(channel)?
+            .effects_mut()
+            .add(effect_id, sample_rate, bpm)
+    }
+
+    pub fn effect_remove(&mut self, channel: usize, slot: usize) -> bool {
+        self.channels
+            .get_mut(channel)
+            .is_some_and(|ch| ch.effects_mut().remove(slot))
+    }
+
+    pub fn effect_move(&mut self, channel: usize, slot: usize, new_position: usize) -> bool {
+        self.channels
+            .get_mut(channel)
+            .is_some_and(|ch| ch.effects_mut().move_effect(slot, new_position))
+    }
+
+    pub fn effect_clear(&mut self, channel: usize) {
+        if let Some(ch) = self.channels.get_mut(channel) {
+            ch.effects_mut().clear();
+        }
+    }
+
+    pub fn effect_set_param(&self, channel: usize, slot: usize, param: u32, value: f32) {
+        if let Some(ch) = self.channels.get(channel) {
+            ch.effects().set_param(slot, param, value);
+        }
+    }
+
+    pub fn effect_count(&self, channel: usize) -> usize {
+        self.channels
+            .get(channel)
+            .map_or(0, |ch| ch.effects().len())
+    }
+
+    pub fn effect_type_at(&self, channel: usize, slot: usize) -> Option<u32> {
+        self.channels
+            .get(channel)
+            .and_then(|ch| ch.effects().effect_type_at(slot))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ffi::EFFECT_DELAY;
+
+    const SR: f32 = 44_100.0;
+
+    fn dc_buffer(value: f32, frames: usize) -> StereoSampleBuffer {
+        StereoSampleBuffer::from_channels(vec![value; frames], vec![value; frames], SR).unwrap()
+    }
+
+    #[test]
+    fn default_channel_count() {
+        let mixer = Mixer::new(SR);
+        assert_eq!(mixer.channel_count(), LOOP_CHANNEL_COUNT);
+    }
+
+    #[test]
+    fn muted_channel_drops_out_after_smoothing() {
+        let mut mixer = Mixer::new(SR);
+        mixer.load(0, dc_buffer(0.5, 64));
+        mixer.set_playing(0, true);
+        // Let the gain settle, then read a baseline level.
+        for _ in 0..4096 {
+            mixer.tick(SR);
+        }
+        let before = mixer.tick(SR).l.abs();
+        assert!(before > 0.1, "expected audible channel, got {before}");
+
+        mixer.set_muted(0, true);
+        for _ in 0..4096 {
+            mixer.tick(SR);
+        }
+        let after = mixer.tick(SR).l.abs();
+        // The exponential gate is ~inaudible here (>50 dB down from the 0.5
+        // baseline); it asymptotes toward zero rather than reaching it exactly.
+        assert!(after < 5e-3, "muted channel should be silent, got {after}");
+    }
+
+    #[test]
+    fn solo_silences_other_channels() {
+        let mut mixer = Mixer::new(SR);
+        mixer.load(0, dc_buffer(0.5, 64));
+        mixer.load(1, dc_buffer(0.5, 64));
+        mixer.set_playing(0, true);
+        mixer.set_playing(1, true);
+        mixer.set_soloed(0, true);
+        for _ in 0..4096 {
+            mixer.tick(SR);
+        }
+        // Only channel 0 should contribute (~0.5), not both (~1.0).
+        let out = mixer.tick(SR).l;
+        assert!(
+            (out - 0.5).abs() < 0.05,
+            "solo leaked other channels: {out}"
+        );
+    }
+
+    #[test]
+    fn effect_add_targets_only_its_channel() {
+        let mut mixer = Mixer::new(SR);
+        assert_eq!(mixer.effect_add(0, EFFECT_DELAY), Some(0));
+        assert_eq!(mixer.effect_count(0), 1);
+        assert_eq!(mixer.effect_count(1), 0);
+        assert!(mixer.effect_add(99, EFFECT_DELAY).is_none());
+    }
+}

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -61,9 +61,14 @@ impl Mixer {
         out
     }
 
-    /// Update the tempo used when creating new note-synced per-channel effects.
+    /// Update the tempo for the mixer: re-tempo every existing note-synced
+    /// per-channel effect (so existing delays follow host BPM changes) and seed
+    /// the value used when creating new ones.
     pub fn set_bpm(&mut self, bpm: f32) {
         self.bpm = bpm;
+        for channel in &self.channels {
+            channel.effects().set_bpm(bpm);
+        }
     }
 
     pub fn channel_count(&self) -> usize {

--- a/src/mixer/stereo_buffer.rs
+++ b/src/mixer/stereo_buffer.rs
@@ -1,0 +1,237 @@
+//! Stereo, immutable, reference-counted sample data for loop playback.
+//!
+//! Unlike the granulator's mono [`crate::instruments::SampleBuffer`], a loop
+//! channel keeps both channels so a stereo loop plays back with its original
+//! image intact. Fractional read positions are resolved with the shared
+//! [`cubic_interpolate`] so varispeed / sample-rate conversion stays click-free.
+
+use std::sync::Arc;
+
+use crate::frame::StereoFrame;
+use crate::utils::cubic_interpolate;
+
+/// Shared stereo sample data. Cloning is cheap (two `Arc` bumps).
+#[derive(Clone, Debug)]
+pub struct StereoSampleBuffer {
+    left: Arc<[f32]>,
+    right: Arc<[f32]>,
+    sample_rate: f32,
+}
+
+impl StereoSampleBuffer {
+    /// Build from de-interleaved left/right channels. Both must be the same
+    /// non-zero length and the sample rate must be positive and finite.
+    pub fn from_channels(
+        left: Vec<f32>,
+        right: Vec<f32>,
+        sample_rate: f32,
+    ) -> Result<Self, String> {
+        if left.is_empty() || right.is_empty() {
+            return Err("StereoSampleBuffer requires at least one frame".to_string());
+        }
+        if left.len() != right.len() {
+            return Err(format!(
+                "StereoSampleBuffer channels must match: left={}, right={}",
+                left.len(),
+                right.len()
+            ));
+        }
+        if !sample_rate.is_finite() || sample_rate <= 0.0 {
+            return Err(format!("Invalid sample rate: {sample_rate}"));
+        }
+        if left.iter().chain(right.iter()).any(|s| !s.is_finite()) {
+            return Err("StereoSampleBuffer samples must be finite".to_string());
+        }
+
+        Ok(Self {
+            left: Arc::from(left.into_boxed_slice()),
+            right: Arc::from(right.into_boxed_slice()),
+            sample_rate,
+        })
+    }
+
+    /// Build from an interleaved frame buffer with `channels` samples per frame.
+    /// A mono source (`channels == 1`) is duplicated to both sides; a source
+    /// with two or more channels uses channels 0 and 1 as left/right.
+    pub fn from_interleaved(
+        samples: &[f32],
+        channels: usize,
+        sample_rate: f32,
+    ) -> Result<Self, String> {
+        if channels == 0 {
+            return Err("StereoSampleBuffer requires at least one channel".to_string());
+        }
+        if samples.is_empty() {
+            return Err("StereoSampleBuffer requires at least one sample".to_string());
+        }
+
+        let frames = samples.len() / channels;
+        if frames == 0 {
+            return Err("StereoSampleBuffer requires at least one full frame".to_string());
+        }
+
+        let mut left = Vec::with_capacity(frames);
+        let mut right = Vec::with_capacity(frames);
+        for frame in samples.chunks_exact(channels) {
+            if channels == 1 {
+                left.push(frame[0]);
+                right.push(frame[0]);
+            } else {
+                left.push(frame[0]);
+                right.push(frame[1]);
+            }
+        }
+
+        Self::from_channels(left, right, sample_rate)
+    }
+
+    /// Load a (mono or stereo) WAV file, preserving the stereo image.
+    /// Mono files are duplicated to both channels; files with more than two
+    /// channels keep channels 0 and 1.
+    #[cfg(feature = "bounce")]
+    pub fn from_wav(path: impl AsRef<std::path::Path>) -> Result<Self, String> {
+        let mut reader = hound::WavReader::open(path.as_ref())
+            .map_err(|e| format!("Failed to open WAV: {e}"))?;
+        let spec = reader.spec();
+        if spec.channels == 0 {
+            return Err("WAV must have at least one channel".to_string());
+        }
+        if spec.sample_rate == 0 {
+            return Err("WAV sample rate must be greater than zero".to_string());
+        }
+
+        let channels = spec.channels as usize;
+        let interleaved = match spec.sample_format {
+            hound::SampleFormat::Float => reader
+                .samples::<f32>()
+                .map(|s| s.map_err(|e| format!("Failed to read WAV sample: {e}")))
+                .collect::<Result<Vec<_>, _>>()?,
+            hound::SampleFormat::Int => match spec.bits_per_sample {
+                0 => return Err("WAV bit depth must be greater than zero".to_string()),
+                1..=8 => {
+                    let scale = ((1_i32 << (spec.bits_per_sample - 1)) - 1) as f32;
+                    reader
+                        .samples::<i8>()
+                        .map(|s| {
+                            s.map(|v| v as f32 / scale)
+                                .map_err(|e| format!("Failed to read WAV sample: {e}"))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                }
+                9..=16 => {
+                    let scale = ((1_i32 << (spec.bits_per_sample - 1)) - 1) as f32;
+                    reader
+                        .samples::<i16>()
+                        .map(|s| {
+                            s.map(|v| v as f32 / scale)
+                                .map_err(|e| format!("Failed to read WAV sample: {e}"))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                }
+                17..=32 => {
+                    let scale = ((1_i64 << (spec.bits_per_sample - 1)) - 1) as f32;
+                    reader
+                        .samples::<i32>()
+                        .map(|s| {
+                            s.map(|v| v as f32 / scale)
+                                .map_err(|e| format!("Failed to read WAV sample: {e}"))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                }
+                bits => return Err(format!("Unsupported WAV bit depth: {bits}")),
+            },
+        };
+
+        if interleaved.is_empty() {
+            return Err("WAV contains no samples".to_string());
+        }
+
+        Self::from_interleaved(&interleaved, channels, spec.sample_rate as f32)
+    }
+
+    /// Number of stereo frames in the buffer.
+    pub fn len(&self) -> usize {
+        self.left.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.left.is_empty()
+    }
+
+    pub fn sample_rate(&self) -> f32 {
+        self.sample_rate
+    }
+
+    #[inline]
+    fn channel_clamped(channel: &[f32], index: isize) -> f32 {
+        let last = channel.len() as isize - 1;
+        channel[index.clamp(0, last) as usize]
+    }
+
+    /// Read a stereo frame at a fractional frame position using cubic
+    /// interpolation. The position is clamped into the valid range; callers
+    /// that loop are responsible for wrapping `position` before calling.
+    #[inline]
+    pub fn read_interpolated(&self, position: f64) -> StereoFrame {
+        if self.left.len() == 1 {
+            return StereoFrame {
+                l: self.left[0],
+                r: self.right[0],
+            };
+        }
+
+        let last = (self.left.len() - 1) as f64;
+        let position = position.clamp(0.0, last);
+        let index = position.floor() as isize;
+        let frac = (position - index as f64) as f32;
+
+        let read = |channel: &[f32]| {
+            let p0 = Self::channel_clamped(channel, index - 1);
+            let p1 = Self::channel_clamped(channel, index);
+            let p2 = Self::channel_clamped(channel, index + 1);
+            let p3 = Self::channel_clamped(channel, index + 2);
+            cubic_interpolate(p0, p1, p2, p3, frac)
+        };
+
+        StereoFrame {
+            l: read(&self.left),
+            r: read(&self.right),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_interleaved_mono_duplicates_to_both_channels() {
+        let buf = StereoSampleBuffer::from_interleaved(&[0.1, 0.2, 0.3], 1, 44100.0).unwrap();
+        assert_eq!(buf.len(), 3);
+        let f = buf.read_interpolated(1.0);
+        assert_eq!(f.l, 0.2);
+        assert_eq!(f.r, 0.2);
+    }
+
+    #[test]
+    fn from_interleaved_stereo_splits_left_right() {
+        // frames: (1.0, -1.0), (0.5, -0.5)
+        let buf =
+            StereoSampleBuffer::from_interleaved(&[1.0, -1.0, 0.5, -0.5], 2, 48000.0).unwrap();
+        assert_eq!(buf.len(), 2);
+        assert_eq!(buf.sample_rate(), 48000.0);
+        let f = buf.read_interpolated(0.0);
+        assert_eq!(f.l, 1.0);
+        assert_eq!(f.r, -1.0);
+    }
+
+    #[test]
+    fn mismatched_channels_rejected() {
+        assert!(StereoSampleBuffer::from_channels(vec![0.0, 0.1], vec![0.0], 44100.0).is_err());
+    }
+
+    #[test]
+    fn non_finite_rejected() {
+        assert!(StereoSampleBuffer::from_channels(vec![f32::NAN], vec![0.0], 44100.0).is_err());
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,3 +15,18 @@ pub fn tuning_to_multiplier(normalized: f32) -> f32 {
     let semitones = (normalized.clamp(0.0, 1.0) - 0.5) * 24.0;
     2.0_f32.powf(semitones / 12.0)
 }
+
+/// 4-point (cubic Catmull-Rom) interpolation between `p1` and `p2`, using the
+/// neighbouring samples `p0` and `p3` to estimate the tangents. `t` is the
+/// fractional position in `[0, 1]` between `p1` and `p2`.
+///
+/// Shared by sample-buffer readers (granular + loop playback) so fractional
+/// playback positions resolve to a smooth, click-free signal.
+#[inline]
+pub fn cubic_interpolate(p0: f32, p1: f32, p2: f32, p3: f32, t: f32) -> f32 {
+    let a0 = -0.5 * p0 + 1.5 * p1 - 1.5 * p2 + 0.5 * p3;
+    let a1 = p0 - 2.5 * p1 + 2.0 * p2 - 0.5 * p3;
+    let a2 = -0.5 * p0 + 0.5 * p2;
+    let a3 = p1;
+    ((a0 * t + a1) * t + a2) * t + a3
+}

--- a/tests/loop_mixer.rs
+++ b/tests/loop_mixer.rs
@@ -237,6 +237,77 @@ fn effect_chain_edit_operations() {
 }
 
 #[test]
+fn master_gain_scales_loops() {
+    // Regression: the loop mixer must sit *before* master gain so the master
+    // fader (and headroom) scales loops, not just the synth/drum bus.
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        let loop_samples = stereo_sine(0.5, 220.0);
+        let frames = (loop_samples.len() / 2) as u32;
+        gooey_engine_loop_load(engine, 0, loop_samples.as_ptr(), frames, 2, SAMPLE_RATE);
+        gooey_engine_loop_set_playing(engine, 0, true);
+
+        gooey_engine_set_master_gain(engine, 1.0);
+        let loud = render_peak(engine, 8192);
+        assert!(
+            loud > 1e-2,
+            "expected audible loop at unity master gain, got {loud}"
+        );
+
+        gooey_engine_set_master_gain(engine, 0.0);
+        let _ = render_peak(engine, 8192); // let the 30 ms master-gain glide settle
+        let silent = render_peak(engine, 8192);
+        assert!(
+            silent < loud * 0.01,
+            "master gain 0 must silence loops too: loud {loud}, silent {silent}"
+        );
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn bpm_change_retempos_existing_loop_delay() {
+    // Regression: changing the host BPM must re-tempo per-channel delays that
+    // already exist, not only effects added afterwards.
+    unsafe fn render_impulse_through_delay(bpm: f32) -> Vec<f32> {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        // 1s loop holding a single impulse at frame 0 (won't wrap within render).
+        let n = SAMPLE_RATE as usize;
+        let mut samples = vec![0.0_f32; n * 2];
+        samples[0] = 0.8;
+        samples[1] = 0.8;
+        gooey_engine_loop_load(engine, 0, samples.as_ptr(), n as u32, 2, SAMPLE_RATE);
+        gooey_engine_loop_set_playing(engine, 0, true);
+        gooey_engine_set_master_gain(engine, 1.0);
+
+        // Add a (quarter-note) delay, THEN change BPM — the order that exposes
+        // the bug.
+        assert_eq!(gooey_engine_loop_effect_add(engine, 0, EFFECT_DELAY), 0);
+        gooey_engine_loop_effect_set_param(engine, 0, 0, DELAY_PARAM_MIX, 0.9);
+        gooey_engine_loop_effect_set_param(engine, 0, 0, DELAY_PARAM_FEEDBACK, 0.4);
+        gooey_engine_set_bpm(engine, bpm);
+
+        let frames = 30_000usize;
+        let mut buffer = vec![0.0_f32; frames * 2];
+        gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+        gooey_engine_free(engine);
+        buffer
+    }
+
+    unsafe {
+        // quarter ≈ 22050 samples at 120 BPM, ≈ 11025 at 240 BPM.
+        let slow = render_impulse_through_delay(120.0);
+        let fast = render_impulse_through_delay(240.0);
+        // If existing delays weren't re-tempo'd both renders would be identical.
+        let diff: f32 = slow.iter().zip(&fast).map(|(a, b)| (a - b).abs()).sum();
+        assert!(
+            diff > 1.0,
+            "BPM change should move an existing delay's echoes (diff {diff})"
+        );
+    }
+}
+
+#[test]
 fn null_engine_is_safe() {
     unsafe {
         let null = std::ptr::null_mut();

--- a/tests/loop_mixer.rs
+++ b/tests/loop_mixer.rs
@@ -1,0 +1,251 @@
+//! End-to-end tests for the loop-mixer FFI (`gooey_engine_loop_*`). Mirrors the
+//! host-side calling sequence an embedded app would use: create engine → load a
+//! loop into a channel → submix (gain/mute/solo) → add per-channel effects →
+//! render → inspect the interleaved stereo output.
+
+use gooey::ffi::*;
+
+const SAMPLE_RATE: f32 = 44_100.0;
+
+/// Build an interleaved stereo sine loop (both channels identical).
+fn stereo_sine(seconds: f32, hz: f32) -> Vec<f32> {
+    let frames = (SAMPLE_RATE * seconds) as usize;
+    let mut out = Vec::with_capacity(frames * 2);
+    for i in 0..frames {
+        let s = (i as f32 / SAMPLE_RATE * hz * std::f32::consts::TAU).sin() * 0.5;
+        out.push(s);
+        out.push(s);
+    }
+    out
+}
+
+/// Render `frames` stereo frames and return the peak absolute sample of the
+/// second half (skips the gain-smoother attack transient).
+unsafe fn render_peak(engine: *mut GooeyEngine, frames: usize) -> f32 {
+    let mut buffer = vec![0.0_f32; frames * 2];
+    gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+    buffer[frames..].iter().fold(0.0_f32, |acc, s| {
+        assert!(s.is_finite(), "non-finite sample in render output");
+        acc.max(s.abs())
+    })
+}
+
+#[test]
+fn load_and_render_produces_audio() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        let loop_samples = stereo_sine(0.5, 220.0);
+        let frames = loop_samples.len() / 2;
+        assert!(gooey_engine_loop_load(
+            engine,
+            0,
+            loop_samples.as_ptr(),
+            frames as u32,
+            2,
+            SAMPLE_RATE,
+        ));
+        gooey_engine_loop_set_playing(engine, 0, true);
+
+        let peak = render_peak(engine, 8192);
+        assert!(peak > 1e-3, "expected audible loop output, got {peak}");
+
+        // Playhead should have advanced.
+        assert!(gooey_engine_loop_get_position(engine, 0) > 0.0);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn load_rejects_invalid_inputs() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        let samples = stereo_sine(0.1, 440.0);
+        let frames = (samples.len() / 2) as u32;
+
+        // Null pointer.
+        assert!(!gooey_engine_loop_load(
+            engine,
+            0,
+            std::ptr::null(),
+            frames,
+            2,
+            SAMPLE_RATE
+        ));
+        // Zero frames / channels.
+        assert!(!gooey_engine_loop_load(
+            engine,
+            0,
+            samples.as_ptr(),
+            0,
+            2,
+            SAMPLE_RATE
+        ));
+        assert!(!gooey_engine_loop_load(
+            engine,
+            0,
+            samples.as_ptr(),
+            frames,
+            0,
+            SAMPLE_RATE
+        ));
+        // Bad sample rate.
+        assert!(!gooey_engine_loop_load(
+            engine,
+            0,
+            samples.as_ptr(),
+            frames,
+            2,
+            0.0
+        ));
+        // Out-of-range channel index.
+        assert!(!gooey_engine_loop_load(
+            engine,
+            LOOP_CHANNEL_COUNT,
+            samples.as_ptr(),
+            frames,
+            2,
+            SAMPLE_RATE,
+        ));
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn mute_silences_a_channel() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        let loop_samples = stereo_sine(0.5, 220.0);
+        let frames = loop_samples.len() / 2;
+        gooey_engine_loop_load(
+            engine,
+            0,
+            loop_samples.as_ptr(),
+            frames as u32,
+            2,
+            SAMPLE_RATE,
+        );
+        gooey_engine_loop_set_playing(engine, 0, true);
+
+        let audible = render_peak(engine, 8192);
+        assert!(audible > 1e-3);
+
+        gooey_engine_loop_set_mute(engine, 0, true);
+        let muted = render_peak(engine, 8192);
+        assert!(
+            muted < audible * 0.02,
+            "muted channel should be ~silent: audible {audible}, muted {muted}"
+        );
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn solo_isolates_channels() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        let loop_samples = stereo_sine(0.5, 220.0);
+        let frames = (loop_samples.len() / 2) as u32;
+        for ch in 0..2 {
+            gooey_engine_loop_load(engine, ch, loop_samples.as_ptr(), frames, 2, SAMPLE_RATE);
+            gooey_engine_loop_set_playing(engine, ch, true);
+        }
+        let both = render_peak(engine, 8192);
+
+        gooey_engine_loop_set_solo(engine, 0, true);
+        let solo = render_peak(engine, 8192);
+        assert!(
+            solo < both,
+            "soloing one of two channels should reduce the summed peak: both {both}, solo {solo}"
+        );
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn per_channel_effect_changes_output() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        // A bright 6 kHz loop so a low-cutoff lowpass has obvious effect.
+        let loop_samples = stereo_sine(0.5, 6_000.0);
+        let frames = loop_samples.len() / 2;
+        gooey_engine_loop_load(
+            engine,
+            0,
+            loop_samples.as_ptr(),
+            frames as u32,
+            2,
+            SAMPLE_RATE,
+        );
+        gooey_engine_loop_set_playing(engine, 0, true);
+
+        let dry = render_peak(engine, 8192);
+
+        // Add a lowpass filter to channel 0 only and clamp its cutoff low.
+        let slot = gooey_engine_loop_effect_add(engine, 0, EFFECT_LOWPASS_FILTER);
+        assert_eq!(slot, 0, "first effect should land in slot 0");
+        assert_eq!(gooey_engine_loop_effect_count(engine, 0), 1);
+        assert_eq!(gooey_engine_loop_effect_count(engine, 1), 0);
+        assert_eq!(
+            gooey_engine_loop_effect_type_at(engine, 0, 0),
+            EFFECT_LOWPASS_FILTER as i32
+        );
+        gooey_engine_loop_effect_set_param(engine, 0, 0, FILTER_PARAM_CUTOFF, 300.0);
+
+        // Let the filter settle, then measure.
+        let _ = render_peak(engine, 8192);
+        let filtered = render_peak(engine, 8192);
+        assert!(
+            filtered < dry * 0.6,
+            "lowpass should attenuate a 6 kHz loop: dry {dry}, filtered {filtered}"
+        );
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn effect_chain_edit_operations() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        assert_eq!(
+            gooey_engine_loop_effect_add(engine, 0, EFFECT_LOWPASS_FILTER),
+            0
+        );
+        assert_eq!(gooey_engine_loop_effect_add(engine, 0, EFFECT_DELAY), 1);
+        assert_eq!(gooey_engine_loop_effect_add(engine, 0, EFFECT_REVERB), 2);
+        assert_eq!(gooey_engine_loop_effect_count(engine, 0), 3);
+
+        // Move reverb (slot 2) to the front.
+        assert!(gooey_engine_loop_effect_move(engine, 0, 2, 0));
+        assert_eq!(
+            gooey_engine_loop_effect_type_at(engine, 0, 0),
+            EFFECT_REVERB as i32
+        );
+
+        // Remove the first effect.
+        assert!(gooey_engine_loop_effect_remove(engine, 0, 0));
+        assert_eq!(gooey_engine_loop_effect_count(engine, 0), 2);
+
+        // The limiter is not a per-channel effect: add must fail.
+        assert_eq!(gooey_engine_loop_effect_add(engine, 0, EFFECT_LIMITER), -1);
+
+        // Clear leaves the chain empty.
+        gooey_engine_loop_effect_clear(engine, 0);
+        assert_eq!(gooey_engine_loop_effect_count(engine, 0), 0);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn null_engine_is_safe() {
+    unsafe {
+        let null = std::ptr::null_mut();
+        // Setters are no-ops; getters return defaults.
+        gooey_engine_loop_set_playing(null, 0, true);
+        gooey_engine_loop_set_gain(null, 0, 1.0);
+        assert_eq!(gooey_engine_loop_get_position(std::ptr::null(), 0), 0.0);
+        assert_eq!(gooey_engine_loop_effect_add(null, 0, EFFECT_DELAY), -1);
+        assert_eq!(gooey_engine_loop_effect_count(std::ptr::null(), 0), 0);
+        assert_eq!(gooey_engine_loop_effect_type_at(std::ptr::null(), 0, 0), -1);
+    }
+}


### PR DESCRIPTION
Adds a reusable core `src/mixer/` module — a 4-channel stereo loop mixer where each channel is a loop player (loop start/end, varispeed, click-free gain, mute/solo) with its own arbitrary effect chain (any `EFFECT_*` on any channel) — embedded in both the native `Engine` and the FFI `GooeyEngine` and summed into the master bus before the global effects + limiter. Control is exposed through 17 new `gooey_engine_loop_*` FFI functions (load, play/gain/mute/solo/loop-window/speed/position, and per-channel effect add/remove/move/clear/param). A new `loop_mixer` CLI example loads up to four stereo WAV loops and lets you submix them live, and the change ships with mixer unit tests plus FFI integration tests (`tests/loop_mixer.rs`). Stereo WAV loading is added via a new `StereoSampleBuffer`, and the shared `cubic_interpolate` helper is promoted to `utils` (reused by the granulator). Tempo warping is intentionally deferred — the playback cursor is structured so BPM-sync is a one-multiplier follow-up. All 345 tests pass, with `cargo fmt`, `cargo clippy`, and the iOS build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)