### PR TITLE
Add STFT spectral resonator effect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,12 @@ name = "gooey"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [features]
-default = ["native"]
+default = ["native", "spectral"]
 native = ["cpal"]
-ios = ["bounce"]  # iOS target - no native audio output, just the engine
+ios = ["bounce", "spectral"]  # iOS target - no native audio output, just the engine
 crossterm = ["dep:crossterm"]
-visualization = ["glfw", "gl", "rustfft"]
+spectral = ["dep:rustfft"]  # STFT-based spectral effects (e.g. SpectralResonator)
+visualization = ["glfw", "gl", "spectral"]  # pulls rustfft in via the spectral feature
 midi = ["midir"]  # MIDI input support for examples
 bounce = ["hound"]  # Offline audio bounce/export to WAV
 
@@ -90,6 +91,10 @@ required-features = ["native", "crossterm"]
 [[example]]
 name = "reverb"
 required-features = ["native", "crossterm"]
+
+[[example]]
+name = "spectral"
+required-features = ["native", "crossterm", "spectral"]
 
 [[example]]
 name = "chords"

--- a/examples/spectral.rs
+++ b/examples/spectral.rs
@@ -1,0 +1,393 @@
+/* Spectral Resonator Lab - Interactive CLI for STFT spectral-resonance experimentation.
+
+The resonator breaks the input into spectral partials, emphasizes the bins that align
+with a tunable fundamental + its harmonics, and lets that energy ring over time.
+
+A snare pattern excites it with broadband transients so the tuned resonance is clearly
+audible. Note: the effect adds ~23 ms of latency (FFT size 1024).
+*/
+
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyEvent},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
+};
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+use gooey::effects::SpectralResonator;
+use gooey::engine::{Engine, EngineOutput, Instrument, Sequencer};
+use gooey::instruments::SnareDrum;
+
+// Lock-free control handle for the resonator effect.
+// SAFETY: SpectralResonator setters take &self and use atomics internally.
+// The raw pointer is valid as long as the engine (which owns the Box<dyn Effect>) is alive.
+struct ResonatorControl {
+    ptr: *const SpectralResonator,
+}
+
+unsafe impl Send for ResonatorControl {}
+
+impl ResonatorControl {
+    fn set_frequency(&self, v: f32) {
+        unsafe { &*self.ptr }.set_frequency(v);
+    }
+    fn set_resonance(&self, v: f32) {
+        unsafe { &*self.ptr }.set_resonance(v);
+    }
+    fn set_sharpness(&self, v: f32) {
+        unsafe { &*self.ptr }.set_sharpness(v);
+    }
+    fn set_mix(&self, v: f32) {
+        unsafe { &*self.ptr }.set_mix(v);
+    }
+}
+
+// Parameter indices
+const PARAM_FREQUENCY: usize = 0;
+const PARAM_RESONANCE: usize = 1;
+const PARAM_SHARPNESS: usize = 2;
+const PARAM_MIX: usize = 3;
+const PARAM_BPM: usize = 4;
+const PARAM_COUNT: usize = 5;
+
+const MIN_FREQ: f32 = 20.0;
+const MAX_FREQ: f32 = 4000.0;
+
+// Wrapper to share SnareDrum between audio thread and main thread
+struct SharedSnare(Arc<Mutex<SnareDrum>>);
+
+impl Instrument for SharedSnare {
+    fn trigger_with_velocity(&mut self, time: f64, velocity: f32) {
+        self.0.lock().unwrap().trigger_with_velocity(time, velocity);
+    }
+
+    fn tick(&mut self, current_time: f64) -> f32 {
+        self.0.lock().unwrap().tick(current_time)
+    }
+
+    fn is_active(&self) -> bool {
+        self.0.lock().unwrap().is_active()
+    }
+
+    fn as_modulatable(&mut self) -> Option<&mut dyn gooey::engine::Modulatable> {
+        None
+    }
+}
+
+struct ResonatorState {
+    frequency: f32,
+    resonance: f32,
+    sharpness: f32,
+    mix: f32,
+    bpm: f32,
+    running: bool,
+    enabled: bool,
+}
+
+fn make_bar(normalized: f32, width: usize) -> String {
+    let filled = (normalized.clamp(0.0, 1.0) * width as f32).round() as usize;
+    let filled = filled.min(width);
+    let empty = width - filled;
+    format!("{}{}", "█".repeat(filled), "░".repeat(empty))
+}
+
+fn render_display(state: &ResonatorState, selected: usize) {
+    print!("\x1b[2J\x1b[H\x1b[?7l");
+
+    print!("=== Spectral Resonator Lab ===\r\n");
+    print!("SPACE=start/stop  B=bypass  Q=quit  ↑↓=sel  ←→=adj  []=fine\r\n");
+    let status = if state.running { "RUNNING" } else { "STOPPED" };
+    let fx_status = if state.enabled { "ON" } else { "BYPASS" };
+    print!(
+        "Status: {}  Resonator: {}  (latency ~23ms)\r\n",
+        status, fx_status
+    );
+    print!("\r\n");
+
+    // Frequency (log-scaled bar)
+    let ind = if selected == PARAM_FREQUENCY {
+        ">"
+    } else {
+        " "
+    };
+    let freq_norm = (state.frequency / MIN_FREQ).log2() / (MAX_FREQ / MIN_FREQ).log2();
+    print!(
+        "{} {:<18} [{}] {:>7.1} Hz\r\n",
+        ind,
+        "frequency",
+        make_bar(freq_norm, 10),
+        state.frequency
+    );
+
+    // Resonance
+    let ind = if selected == PARAM_RESONANCE {
+        ">"
+    } else {
+        " "
+    };
+    print!(
+        "{} {:<18} [{}] {:>6.2}\r\n",
+        ind,
+        "resonance (ring)",
+        make_bar(state.resonance, 10),
+        state.resonance
+    );
+
+    // Sharpness
+    let ind = if selected == PARAM_SHARPNESS {
+        ">"
+    } else {
+        " "
+    };
+    print!(
+        "{} {:<18} [{}] {:>6.2}\r\n",
+        ind,
+        "sharpness",
+        make_bar(state.sharpness, 10),
+        state.sharpness
+    );
+
+    // Mix
+    let ind = if selected == PARAM_MIX { ">" } else { " " };
+    print!(
+        "{} {:<18} [{}] {:>6.2}\r\n",
+        ind,
+        "mix",
+        make_bar(state.mix, 10),
+        state.mix
+    );
+
+    // BPM
+    let ind = if selected == PARAM_BPM { ">" } else { " " };
+    let bpm_norm = (state.bpm - 60.0) / 140.0;
+    print!(
+        "{} {:<18} [{}] {:>6.0} BPM\r\n",
+        ind,
+        "bpm",
+        make_bar(bpm_norm, 10),
+        state.bpm
+    );
+
+    io::stdout().flush().unwrap();
+}
+
+#[cfg(feature = "native")]
+fn main() -> anyhow::Result<()> {
+    let sample_rate = 44100.0;
+
+    let mut engine = Engine::new(sample_rate);
+
+    let snare = Arc::new(Mutex::new(SnareDrum::new(sample_rate)));
+    engine.add_instrument("snare", Box::new(SharedSnare(snare.clone())));
+
+    let bpm = 120.0;
+    engine.set_bpm(bpm);
+
+    // Steady pattern so the resonator is continuously excited.
+    let pattern = vec![
+        true, false, true, false, true, false, true, false, true, false, true, false, true, false,
+        true, false,
+    ];
+    let sequencer = Sequencer::with_pattern(bpm, sample_rate, pattern, "snare");
+    engine.add_sequencer(sequencer);
+
+    engine.set_master_gain(0.7);
+
+    let init = ResonatorState {
+        frequency: 220.0,
+        resonance: 0.85,
+        sharpness: 0.7,
+        mix: 0.6,
+        bpm,
+        running: false,
+        enabled: true,
+    };
+
+    // Create the resonator and grab a lock-free control handle before moving it in.
+    let resonator = Box::new(SpectralResonator::new(
+        sample_rate,
+        init.frequency,
+        init.resonance,
+        init.sharpness,
+        init.mix,
+    ));
+    let resonator_control = ResonatorControl {
+        ptr: &*resonator as *const SpectralResonator,
+    };
+    engine.add_global_effect(resonator);
+
+    let audio_engine = Arc::new(Mutex::new(engine));
+
+    let mut engine_output = EngineOutput::new();
+    engine_output.initialize(sample_rate)?;
+
+    #[cfg(feature = "visualization")]
+    engine_output.enable_visualization(1200, 600, 2.0)?;
+
+    engine_output.create_stream_with_engine(audio_engine.clone())?;
+    engine_output.start()?;
+
+    let mut state = init;
+    let mut selected: usize = 0;
+    let mut needs_redraw = true;
+
+    execute!(io::stdout(), Clear(ClearType::All), cursor::Hide)?;
+    enable_raw_mode()?;
+
+    let result = loop {
+        if engine_output.update_visualization() {
+            break Ok(());
+        }
+
+        if needs_redraw {
+            render_display(&state, selected);
+            needs_redraw = false;
+        }
+
+        if event::poll(std::time::Duration::from_millis(16))? {
+            if let Event::Key(KeyEvent { code, .. }) = event::read()? {
+                match code {
+                    KeyCode::Up => {
+                        selected = selected.saturating_sub(1);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Down => {
+                        selected = (selected + 1).min(PARAM_COUNT - 1);
+                        needs_redraw = true;
+                    }
+                    KeyCode::Right => {
+                        adjust_param(
+                            &audio_engine,
+                            &resonator_control,
+                            &mut state,
+                            selected,
+                            1.0,
+                            false,
+                        );
+                        needs_redraw = true;
+                    }
+                    KeyCode::Left => {
+                        adjust_param(
+                            &audio_engine,
+                            &resonator_control,
+                            &mut state,
+                            selected,
+                            -1.0,
+                            false,
+                        );
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char(']') => {
+                        adjust_param(
+                            &audio_engine,
+                            &resonator_control,
+                            &mut state,
+                            selected,
+                            1.0,
+                            true,
+                        );
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('[') => {
+                        adjust_param(
+                            &audio_engine,
+                            &resonator_control,
+                            &mut state,
+                            selected,
+                            -1.0,
+                            true,
+                        );
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('b') | KeyCode::Char('B') => {
+                        state.enabled = !state.enabled;
+                        if state.enabled {
+                            resonator_control.set_mix(state.mix);
+                        } else {
+                            resonator_control.set_mix(0.0);
+                        }
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char(' ') => {
+                        let mut engine = audio_engine.lock().unwrap();
+                        if let Some(seq) = engine.sequencer_mut(0) {
+                            if seq.is_running() {
+                                seq.stop();
+                                state.running = false;
+                            } else {
+                                seq.start();
+                                state.running = true;
+                            }
+                        }
+                        needs_redraw = true;
+                    }
+                    KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => {
+                        break Ok(());
+                    }
+                    _ => {}
+                }
+            }
+        }
+    };
+
+    print!("\x1b[?7h");
+    execute!(io::stdout(), cursor::Show)?;
+    disable_raw_mode()?;
+    println!("\nQuitting...");
+
+    result
+}
+
+#[cfg(feature = "native")]
+fn adjust_param(
+    audio_engine: &Arc<Mutex<Engine>>,
+    control: &ResonatorControl,
+    state: &mut ResonatorState,
+    param: usize,
+    direction: f32,
+    fine: bool,
+) {
+    match param {
+        PARAM_FREQUENCY => {
+            // Multiplicative (musical) steps: a semitone coarse, a tenth fine.
+            let semitones = if fine { 0.1 } else { 1.0 } * direction;
+            state.frequency =
+                (state.frequency * 2.0_f32.powf(semitones / 12.0)).clamp(MIN_FREQ, MAX_FREQ);
+            control.set_frequency(state.frequency);
+        }
+        PARAM_RESONANCE => {
+            let step = if fine { 0.01 } else { 0.05 };
+            state.resonance = (state.resonance + step * direction).clamp(0.0, 1.0);
+            control.set_resonance(state.resonance);
+        }
+        PARAM_SHARPNESS => {
+            let step = if fine { 0.01 } else { 0.05 };
+            state.sharpness = (state.sharpness + step * direction).clamp(0.0, 1.0);
+            control.set_sharpness(state.sharpness);
+        }
+        PARAM_MIX => {
+            let step = if fine { 0.01 } else { 0.05 };
+            state.mix = (state.mix + step * direction).clamp(0.0, 1.0);
+            if state.enabled {
+                control.set_mix(state.mix);
+            }
+        }
+        PARAM_BPM => {
+            let step = if fine { 1.0 } else { 5.0 };
+            state.bpm = (state.bpm + step * direction).clamp(60.0, 200.0);
+            let mut engine = audio_engine.lock().unwrap();
+            engine.set_bpm(state.bpm);
+            if let Some(seq) = engine.sequencer_mut(0) {
+                seq.set_bpm(state.bpm);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(not(feature = "native"))]
+fn main() {
+    println!("This example is only available with the 'native' feature enabled.");
+}

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -23,6 +23,8 @@
 
 use std::collections::HashSet;
 
+#[cfg(feature = "spectral")]
+use crate::effects::SpectralResonator;
 use crate::effects::{
     DelayEffect, DelayTiming, Effect, LowpassFilterEffect, SoftLimiter, TubeSaturation,
 };
@@ -536,6 +538,13 @@ enum EffectDef {
     Limiter {
         threshold: f32,
     },
+    #[cfg(feature = "spectral")]
+    SpectralResonator {
+        frequency: f32,
+        resonance: f32,
+        sharpness: f32,
+        mix: f32,
+    },
 }
 
 impl EffectDef {
@@ -625,6 +634,62 @@ impl EffectDef {
                 let threshold = parse_one_f32_arg_named(line_number, &tokens[1..], "threshold")?;
                 Ok(Self::Limiter { threshold })
             }
+            #[cfg(feature = "spectral")]
+            "spectral" | "resonator" => {
+                // Defaults; overridable positionally (freq res sharpness mix) or by key=value.
+                let mut frequency = 220.0_f32;
+                let mut resonance = 0.5_f32;
+                let mut sharpness = 0.5_f32;
+                let mut mix = 0.5_f32;
+                let mut positional: Vec<&str> = Vec::new();
+
+                for arg in &tokens[1..] {
+                    if let Some((k, v)) = arg.split_once('=') {
+                        match k.to_ascii_lowercase().as_str() {
+                            "freq" | "frequency" | "hz" => {
+                                frequency = parse_f32(line_number, "frequency", v)?;
+                            }
+                            "res" | "resonance" => {
+                                resonance = parse_f32(line_number, "resonance", v)?;
+                            }
+                            "sharp" | "sharpness" => {
+                                sharpness = parse_f32(line_number, "sharpness", v)?;
+                            }
+                            "mix" => {
+                                mix = parse_f32(line_number, "mix", v)?;
+                            }
+                            other => {
+                                return Err(format!(
+                                    "line {}: unknown spectral argument '{}'",
+                                    line_number, other
+                                ));
+                            }
+                        }
+                    } else {
+                        positional.push(*arg);
+                    }
+                }
+
+                if !positional.is_empty() {
+                    frequency = parse_f32(line_number, "frequency", positional[0])?;
+                }
+                if positional.len() >= 2 {
+                    resonance = parse_f32(line_number, "resonance", positional[1])?;
+                }
+                if positional.len() >= 3 {
+                    sharpness = parse_f32(line_number, "sharpness", positional[2])?;
+                }
+                if positional.len() >= 4 {
+                    mix = parse_f32(line_number, "mix", positional[3])?;
+                }
+
+                Ok(Self::SpectralResonator {
+                    frequency,
+                    resonance,
+                    sharpness,
+                    mix,
+                })
+            }
             other => Err(format!(
                 "line {}: unknown effect type '{}'",
                 line_number, other
@@ -662,6 +727,19 @@ impl EffectDef {
                 mix,
             ))),
             Self::Limiter { threshold } => Ok(Box::new(SoftLimiter::new(threshold))),
+            #[cfg(feature = "spectral")]
+            Self::SpectralResonator {
+                frequency,
+                resonance,
+                sharpness,
+                mix,
+            } => Ok(Box::new(SpectralResonator::new(
+                sample_rate,
+                frequency,
+                resonance,
+                sharpness,
+                mix,
+            ))),
         }
     }
 }

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -5,6 +5,8 @@ pub mod limiter;
 pub mod lowpass_filter;
 pub mod reverb;
 pub mod saturation;
+#[cfg(feature = "spectral")]
+pub mod spectral_resonator;
 pub mod tilt_filter;
 pub mod waveshaper;
 
@@ -15,6 +17,8 @@ pub use self::limiter::*;
 pub use self::lowpass_filter::*;
 pub use self::reverb::*;
 pub use self::saturation::*;
+#[cfg(feature = "spectral")]
+pub use self::spectral_resonator::*;
 pub use self::tilt_filter::*;
 pub use self::waveshaper::*;
 

--- a/src/effects/spectral_resonator.rs
+++ b/src/effects/spectral_resonator.rs
@@ -1,0 +1,339 @@
+//! Spectral resonator effect (STFT-based).
+//!
+//! Breaks the input into spectral partials with a short-time Fourier transform,
+//! then emphasizes and *resonates* the frequency bins that align with a tunable
+//! fundamental and its harmonic series. A per-bin magnitude memory with a decay
+//! coefficient lets that energy ring over time, and per-bin phase accumulation
+//! keeps the ring phase-coherent — producing tuned, metallic, pad-like
+//! resonances (conceptually similar to Ableton's Spectral Resonator).
+//!
+//! Built on [`StftProcessor`](crate::utils::stft::StftProcessor); see that
+//! module for the windowing/overlap-add details. Note this effect adds
+//! `FFT_SIZE` (1024) samples of latency — ~23 ms at 44.1 kHz — to wherever it
+//! sits in the chain. There is no latency compensation across effects.
+
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use rustfft::num_complex::Complex;
+
+use crate::effects::Effect;
+use crate::frame::StereoFrame;
+use crate::utils::smoother::SmoothedParam;
+use crate::utils::stft::StftProcessor;
+
+/// FFT size for the spectral transform (fixed for v1).
+const FFT_SIZE: usize = 1024;
+/// Highest bin index (inclusive) of the non-redundant half-spectrum.
+const NYQUIST_BIN: usize = FFT_SIZE / 2;
+
+/// Threshold for flushing denormal numbers to zero.
+const DENORMAL_THRESHOLD: f32 = 1e-15;
+
+/// Fundamental frequency range, in Hz.
+const MIN_FREQUENCY: f32 = 20.0;
+const MAX_FREQUENCY: f32 = 4000.0;
+
+/// Per-channel mutable state (wrapped in `UnsafeCell` for interior mutability).
+struct ResonatorState {
+    stft: StftProcessor,
+
+    /// Dry signal delayed by `FFT_SIZE` so the wet/dry mix is phase-aligned with
+    /// the STFT latency.
+    dry_delay: Vec<f32>,
+    dry_pos: usize,
+
+    /// Per-bin resonant magnitude memory (`NYQUIST_BIN + 1` bins).
+    mag_mem: Vec<f32>,
+    /// Per-bin phase accumulator driving the coherent ring.
+    phase_acc: Vec<f32>,
+
+    freq_smoothed: SmoothedParam,
+    resonance_smoothed: SmoothedParam,
+    sharpness_smoothed: SmoothedParam,
+    mix_smoothed: SmoothedParam,
+}
+
+/// Spectral resonator.
+///
+/// Parameters (all lock-free via atomics, smoothed per-sample):
+/// - `frequency`: fundamental in Hz (20–4000). Resonant peaks sit on this and
+///   its integer harmonics.
+/// - `resonance`: 0–1, ring/sustain time (mapped to a per-frame magnitude decay).
+/// - `sharpness`: 0–1, narrowness of each resonant peak (1 = pure ring, 0 =
+///   lets more of the input through).
+/// - `mix`: 0–1 dry/wet.
+pub struct SpectralResonator {
+    sample_rate: f32,
+    state: UnsafeCell<[ResonatorState; 2]>,
+
+    frequency_target: AtomicU32,
+    resonance_target: AtomicU32,
+    sharpness_target: AtomicU32,
+    mix_target: AtomicU32,
+}
+
+// SAFETY: interior `UnsafeCell` state is only mutated from the audio thread
+// (`process`/`process_stereo`); parameter updates from other threads go through
+// lock-free atomics. This mirrors the established pattern in `DelayEffect`.
+unsafe impl Send for SpectralResonator {}
+unsafe impl Sync for SpectralResonator {}
+
+impl SpectralResonator {
+    /// Create a new spectral resonator.
+    pub fn new(sample_rate: f32, frequency: f32, resonance: f32, sharpness: f32, mix: f32) -> Self {
+        let frequency_c = frequency.clamp(MIN_FREQUENCY, MAX_FREQUENCY);
+        let resonance_c = resonance.clamp(0.0, 1.0);
+        let sharpness_c = sharpness.clamp(0.0, 1.0);
+        let mix_c = mix.clamp(0.0, 1.0);
+
+        let make_state = || ResonatorState {
+            stft: StftProcessor::new(FFT_SIZE, sample_rate),
+            dry_delay: vec![0.0; FFT_SIZE],
+            dry_pos: 0,
+            mag_mem: vec![0.0; NYQUIST_BIN + 1],
+            phase_acc: vec![0.0; NYQUIST_BIN + 1],
+            freq_smoothed: SmoothedParam::new(
+                frequency_c,
+                MIN_FREQUENCY,
+                MAX_FREQUENCY,
+                sample_rate,
+                30.0,
+            ),
+            resonance_smoothed: SmoothedParam::new(resonance_c, 0.0, 1.0, sample_rate, 30.0),
+            sharpness_smoothed: SmoothedParam::new(sharpness_c, 0.0, 1.0, sample_rate, 30.0),
+            mix_smoothed: SmoothedParam::new(mix_c, 0.0, 1.0, sample_rate, 30.0),
+        };
+
+        Self {
+            sample_rate,
+            state: UnsafeCell::new([make_state(), make_state()]),
+            frequency_target: AtomicU32::new(frequency_c.to_bits()),
+            resonance_target: AtomicU32::new(resonance_c.to_bits()),
+            sharpness_target: AtomicU32::new(sharpness_c.to_bits()),
+            mix_target: AtomicU32::new(mix_c.to_bits()),
+        }
+    }
+
+    /// Set the fundamental frequency in Hz (clamped to 20–4000).
+    pub fn set_frequency(&self, hz: f32) {
+        self.frequency_target.store(
+            hz.clamp(MIN_FREQUENCY, MAX_FREQUENCY).to_bits(),
+            Ordering::Relaxed,
+        );
+    }
+    pub fn get_frequency(&self) -> f32 {
+        f32::from_bits(self.frequency_target.load(Ordering::Relaxed))
+    }
+
+    /// Set the resonance/ring amount (0–1).
+    pub fn set_resonance(&self, v: f32) {
+        self.resonance_target
+            .store(v.clamp(0.0, 1.0).to_bits(), Ordering::Relaxed);
+    }
+    pub fn get_resonance(&self) -> f32 {
+        f32::from_bits(self.resonance_target.load(Ordering::Relaxed))
+    }
+
+    /// Set the peak sharpness (0–1).
+    pub fn set_sharpness(&self, v: f32) {
+        self.sharpness_target
+            .store(v.clamp(0.0, 1.0).to_bits(), Ordering::Relaxed);
+    }
+    pub fn get_sharpness(&self) -> f32 {
+        f32::from_bits(self.sharpness_target.load(Ordering::Relaxed))
+    }
+
+    /// Set the dry/wet mix (0–1).
+    pub fn set_mix(&self, v: f32) {
+        self.mix_target
+            .store(v.clamp(0.0, 1.0).to_bits(), Ordering::Relaxed);
+    }
+    pub fn get_mix(&self) -> f32 {
+        f32::from_bits(self.mix_target.load(Ordering::Relaxed))
+    }
+
+    /// Inherent latency in samples (`FFT_SIZE`).
+    pub fn latency_samples(&self) -> usize {
+        FFT_SIZE
+    }
+
+    fn process_one(&self, state: &mut ResonatorState, input: f32) -> f32 {
+        let input = if input.is_finite() { input } else { 0.0 };
+
+        // Pull atomic targets into the smoothers and advance one sample.
+        state.freq_smoothed.set_target(f32::from_bits(
+            self.frequency_target.load(Ordering::Relaxed),
+        ));
+        state.resonance_smoothed.set_target(f32::from_bits(
+            self.resonance_target.load(Ordering::Relaxed),
+        ));
+        state.sharpness_smoothed.set_target(f32::from_bits(
+            self.sharpness_target.load(Ordering::Relaxed),
+        ));
+        state
+            .mix_smoothed
+            .set_target(f32::from_bits(self.mix_target.load(Ordering::Relaxed)));
+
+        let frequency = state.freq_smoothed.tick();
+        let resonance = state.resonance_smoothed.tick();
+        let sharpness = state.sharpness_smoothed.tick();
+        let mix = state.mix_smoothed.tick();
+
+        // Map resonance (0–1) to a per-frame magnitude decay. A squared
+        // complement puts most of the knob travel in the long-tail region and
+        // caps below 1.0 so the ring always eventually dies.
+        let decay = (1.0 - (1.0 - resonance) * (1.0 - resonance)).min(0.999);
+        // Map sharpness (0–1) to a Gaussian peak half-width in bins.
+        let bw_bins = (1.0 - sharpness) * 8.0 + 0.7;
+        let bin_hz = self.sample_rate / FFT_SIZE as f32;
+        // Per-frame phase advance for bin k is `phase_inc * k`.
+        let phase_inc = 2.0 * std::f32::consts::PI * state.stft.hop() as f32 / FFT_SIZE as f32;
+
+        // Split the borrow so the closure can hold `mag_mem`/`phase_acc` while
+        // the STFT processor borrows its own fields.
+        let ResonatorState {
+            stft,
+            mag_mem,
+            phase_acc,
+            ..
+        } = state;
+
+        let mut modify = |spec: &mut [Complex<f32>]| {
+            for k in 0..=NYQUIST_BIN {
+                // Resonant gain: 1.0 at a harmonic, falling off as a Gaussian
+                // with the bin-distance to the nearest harmonic. DC is removed.
+                let gain = if k == 0 || frequency <= 0.0 {
+                    0.0
+                } else {
+                    let bin_freq = k as f32 * bin_hz;
+                    let harmonic = (bin_freq / frequency).round().max(1.0);
+                    let dist_bins = (bin_freq - harmonic * frequency).abs() / bin_hz;
+                    let z = dist_bins / bw_bins;
+                    (-z * z).exp()
+                };
+
+                let input_mag = spec[k].norm();
+                let target = input_mag * gain;
+                // Resonant feedback: hold the larger of the new excitation and
+                // the decayed previous magnitude.
+                let m = target.max(mag_mem[k] * decay);
+                mag_mem[k] = m;
+
+                // Advance the per-bin phase and synthesize the resonant bin.
+                let ph =
+                    (phase_acc[k] + phase_inc * k as f32).rem_euclid(2.0 * std::f32::consts::PI);
+                phase_acc[k] = ph;
+
+                if k == 0 {
+                    spec[0] = Complex::new(0.0, 0.0);
+                } else if k == NYQUIST_BIN {
+                    // Nyquist bin must be real for a real inverse transform.
+                    spec[k] = Complex::new(m * ph.cos(), 0.0);
+                } else {
+                    let bin = Complex::new(m * ph.cos(), m * ph.sin());
+                    spec[k] = bin;
+                    // Maintain Hermitian symmetry so the IFFT output is real.
+                    spec[FFT_SIZE - k] = bin.conj();
+                }
+            }
+        };
+
+        let wet = stft.process_sample(input, &mut modify);
+
+        // Delay the dry path by FFT_SIZE to align with the wet latency.
+        let dry = state.dry_delay[state.dry_pos];
+        state.dry_delay[state.dry_pos] = input;
+        state.dry_pos = (state.dry_pos + 1) % FFT_SIZE;
+
+        let mut out = dry * (1.0 - mix) + wet * mix;
+        if !out.is_finite() || out.abs() < DENORMAL_THRESHOLD {
+            out = 0.0;
+        }
+        out
+    }
+}
+
+impl Effect for SpectralResonator {
+    fn process(&self, input: f32) -> f32 {
+        let states = unsafe { &mut *self.state.get() };
+        self.process_one(&mut states[0], input)
+    }
+
+    fn process_stereo(&self, input: StereoFrame) -> StereoFrame {
+        let states = unsafe { &mut *self.state.get() };
+        StereoFrame {
+            l: self.process_one(&mut states[0], input.l),
+            r: self.process_one(&mut states[1], input.r),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SR: f32 = 44_100.0;
+
+    #[test]
+    fn params_are_clamped() {
+        let fx = SpectralResonator::new(SR, 220.0, 0.5, 0.5, 0.5);
+        fx.set_frequency(99_999.0);
+        assert_eq!(fx.get_frequency(), MAX_FREQUENCY);
+        fx.set_frequency(1.0);
+        assert_eq!(fx.get_frequency(), MIN_FREQUENCY);
+        fx.set_resonance(2.0);
+        assert_eq!(fx.get_resonance(), 1.0);
+        fx.set_sharpness(-1.0);
+        assert_eq!(fx.get_sharpness(), 0.0);
+        fx.set_mix(5.0);
+        assert_eq!(fx.get_mix(), 1.0);
+    }
+
+    #[test]
+    fn nan_input_yields_finite_output() {
+        let fx = SpectralResonator::new(SR, 220.0, 0.8, 0.8, 1.0);
+        for _ in 0..(FFT_SIZE * 4) {
+            let out = fx.process(f32::NAN);
+            assert!(out.is_finite());
+        }
+    }
+
+    #[test]
+    fn output_stays_bounded_under_sustained_input() {
+        let fx = SpectralResonator::new(SR, 220.0, 1.0, 0.9, 1.0);
+        let mut max_abs = 0.0_f32;
+        for i in 0..(SR as usize) {
+            let x = (2.0 * std::f32::consts::PI * 220.0 * i as f32 / SR).sin();
+            let out = fx.process(x);
+            assert!(out.is_finite());
+            max_abs = max_abs.max(out.abs());
+        }
+        assert!(max_abs < 100.0, "output blew up: {max_abs}");
+    }
+
+    #[test]
+    fn mix_zero_passes_delayed_dry() {
+        let fx = SpectralResonator::new(SR, 220.0, 0.9, 0.9, 0.0);
+        let input: Vec<f32> = (0..(FFT_SIZE * 3))
+            .map(|i| (2.0 * std::f32::consts::PI * 330.0 * i as f32 / SR).sin())
+            .collect();
+        let output: Vec<f32> = input.iter().map(|&x| fx.process(x)).collect();
+        // With mix=0 the output is the dry signal delayed by FFT_SIZE.
+        let mut max_err = 0.0_f32;
+        for i in FFT_SIZE..input.len() {
+            max_err = max_err.max((output[i] - input[i - FFT_SIZE]).abs());
+        }
+        assert!(max_err < 1e-6, "dry path not delayed cleanly: {max_err}");
+    }
+
+    #[test]
+    fn mono_input_keeps_channels_identical() {
+        let fx = SpectralResonator::new(SR, 220.0, 0.8, 0.7, 1.0);
+        for i in 0..(FFT_SIZE * 4) {
+            let x = (2.0 * std::f32::consts::PI * 220.0 * i as f32 / SR).sin();
+            let out = fx.process_stereo(StereoFrame::mono(x));
+            assert_eq!(out.l, out.r, "channels diverged at {i}");
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,8 @@
 pub mod blendable;
 pub mod oversampler;
 pub mod smoother;
+#[cfg(feature = "spectral")]
+pub mod stft;
 
 pub use blendable::{Blendable, PresetBlender};
 pub use oversampler::{Oversampler, Oversampler2x, Oversampler4x, OversamplingMode};

--- a/src/utils/stft.rs
+++ b/src/utils/stft.rs
@@ -1,0 +1,310 @@
+//! Short-time Fourier transform (STFT) processor with weighted overlap-add.
+//!
+//! This bridges block-based spectral processing into libgooey's strictly
+//! per-sample [`Effect`](crate::effects::Effect) interface: you feed one input
+//! sample and get one output sample back, while internally the processor
+//! accumulates frames, runs an FFT every hop, lets a caller-supplied closure
+//! modify the complex spectrum, runs the inverse FFT, and overlap-adds the
+//! windowed result into an output ring.
+//!
+//! ## Windowing / reconstruction
+//!
+//! A periodic Hann window is applied on BOTH analysis and synthesis (a `w²`
+//! weighted-overlap-add, WOLA). At 75% overlap (hop = `fft_size / 4`) the sum
+//! of the squared Hann windows is constant, satisfying the constant-overlap-add
+//! (COLA) condition, so a no-op spectral modification reconstructs the input
+//! exactly (delayed by `fft_size` samples). The normalization constant — which
+//! folds in both the COLA window sum and rustfft's unnormalized inverse `1/N`
+//! factor — is computed numerically at construction so it stays correct if the
+//! FFT size or overlap changes.
+//!
+//! ## Latency
+//!
+//! Output is delayed by exactly `fft_size` samples (one analysis window). The
+//! first `fft_size` output samples are silence (pre-roll). There is no
+//! latency-compensation mechanism in the effect chain, so any effect built on
+//! this adds `fft_size` samples of latency to wherever it sits.
+//!
+//! ## Real-time safety
+//!
+//! All buffers and FFT plans are allocated in [`StftProcessor::new`]. The
+//! per-sample path uses `process_with_scratch` with preallocated scratch, so it
+//! never allocates on the audio thread.
+
+use std::sync::Arc;
+
+use rustfft::{num_complex::Complex, Fft, FftPlanner};
+
+/// Overlap factor: hop = fft_size / OVERLAP. 4 → 75% overlap (standard WOLA).
+const OVERLAP: usize = 4;
+
+/// Single-channel STFT / weighted-overlap-add processor.
+///
+/// One instance holds the state for one audio channel; stereo effects keep two.
+/// The forward/inverse FFT plans are shared via `Arc` (the `Fft` itself is
+/// `Sync`), but every buffer below is per-instance, so two channels never alias.
+pub struct StftProcessor {
+    fft_size: usize,
+    hop: usize,
+
+    fft_fwd: Arc<dyn Fft<f32>>,
+    fft_inv: Arc<dyn Fft<f32>>,
+
+    /// Periodic Hann window, length `fft_size`. Used for both analysis and
+    /// synthesis.
+    window: Vec<f32>,
+    /// Combined normalization: `1 / (Σ w² · fft_size)`. The `Σ w²` term is the
+    /// COLA window-overlap sum; the `fft_size` term cancels rustfft's
+    /// unnormalized inverse transform.
+    cola_scale: f32,
+
+    /// Ring of the most recent `fft_size` input samples.
+    history: Vec<f32>,
+    hist_write: usize,
+
+    /// Complex FFT work buffer (`fft_size`).
+    spectrum: Vec<Complex<f32>>,
+    fwd_scratch: Vec<Complex<f32>>,
+    inv_scratch: Vec<Complex<f32>>,
+
+    /// Output overlap-add ring. Length `fft_size + hop` guarantees the slot for
+    /// an emitted (and cleared) output position is not reused by a future frame
+    /// before that position has been read out.
+    out_buf: Vec<f32>,
+
+    /// Number of input samples consumed so far. Drives frame triggering and the
+    /// `fft_size`-sample output delay. `u64` so it never wraps in practice.
+    n_in: u64,
+}
+
+impl StftProcessor {
+    /// Create a processor for the given FFT size. `fft_size` must be a multiple
+    /// of [`OVERLAP`] (4); 1024 is the typical choice (~23 ms latency at 44.1 kHz).
+    pub fn new(fft_size: usize, _sample_rate: f32) -> Self {
+        debug_assert!(
+            fft_size % OVERLAP == 0,
+            "fft_size must be divisible by the overlap factor"
+        );
+        let hop = fft_size / OVERLAP;
+
+        let mut planner = FftPlanner::<f32>::new();
+        let fft_fwd = planner.plan_fft_forward(fft_size);
+        let fft_inv = planner.plan_fft_inverse(fft_size);
+
+        // Periodic Hann window (matches src/visualization/spectrogram.rs).
+        let window: Vec<f32> = (0..fft_size)
+            .map(|i| 0.5 * (1.0 - (2.0 * std::f32::consts::PI * i as f32 / fft_size as f32).cos()))
+            .collect();
+
+        // COLA window-overlap sum at one output position: with analysis +
+        // synthesis Hann at this hop the per-position gain is Σ_k w[k·hop]².
+        // (Constant across positions for valid COLA configurations.)
+        let mut wsum = 0.0_f32;
+        let mut k = 0;
+        while k < fft_size {
+            wsum += window[k] * window[k];
+            k += hop;
+        }
+        let cola_scale = 1.0 / (wsum * fft_size as f32);
+
+        let fwd_scratch = vec![Complex::new(0.0, 0.0); fft_fwd.get_inplace_scratch_len()];
+        let inv_scratch = vec![Complex::new(0.0, 0.0); fft_inv.get_inplace_scratch_len()];
+
+        Self {
+            fft_size,
+            hop,
+            fft_fwd,
+            fft_inv,
+            window,
+            cola_scale,
+            history: vec![0.0; fft_size],
+            hist_write: 0,
+            spectrum: vec![Complex::new(0.0, 0.0); fft_size],
+            fwd_scratch,
+            inv_scratch,
+            out_buf: vec![0.0; fft_size + hop],
+            n_in: 0,
+        }
+    }
+
+    /// The hop size in samples (distance between successive analysis frames).
+    pub fn hop(&self) -> usize {
+        self.hop
+    }
+
+    /// Inherent latency in samples (`fft_size`).
+    pub fn latency_samples(&self) -> usize {
+        self.fft_size
+    }
+
+    /// Push one input sample and return one output sample (delayed by
+    /// `fft_size`). On every hop boundary the analysis/modify/synthesis cycle
+    /// runs; `modify` receives the full complex spectrum (length `fft_size`) to
+    /// mutate in place. The output sample corresponds to the input fed
+    /// `fft_size` samples ago; the first `fft_size` outputs are silence.
+    #[inline]
+    pub fn process_sample<F: FnMut(&mut [Complex<f32>])>(
+        &mut self,
+        input: f32,
+        modify: &mut F,
+    ) -> f32 {
+        let n = self.n_in;
+        let out_len = self.out_buf.len();
+
+        // 1. Store the input in the history ring; hist_write now points at the
+        //    oldest retained sample.
+        self.history[self.hist_write] = if input.is_finite() { input } else { 0.0 };
+        self.hist_write = (self.hist_write + 1) % self.fft_size;
+
+        // 2. Emit (and clear) the output for absolute position n - fft_size.
+        //    Negative positions are pre-roll silence.
+        let out = if n >= self.fft_size as u64 {
+            let pos = n - self.fft_size as u64;
+            let idx = (pos % out_len as u64) as usize;
+            let v = self.out_buf[idx];
+            self.out_buf[idx] = 0.0;
+            v
+        } else {
+            0.0
+        };
+
+        // 3. On a hop boundary, the frame ending at input index n is complete.
+        if (n + 1) % self.hop as u64 == 0 {
+            self.run_frame(n, modify);
+        }
+
+        self.n_in += 1;
+        out
+    }
+
+    /// Run one analysis → modify → synthesis frame for the block ending at input
+    /// index `frame_end`. The reconstructed block maps to output positions
+    /// `[frame_end - fft_size + 1 ..= frame_end]`.
+    fn run_frame<F: FnMut(&mut [Complex<f32>])>(&mut self, frame_end: u64, modify: &mut F) {
+        // Copy the fft_size most recent inputs (oldest → newest) into the
+        // complex buffer, applying the analysis window.
+        let start = self.hist_write; // oldest retained sample
+        for n in 0..self.fft_size {
+            let s = self.history[(start + n) % self.fft_size];
+            self.spectrum[n] = Complex::new(s * self.window[n], 0.0);
+        }
+
+        self.fft_fwd
+            .process_with_scratch(&mut self.spectrum, &mut self.fwd_scratch);
+
+        modify(&mut self.spectrum);
+
+        self.fft_inv
+            .process_with_scratch(&mut self.spectrum, &mut self.inv_scratch);
+
+        // Overlap-add the windowed, normalized result into the output ring. The
+        // first output sample of this block is at absolute position
+        // frame_end - fft_size + 1, which is negative for the first few frames
+        // (their leading part lands in the discarded pre-roll); skip those.
+        let out_len = self.out_buf.len() as i64;
+        let block_start = frame_end as i64 + 1 - self.fft_size as i64;
+        for n in 0..self.fft_size {
+            let pos = block_start + n as i64;
+            if pos < 0 {
+                continue;
+            }
+            let y = self.spectrum[n].re * self.window[n] * self.cola_scale;
+            let idx = (pos % out_len) as usize;
+            self.out_buf[idx] += y;
+        }
+    }
+
+    /// Clear all internal state (buffers and indices) back to silence.
+    pub fn reset(&mut self) {
+        self.history.iter_mut().for_each(|s| *s = 0.0);
+        self.out_buf.iter_mut().for_each(|s| *s = 0.0);
+        self.hist_write = 0;
+        self.n_in = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FFT_SIZE: usize = 1024;
+    const SR: f32 = 44_100.0;
+
+    /// A no-op spectral modification must reconstruct the input exactly, delayed
+    /// by `fft_size`. This is the load-bearing correctness test: it fails if the
+    /// COLA normalization or the overlap-add index bookkeeping is wrong.
+    #[test]
+    fn reconstructs_input_delayed_by_fft_size() {
+        let mut stft = StftProcessor::new(FFT_SIZE, SR);
+        let mut noop = |_spec: &mut [Complex<f32>]| {};
+
+        // 1 kHz sine input.
+        let freq = 1000.0_f32;
+        let n_samples = FFT_SIZE * 8;
+        let input: Vec<f32> = (0..n_samples)
+            .map(|i| (2.0 * std::f32::consts::PI * freq * i as f32 / SR).sin())
+            .collect();
+
+        let output: Vec<f32> = input
+            .iter()
+            .map(|&x| stft.process_sample(x, &mut noop))
+            .collect();
+
+        // After the pre-roll, output[i] should equal input[i - FFT_SIZE]. Allow
+        // a small margin near the very start of the steady region for window
+        // ramp-in, so compare from 2*FFT_SIZE onward.
+        let mut max_err = 0.0_f32;
+        for i in (2 * FFT_SIZE)..n_samples {
+            let err = (output[i] - input[i - FFT_SIZE]).abs();
+            max_err = max_err.max(err);
+        }
+        assert!(
+            max_err < 1e-3,
+            "reconstruction error too large: {max_err} (COLA/indexing bug)"
+        );
+    }
+
+    #[test]
+    fn silence_in_silence_out_no_nan() {
+        let mut stft = StftProcessor::new(FFT_SIZE, SR);
+        let mut noop = |_spec: &mut [Complex<f32>]| {};
+        for _ in 0..(FFT_SIZE * 4) {
+            let out = stft.process_sample(0.0, &mut noop);
+            assert!(out.is_finite());
+            assert_eq!(out, 0.0);
+        }
+    }
+
+    #[test]
+    fn first_fft_size_outputs_are_silent_preroll() {
+        let mut stft = StftProcessor::new(FFT_SIZE, SR);
+        let mut noop = |_spec: &mut [Complex<f32>]| {};
+        // Impulse at t=0.
+        let mut outputs = Vec::new();
+        for i in 0..(FFT_SIZE * 3) {
+            let x = if i == 0 { 1.0 } else { 0.0 };
+            outputs.push(stft.process_sample(x, &mut noop));
+        }
+        // Pre-roll: the first fft_size outputs are silence.
+        for (i, &o) in outputs.iter().take(FFT_SIZE).enumerate() {
+            assert_eq!(o, 0.0, "expected pre-roll silence at {i}, got {o}");
+        }
+        // Energy must appear after the delay.
+        let tail_energy: f32 = outputs[FFT_SIZE..].iter().map(|o| o.abs()).sum();
+        assert!(tail_energy > 1e-3, "impulse energy missing after pre-roll");
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut stft = StftProcessor::new(FFT_SIZE, SR);
+        let mut noop = |_spec: &mut [Complex<f32>]| {};
+        for _ in 0..(FFT_SIZE * 2) {
+            stft.process_sample(0.5, &mut noop);
+        }
+        stft.reset();
+        // Immediately after reset the next fft_size outputs are pre-roll silence.
+        for _ in 0..FFT_SIZE {
+            assert_eq!(stft.process_sample(0.0, &mut noop), 0.0);
+        }
+    }
+}

--- a/tests/spectral_resonator.rs
+++ b/tests/spectral_resonator.rs
@@ -1,0 +1,67 @@
+//! Integration tests for the STFT-based SpectralResonator effect.
+#![cfg(feature = "spectral")]
+
+use gooey::dsl::Program;
+use gooey::effects::{Effect, SpectralResonator};
+use gooey::frame::StereoFrame;
+
+const SAMPLE_RATE: f32 = 44_100.0;
+
+/// Mono input must stay dual-mono (the two per-channel STFT states share the
+/// same parameters and see identical input), and the output must stay finite
+/// and bounded even with heavy resonance.
+#[test]
+fn mono_input_stays_dual_mono_and_bounded() {
+    let fx = SpectralResonator::new(SAMPLE_RATE, 220.0, 0.95, 0.8, 1.0);
+
+    let frames = 1usize << 15; // span well past the FFT pre-roll
+    let mut max_abs = 0.0_f32;
+    for i in 0..frames {
+        // Broadband-ish excitation: fundamental + a couple of partials.
+        let t = i as f32 / SAMPLE_RATE;
+        let x = 0.3
+            * ((2.0 * std::f32::consts::PI * 220.0 * t).sin()
+                + (2.0 * std::f32::consts::PI * 440.0 * t).sin()
+                + (2.0 * std::f32::consts::PI * 660.0 * t).sin());
+        let out = fx.process_stereo(StereoFrame::mono(x));
+        assert_eq!(out.l, out.r, "left != right at frame {i} for mono input");
+        assert!(out.l.is_finite(), "non-finite output at frame {i}");
+        max_abs = max_abs.max(out.l.abs());
+    }
+    assert!(max_abs < 100.0, "resonator output blew up: {max_abs}");
+    assert!(
+        max_abs > 1e-4,
+        "expected audible resonant output, peak {max_abs}"
+    );
+}
+
+/// The effect wires through the DSL (`fx spectral ...`) and into an engine.
+#[test]
+fn dsl_builds_and_renders_spectral_effect() {
+    let src = r#"
+        bpm 120
+        master 0.5
+
+        inst kick kick
+        seq kick x...x...x...x...
+
+        fx clear
+        fx spectral freq=330 res=0.7 sharp=0.6 mix=0.8
+    "#;
+
+    let program = Program::parse(src).expect("parse");
+    let mut engine = program.build_engine(SAMPLE_RATE).expect("build engine");
+
+    // `fx clear` removes the default limiter; only the spectral effect remains.
+    assert_eq!(engine.global_effect_count(), 1);
+
+    // Render past the pre-roll; output must stay finite and bounded.
+    let frames = 1usize << 15;
+    for i in 0..frames {
+        let s = engine.tick_stereo(i as f64 / SAMPLE_RATE as f64);
+        assert!(
+            s.l.is_finite() && s.r.is_finite() && s.l.abs() < 100.0 && s.r.abs() < 100.0,
+            "spectral engine output unstable at frame {i}: {s:?}"
+        );
+    }
+}


### PR DESCRIPTION
Adds a **Spectral Resonator**: an STFT-based global effect that breaks input audio into spectral partials, resonates the bins aligned to a tunable fundamental and its harmonics, and rings that energy out over time (tunable `frequency`, `resonance`, `sharpness`, `mix`). It's built on a new reusable weighted-overlap-add STFT engine (`src/utils/stft.rs`, Hann² windowing at 75% overlap, numerically-computed COLA normalization, zero audio-thread allocation) that bridges block-based FFT into libgooey's per-sample `Effect` interface with `fft_size` (1024 ≈ 23 ms) latency. The effect (`src/effects/spectral_resonator.rs`) mirrors the delay effect's `UnsafeCell` per-channel state + atomic-parameter pattern, using per-bin magnitude memory and phase accumulation for a phase-coherent ring. A new `spectral` Cargo feature gates it (decoupling rustfft from `visualization`; included in `default` and `ios`), and it's wired into the DSL as `fx spectral …`. Includes an interactive example (`examples/spectral.rs`) plus unit and integration tests covering STFT reconstruction/COLA, parameter clamping, stability, and dual-mono behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)