### PR TITLE
Add visual aliasing-validation tooling and naive oscillator option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ benches/target/
 test-results/ 
 
 .opencode/**
+
+# Generated aliasing validation plots/WAVs (examples/aliasing_plots.rs)
+/aliasing-plots/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +37,15 @@ checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
 dependencies = [
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -155,6 +170,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +238,19 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clang-sys"
@@ -284,6 +324,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +360,42 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "20.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
+dependencies = [
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+]
 
 [[package]]
 name = "coreaudio-rs"
@@ -380,6 +462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +502,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "dwrote"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b35532432acc8b19ceed096e35dfa088d3ea037fe4f3c085f1f97f33b4d02"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "winapi",
+ "wio",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,10 +572,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
+name = "font-kit"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
+dependencies = [
+ "bitflags 2.9.1",
+ "byteorder",
+ "core-foundation",
+ "core-graphics",
+ "core-text",
+ "dirs",
+ "dwrote",
+ "float-ord",
+ "freetype-sys",
+ "lazy_static",
+ "libc",
+ "log",
+ "pathfinder_geometry",
+ "pathfinder_simd",
+ "walkdir",
+ "winapi",
+ "yeslogic-fontconfig-sys",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "freetype-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7edc5b9669349acfda99533e9e0bcf26a51862ab43b08ee7745c55d28eb134"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
 
 [[package]]
 name = "getrandom"
@@ -454,6 +686,16 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "gif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -518,6 +760,7 @@ dependencies = [
  "halfband",
  "hound",
  "midir",
+ "plotters",
  "rustfft",
 ]
 
@@ -564,6 +807,44 @@ name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.56.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "jpeg-decoder",
+ "num-traits",
+ "png",
+]
 
 [[package]]
 name = "indexmap"
@@ -617,7 +898,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -634,9 +915,15 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -655,6 +942,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +961,15 @@ checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -730,6 +1032,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,7 +1064,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -898,6 +1210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,10 +1251,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pathfinder_geometry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b7e7b4ea703700ce73ebf128e1450eb69c3a8329199ffbfb9b2a0418e5ad3"
+dependencies = [
+ "log",
+ "pathfinder_simd",
+]
+
+[[package]]
+name = "pathfinder_simd"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "chrono",
+ "font-kit",
+ "image",
+ "lazy_static",
+ "num-traits",
+ "pathfinder_geometry",
+ "plotters-backend",
+ "plotters-bitmap",
+ "plotters-svg",
+ "ttf-parser",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-bitmap"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ce181e3f6bf82d6c1dc569103ca7b1bd964c60ba03d7e6cdfbb3e3eb7f7405"
+dependencies = [
+ "gif",
+ "image",
+ "plotters-backend",
+]
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "primal-check"
@@ -996,6 +1392,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1436,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustfft"
@@ -1077,6 +1493,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1159,6 +1581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,7 +1639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1238,7 +1666,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1246,6 +1683,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1287,6 +1735,12 @@ dependencies = [
  "num-integer",
  "strength_reduce",
 ]
+
+[[package]]
+name = "ttf-parser"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "unicode-ident"
@@ -1405,6 +1859,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -1804,6 +2264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wio"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,6 +2286,17 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "yeslogic-fontconfig-sys"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crossterm = ["dep:crossterm"]
 visualization = ["glfw", "gl", "rustfft"]
 midi = ["midir"]  # MIDI input support for examples
 bounce = ["hound"]  # Offline audio bounce/export to WAV
+plots = ["rustfft", "plotters", "hound"]  # Offline aliasing spectrum/spectrogram PNGs
 
 [profile.release]
 panic = "unwind"
@@ -33,6 +34,7 @@ gl = { version = "0.14", optional = true }
 rustfft = { version = "6.2", optional = true }
 midir = { version = "0.10", optional = true }
 hound = { version = "3.5", optional = true }
+plotters = { version = "0.3", optional = true }
 halfband = "0.2"
 
 [[example]]
@@ -106,3 +108,7 @@ required-features = ["native", "crossterm", "bounce"]
 [[example]]
 name = "antialias_validation"
 required-features = ["bounce"]
+
+[[example]]
+name = "aliasing_plots"
+required-features = ["plots"]

--- a/examples/aliasing_plots.rs
+++ b/examples/aliasing_plots.rs
@@ -1,0 +1,659 @@
+//! Visual aliasing validation: render spectrum and spectrogram PNGs so aliasing
+//! artifacts can be *seen* and proven, not just heard.
+//!
+//! Run with:
+//! `cargo run --release --example aliasing_plots --features plots`
+//!
+//! Render a single targeted spectrum instead of the full suite:
+//! `cargo run --release --example aliasing_plots --features plots -- --waveform saw --freq 2200`
+//!
+//! Outputs (PNGs + source WAVs) land in `aliasing-plots/` (gitignored).
+//!
+//! What to look for:
+//! - Steady-tone spectra: real partials sit on the green harmonic markers. Any spike
+//!   *between* the markers is aliasing (a partial folded back below Nyquist).
+//! - Sweep spectrograms: real content sweeps upward; aliasing shows as lines sweeping
+//!   *downward*, reflecting off the Nyquist ceiling.
+
+use std::error::Error;
+use std::f64::consts::TAU;
+use std::path::{Path, PathBuf};
+
+use gooey::envelope::ADSRConfig;
+use gooey::gen::polyblep::{polyblep_saw, polyblep_square};
+use gooey::gen::{Oscillator, Waveform};
+use gooey::utils::{Oversampler, OversamplingMode};
+
+use plotters::prelude::*;
+use rustfft::{num_complex::Complex, FftPlanner};
+
+const SAMPLE_RATE: f32 = 48_000.0;
+/// Drive used for the nonlinear (tanh) anti-alias demonstration. Matches the spirit of
+/// `examples/antialias_validation.rs`.
+const DRIVE: f32 = 10.0;
+
+// ---------------------------------------------------------------------------
+// Signal generation
+// ---------------------------------------------------------------------------
+
+/// Render a steady tone from the *shipping* `Oscillator` (exercises PolyBLEP saw/square,
+/// Gibbs-tapered triangle, etc.). The envelope is held at full sustain and never released,
+/// so the captured region has constant amplitude. A warmup is discarded so the attack ramp
+/// does not pollute the spectrum.
+fn render_osc_tone(waveform: Waveform, freq: f32, n: usize, antialias: bool) -> Vec<f32> {
+    let warmup = 4096usize;
+    let mut osc = Oscillator::new(SAMPLE_RATE, freq);
+    osc.waveform = waveform;
+    osc.set_antialias(antialias);
+    osc.set_adsr(ADSRConfig::new(0.001, 0.001, 1.0, 0.001));
+    osc.set_volume(1.0);
+    osc.trigger(0.0);
+
+    let mut out = Vec::with_capacity(n);
+    for i in 0..(warmup + n) {
+        let t = i as f64 / SAMPLE_RATE as f64;
+        let s = osc.tick(t);
+        if i >= warmup {
+            out.push(s);
+        }
+    }
+    out
+}
+
+/// Render a steady tone at a fixed frequency via an `f64` phase accumulator, evaluating
+/// `gen(phase, phase_inc)` per sample. Used for the controlled naive-vs-band-limited
+/// comparison: the only difference between the two is the generator, not the (jitter-free)
+/// phase source.
+fn render_tone(freq: f32, n: usize, mut gen: impl FnMut(f64, f64) -> f32) -> Vec<f32> {
+    let dt = freq as f64 / SAMPLE_RATE as f64;
+    let mut phase = 0.0f64;
+    let mut out = Vec::with_capacity(n);
+    for _ in 0..n {
+        out.push(gen(phase, dt));
+        phase = (phase + dt).rem_euclid(1.0);
+    }
+    out
+}
+
+/// Render a fixed-frequency oscillator generated at `mode`'s oversampling factor and
+/// decimated back to the base rate via the same half-band `Oversampler` the engine uses for
+/// nonlinear effects. The oscillator is the *signal source* (the oversampler's input is
+/// unused), so this is classic oversampled generation: synthesize fast, low-pass, decimate.
+/// `square`/`antialias` pick which generator runs at the oversampled rate.
+fn render_osc_oversampled(
+    square: bool,
+    antialias: bool,
+    mode: OversamplingMode,
+    freq: f32,
+    n: usize,
+) -> Vec<f32> {
+    let factor = mode.factor();
+    let dt = freq as f64 / SAMPLE_RATE as f64;
+    let sub_dt = dt / factor as f64; // phase step at the oversampled rate
+    let mut phase = 0.0f64;
+    let mut os = Oversampler::new(mode);
+
+    let warmup = 4096usize;
+    let mut out = Vec::with_capacity(n);
+    for i in 0..(warmup + n) {
+        let s = os.process(0.0, |_| {
+            let v = if square {
+                if antialias {
+                    polyblep_square(phase, sub_dt)
+                } else if phase < 0.5 {
+                    1.0
+                } else {
+                    -1.0
+                }
+            } else if antialias {
+                polyblep_saw(phase, sub_dt)
+            } else {
+                (2.0 * phase - 1.0) as f32
+            };
+            phase = (phase + sub_dt).rem_euclid(1.0);
+            v
+        });
+        if i >= warmup {
+            out.push(s);
+        }
+    }
+    out
+}
+
+/// Render an exponential frequency sweep, evaluating `gen(phase, phase_inc)` per sample.
+/// The phase is integrated by a proper accumulator so the sweep itself introduces no
+/// artifacts (unlike the oscillator's time-based phase, which jumps when frequency changes).
+fn render_sweep(
+    start_hz: f32,
+    end_hz: f32,
+    dur_s: f32,
+    mut gen: impl FnMut(f64, f64) -> f32,
+) -> Vec<f32> {
+    let n = (dur_s * SAMPLE_RATE) as usize;
+    let ratio = (end_hz / start_hz) as f64;
+    let mut phase = 0.0f64;
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let p = i as f64 / n as f64;
+        let freq = start_hz as f64 * ratio.powf(p);
+        let dt = freq / SAMPLE_RATE as f64;
+        out.push(gen(phase, dt));
+        phase = (phase + dt).rem_euclid(1.0);
+    }
+    out
+}
+
+/// Render a sine sweep pushed through a tanh nonlinearity at the given oversampling mode.
+/// Higher oversampling should visibly shrink the downward-sweeping alias bands.
+fn render_nonlinear_sweep(
+    mode: OversamplingMode,
+    start_hz: f32,
+    end_hz: f32,
+    dur_s: f32,
+) -> Vec<f32> {
+    let n = (dur_s * SAMPLE_RATE) as usize;
+    let ratio = (end_hz / start_hz) as f64;
+    let mut phase = 0.0f64;
+    let mut os = Oversampler::new(mode);
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let p = i as f64 / n as f64;
+        let freq = start_hz as f64 * ratio.powf(p);
+        let dt = freq / SAMPLE_RATE as f64;
+        let input = (TAU * phase).sin() as f32 * 0.8;
+        out.push(os.process(input, |x| (x * DRIVE).tanh()));
+        phase = (phase + dt).rem_euclid(1.0);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// FFT analysis (Hann window -> rustfft -> magnitude -> dB), mirroring the recipe in
+// src/visualization/spectrogram.rs but without the GUI-gated `visualization` feature.
+// ---------------------------------------------------------------------------
+
+fn hann(i: usize, n: usize) -> f32 {
+    0.5 * (1.0 - (TAU as f32 * i as f32 / n as f32).cos())
+}
+
+/// Magnitude spectrum of the last `fft_size` samples, in dB, peak-normalized to 0 dB.
+/// Bin `i` corresponds to frequency `i * SAMPLE_RATE / fft_size`.
+fn spectrum_db(samples: &[f32], fft_size: usize, planner: &mut FftPlanner<f32>) -> Vec<f32> {
+    let start = samples.len().saturating_sub(fft_size);
+    let frame = &samples[start..];
+    let mut buf: Vec<Complex<f32>> = (0..fft_size)
+        .map(|i| {
+            let s = frame.get(i).copied().unwrap_or(0.0);
+            Complex::new(s * hann(i, fft_size), 0.0)
+        })
+        .collect();
+
+    let fft = planner.plan_fft_forward(fft_size);
+    fft.process(&mut buf);
+
+    let num_bins = fft_size / 2;
+    let mags: Vec<f32> = buf[..num_bins]
+        .iter()
+        .map(|c| (c.re * c.re + c.im * c.im).sqrt())
+        .collect();
+    let max = mags.iter().copied().fold(1e-30f32, f32::max);
+    mags.iter()
+        .map(|m| 20.0 * (m / max + 1e-12).log10())
+        .collect()
+}
+
+/// Sliding-window spectrogram. Returns one column per hop; each column is `fft_size/2`
+/// magnitudes in dB, normalized so the global peak across the whole signal is 0 dB.
+fn spectrogram(
+    samples: &[f32],
+    fft_size: usize,
+    hop: usize,
+    planner: &mut FftPlanner<f32>,
+) -> Vec<Vec<f32>> {
+    let num_bins = fft_size / 2;
+    let fft = planner.plan_fft_forward(fft_size);
+
+    let mut cols: Vec<Vec<f32>> = Vec::new();
+    let mut global_max = 1e-30f32;
+    let mut start = 0;
+    while start + fft_size <= samples.len() {
+        let frame = &samples[start..start + fft_size];
+        let mut buf: Vec<Complex<f32>> = (0..fft_size)
+            .map(|i| Complex::new(frame[i] * hann(i, fft_size), 0.0))
+            .collect();
+        fft.process(&mut buf);
+        let mags: Vec<f32> = buf[..num_bins]
+            .iter()
+            .map(|c| (c.re * c.re + c.im * c.im).sqrt())
+            .collect();
+        for &m in &mags {
+            if m > global_max {
+                global_max = m;
+            }
+        }
+        cols.push(mags);
+        start += hop;
+    }
+
+    for mags in &mut cols {
+        for m in mags.iter_mut() {
+            *m = 20.0 * (*m / global_max + 1e-12).log10();
+        }
+    }
+    cols
+}
+
+// ---------------------------------------------------------------------------
+// Plotting
+// ---------------------------------------------------------------------------
+
+/// "Hot" colormap: black -> red -> yellow -> white as `t` goes 0..1 (louder = brighter).
+fn heat(t: f32) -> (u8, u8, u8) {
+    let r = (t * 3.0).clamp(0.0, 1.0);
+    let g = (t * 3.0 - 1.0).clamp(0.0, 1.0);
+    let b = (t * 3.0 - 2.0).clamp(0.0, 1.0);
+    ((r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8)
+}
+
+fn plot_spectrum(
+    path: &Path,
+    title: &str,
+    spec_db: &[f32],
+    fft_size: usize,
+    markers: Option<f32>,
+) -> Result<(), Box<dyn Error>> {
+    let root = BitMapBackend::new(path, (1200, 600)).into_drawing_area();
+    root.fill(&WHITE)?;
+    let nyquist = SAMPLE_RATE / 2.0;
+
+    let mut chart = ChartBuilder::on(&root)
+        .caption(title, ("sans-serif", 24))
+        .margin(15)
+        .x_label_area_size(45)
+        .y_label_area_size(60)
+        .build_cartesian_2d(0f32..nyquist, -120f32..5f32)?;
+
+    chart
+        .configure_mesh()
+        .x_desc("Frequency (Hz)")
+        .y_desc("Magnitude (dB)")
+        .draw()?;
+
+    // Vertical markers at the true harmonic frequencies. Real partials land on these lines;
+    // aliased components land between them.
+    if let Some(f0) = markers {
+        let mut k = 1;
+        while (k as f32) * f0 < nyquist {
+            let f = (k as f32) * f0;
+            chart.draw_series(std::iter::once(PathElement::new(
+                vec![(f, -120f32), (f, 5f32)],
+                ShapeStyle::from(RGBColor(0, 150, 0).mix(0.25)).stroke_width(1),
+            )))?;
+            k += 1;
+        }
+    }
+
+    let bin_hz = SAMPLE_RATE / fft_size as f32;
+    chart.draw_series(LineSeries::new(
+        spec_db
+            .iter()
+            .enumerate()
+            .map(|(i, &db)| (i as f32 * bin_hz, db)),
+        BLUE.stroke_width(1),
+    ))?;
+
+    root.present()?;
+    Ok(())
+}
+
+fn spectrogram_rgb(cols: &[Vec<f32>], num_bins: usize, w: u32, h: u32) -> Vec<u8> {
+    let num_cols = cols.len().max(1);
+    // Display floor: bins at/below this map to black so only the stronger partials and
+    // alias lines show. -72 dB keeps the leakage background dark while preserving foldback.
+    let floor = -72.0f32;
+    let mut buf = vec![0u8; (w * h * 3) as usize];
+    let h_div = (h.max(2) - 1) as f32;
+    for py in 0..h {
+        // py = 0 is the top of the image, which we map to Nyquist (high frequency).
+        let frac = 1.0 - (py as f32) / h_div;
+        let bin = ((frac * (num_bins as f32 - 1.0)).round() as usize).min(num_bins - 1);
+        for px in 0..w {
+            let col = (((px as f32 / w as f32) * num_cols as f32) as usize).min(num_cols - 1);
+            let db = cols[col].get(bin).copied().unwrap_or(floor);
+            let t = ((db - floor) / (0.0 - floor)).clamp(0.0, 1.0);
+            let (r, g, b) = heat(t);
+            let idx = ((py * w + px) * 3) as usize;
+            buf[idx] = r;
+            buf[idx + 1] = g;
+            buf[idx + 2] = b;
+        }
+    }
+    buf
+}
+
+fn plot_spectrogram(
+    path: &Path,
+    title: &str,
+    cols: &[Vec<f32>],
+    fft_size: usize,
+    dur_s: f32,
+) -> Result<(), Box<dyn Error>> {
+    let root = BitMapBackend::new(path, (1200, 600)).into_drawing_area();
+    root.fill(&WHITE)?;
+    let nyquist = SAMPLE_RATE / 2.0;
+
+    let mut chart = ChartBuilder::on(&root)
+        .caption(title, ("sans-serif", 24))
+        .margin(15)
+        .x_label_area_size(45)
+        .y_label_area_size(60)
+        .build_cartesian_2d(0f32..dur_s, 0f32..nyquist)?;
+
+    chart
+        .configure_mesh()
+        .disable_mesh()
+        .x_desc("Time (s)")
+        .y_desc("Frequency (Hz)")
+        .draw()?;
+
+    let (w_px, h_px) = chart.plotting_area().dim_in_pixel();
+    let img = spectrogram_rgb(cols, fft_size / 2, w_px, h_px);
+    let elem = BitMapElement::with_owned_buffer((0f32, nyquist), (w_px, h_px), img)
+        .ok_or("spectrogram bitmap buffer size mismatch")?;
+    chart.draw_series(std::iter::once(elem))?;
+
+    root.present()?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// WAV export (for cross-checking in an external meter)
+// ---------------------------------------------------------------------------
+
+fn write_wav(path: &Path, samples: &[f32]) -> Result<(), Box<dyn Error>> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: SAMPLE_RATE as u32,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
+    let mut writer = hound::WavWriter::create(path, spec)?;
+    for &s in samples {
+        writer.write_sample(s)?;
+    }
+    writer.finalize()?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Misc helpers / CLI
+// ---------------------------------------------------------------------------
+
+fn waveform_name(w: Waveform) -> &'static str {
+    match w {
+        Waveform::Sine => "sine",
+        Waveform::Square => "square",
+        Waveform::Saw => "saw",
+        Waveform::Triangle => "triangle",
+        Waveform::RingMod => "ringmod",
+        Waveform::Noise => "noise",
+    }
+}
+
+fn parse_waveform(s: &str) -> Option<Waveform> {
+    match s.to_ascii_lowercase().as_str() {
+        "sine" => Some(Waveform::Sine),
+        "square" => Some(Waveform::Square),
+        "saw" => Some(Waveform::Saw),
+        "triangle" => Some(Waveform::Triangle),
+        "ringmod" | "ring_mod" => Some(Waveform::RingMod),
+        "noise" => Some(Waveform::Noise),
+        _ => None,
+    }
+}
+
+/// Harmonic markers only make sense for the pitched, harmonically-structured waveforms.
+fn marker_for(w: Waveform, f0: f32) -> Option<f32> {
+    match w {
+        Waveform::Sine | Waveform::Square | Waveform::Saw | Waveform::Triangle => Some(f0),
+        Waveform::RingMod | Waveform::Noise => None,
+    }
+}
+
+/// Parse `--waveform <name> --freq <hz>` for single-shot mode. Returns None if not requested.
+fn parse_single_shot(args: &[String]) -> Option<(Waveform, f32)> {
+    let mut waveform = None;
+    let mut freq = None;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--waveform" => {
+                waveform = args.get(i + 1).and_then(|s| parse_waveform(s));
+                i += 2;
+            }
+            "--freq" => {
+                freq = args.get(i + 1).and_then(|s| s.parse::<f32>().ok());
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    match (waveform, freq) {
+        (Some(w), Some(f)) => Some((w, f)),
+        _ => None,
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let out = PathBuf::from("aliasing-plots");
+    std::fs::create_dir_all(&out)?;
+    let mut planner = FftPlanner::<f32>::new();
+
+    const SPEC_FFT: usize = 1 << 14; // 16384
+    const SPEC_N: usize = 1 << 15; // 32768 captured samples
+    const SG_FFT: usize = 2048;
+    const SG_HOP: usize = 512;
+    const SWEEP_DUR: f32 = 5.0;
+
+    let args: Vec<String> = std::env::args().collect();
+
+    // Single-shot: render just one spectrum and exit.
+    if let Some((w, freq)) = parse_single_shot(&args) {
+        let sig = render_osc_tone(w, freq, SPEC_N, true);
+        let db = spectrum_db(&sig, SPEC_FFT, &mut planner);
+        let name = format!("spectrum-{}-{}hz.png", waveform_name(w), freq as u32);
+        let title = format!(
+            "{} @ {:.0} Hz (sr {:.0} Hz)",
+            waveform_name(w),
+            freq,
+            SAMPLE_RATE
+        );
+        plot_spectrum(&out.join(&name), &title, &db, SPEC_FFT, marker_for(w, freq))?;
+        println!("Wrote {}", out.join(&name).display());
+        return Ok(());
+    }
+
+    // ---- Full default suite ----
+    println!("Rendering aliasing plots to {}", out.display());
+
+    // 1) Steady-tone spectra at a high fundamental where harmonics fold.
+    let f0 = 2200.0f32;
+
+    // 1a) Controlled comparison: identical (jitter-free) phase source, naive vs band-limited.
+    // Real partials land on the green harmonic markers; aliasing shows as spikes between them.
+    type ToneGen = (&'static str, &'static str, Box<dyn FnMut(f64, f64) -> f32>);
+    let tone_gens: Vec<ToneGen> = vec![
+        (
+            "sine",
+            "sine (reference, band-limited by nature)",
+            Box::new(|phase, _| (TAU * phase).sin() as f32),
+        ),
+        (
+            "saw-naive",
+            "saw (NAIVE / aliased)",
+            Box::new(|phase, _| (2.0 * phase - 1.0) as f32),
+        ),
+        (
+            "saw-bandlimited",
+            "saw (PolyBLEP band-limited)",
+            Box::new(polyblep_saw),
+        ),
+        (
+            "square-naive",
+            "square (NAIVE / aliased)",
+            Box::new(|phase, _| if phase < 0.5 { 1.0 } else { -1.0 }),
+        ),
+        (
+            "square-bandlimited",
+            "square (PolyBLEP band-limited)",
+            Box::new(polyblep_square),
+        ),
+    ];
+    for (slug, label, gen) in tone_gens {
+        let sig = render_tone(f0, SPEC_N, gen);
+        let db = spectrum_db(&sig, SPEC_FFT, &mut planner);
+        let name = format!("spectrum-{}-{}hz.png", slug, f0 as u32);
+        let title = format!("{} @ {:.0} Hz, sr {:.0} Hz", label, f0, SAMPLE_RATE);
+        plot_spectrum(&out.join(&name), &title, &db, SPEC_FFT, Some(f0))?;
+        println!("  wrote {}", name);
+    }
+
+    // 1b) The shipping Oscillator path (all 6 waveforms, as actually used by the engine).
+    // Note: the Oscillator reconstructs phase from f32 time, which adds its own low-level
+    // broadband floor on top of any aliasing — these are the "as-shipped" reality, not the
+    // isolated band-limiting algorithm shown in 1a.
+    for w in [
+        Waveform::Sine,
+        Waveform::Saw,
+        Waveform::Square,
+        Waveform::Triangle,
+        Waveform::RingMod,
+        Waveform::Noise,
+    ] {
+        let sig = render_osc_tone(w, f0, SPEC_N, true);
+        let db = spectrum_db(&sig, SPEC_FFT, &mut planner);
+        let name = format!("osc-{}-{}hz.png", waveform_name(w), f0 as u32);
+        let title = format!(
+            "{} (Oscillator, as shipped) @ {:.0} Hz, sr {:.0} Hz",
+            waveform_name(w),
+            f0,
+            SAMPLE_RATE
+        );
+        plot_spectrum(&out.join(&name), &title, &db, SPEC_FFT, marker_for(w, f0))?;
+        println!("  wrote {}", name);
+    }
+
+    // 1c) The same Oscillator with anti-aliasing turned OFF (set_antialias(false)) for the
+    // waveforms that have a band-limited variant. Compare each against its `osc-*` twin above.
+    for w in [Waveform::Saw, Waveform::Square, Waveform::Triangle] {
+        let sig = render_osc_tone(w, f0, SPEC_N, false);
+        let db = spectrum_db(&sig, SPEC_FFT, &mut planner);
+        let name = format!("osc-{}-naive-{}hz.png", waveform_name(w), f0 as u32);
+        let title = format!(
+            "{} (Oscillator, antialias OFF) @ {:.0} Hz, sr {:.0} Hz",
+            waveform_name(w),
+            f0,
+            SAMPLE_RATE
+        );
+        plot_spectrum(&out.join(&name), &title, &db, SPEC_FFT, marker_for(w, f0))?;
+        println!("  wrote {}", name);
+    }
+
+    // 1d) Oversampled generation: synthesize the oscillator at 2x/4x and decimate through the
+    // engine's half-band filters. For the naive generator this is an alternative to PolyBLEP
+    // (aliasing shrinks as the factor rises); for the PolyBLEP generator it shrinks the
+    // residual aliasing PolyBLEP leaves behind. Compare each triplet against its Off plot.
+    for (square, wave) in [(false, "saw"), (true, "square")] {
+        for (antialias, meth, meth_label) in [(false, "naive", "naive"), (true, "blep", "PolyBLEP")]
+        {
+            for (mode, ms) in [
+                (OversamplingMode::Off, "off"),
+                (OversamplingMode::X2, "2x"),
+                (OversamplingMode::X4, "4x"),
+            ] {
+                let sig = render_osc_oversampled(square, antialias, mode, f0, SPEC_N);
+                let db = spectrum_db(&sig, SPEC_FFT, &mut planner);
+                let name = format!("spectrum-{}-{}-os-{}-{}hz.png", wave, meth, ms, f0 as u32);
+                let title = format!(
+                    "{} ({}) — {} oversampling @ {:.0} Hz, sr {:.0} Hz",
+                    wave, meth_label, ms, f0, SAMPLE_RATE
+                );
+                plot_spectrum(&out.join(&name), &title, &db, SPEC_FFT, Some(f0))?;
+                println!("  wrote {}", name);
+            }
+        }
+    }
+
+    // 2) Sweep spectrograms (the foldback picture). Oscillators: naive vs band-limited.
+    let sweep_start = 200.0f32;
+    let sweep_end = 8000.0f32;
+
+    let osc_sweeps: [(&str, Vec<f32>); 4] = [
+        (
+            "saw-naive",
+            render_sweep(sweep_start, sweep_end, SWEEP_DUR, |phase, _| {
+                (2.0 * phase - 1.0) as f32
+            }),
+        ),
+        (
+            "saw-bandlimited",
+            render_sweep(sweep_start, sweep_end, SWEEP_DUR, |phase, dt| {
+                polyblep_saw(phase, dt)
+            }),
+        ),
+        (
+            "square-naive",
+            render_sweep(sweep_start, sweep_end, SWEEP_DUR, |phase, _| {
+                if phase < 0.5 {
+                    1.0
+                } else {
+                    -1.0
+                }
+            }),
+        ),
+        (
+            "square-bandlimited",
+            render_sweep(sweep_start, sweep_end, SWEEP_DUR, |phase, dt| {
+                polyblep_square(phase, dt)
+            }),
+        ),
+    ];
+
+    for (label, sig) in &osc_sweeps {
+        let cols = spectrogram(sig, SG_FFT, SG_HOP, &mut planner);
+        let name = format!("spectrogram-{}-sweep.png", label);
+        let title = format!(
+            "{} sweep {:.0}-{:.0} Hz, sr {:.0} Hz",
+            label, sweep_start, sweep_end, SAMPLE_RATE
+        );
+        plot_spectrogram(&out.join(&name), &title, &cols, SG_FFT, SWEEP_DUR)?;
+        write_wav(&out.join(format!("{}-sweep.wav", label)), sig)?;
+        println!("  wrote {} (+wav)", name);
+    }
+
+    // 3) Nonlinear (tanh) sweep at Off / 2x / 4x oversampling.
+    let nl_start = 1000.0f32;
+    let nl_end = 20000.0f32;
+    for (mode, label) in [
+        (OversamplingMode::Off, "off"),
+        (OversamplingMode::X2, "2x"),
+        (OversamplingMode::X4, "4x"),
+    ] {
+        let sig = render_nonlinear_sweep(mode, nl_start, nl_end, SWEEP_DUR);
+        let cols = spectrogram(&sig, SG_FFT, SG_HOP, &mut planner);
+        let name = format!("spectrogram-tanh-{}.png", label);
+        let title = format!(
+            "tanh(drive={:.0}) sine sweep {:.0}-{:.0} Hz, oversampling {}",
+            DRIVE, nl_start, nl_end, label
+        );
+        plot_spectrogram(&out.join(&name), &title, &cols, SG_FFT, SWEEP_DUR)?;
+        write_wav(&out.join(format!("tanh-{}-sweep.wav", label)), &sig)?;
+        println!("  wrote {} (+wav)", name);
+    }
+
+    println!(
+        "Done. Open the PNGs in {} to inspect aliasing.",
+        out.display()
+    );
+    Ok(())
+}

--- a/src/gen/oscillator.rs
+++ b/src/gen/oscillator.rs
@@ -13,6 +13,11 @@ pub struct Oscillator {
     pub volume: f32,
     pub modulator_frequency_hz: f32,
     pub enabled: bool,
+    /// When `false`, Square/Saw/Triangle are generated naively (no band-limiting), so the
+    /// aliasing that the band-limited path suppresses becomes audible/visible for comparison.
+    /// Sine, RingMod, and Noise are unaffected (they have no band-limited variant here).
+    /// Defaults to `true`.
+    pub antialias: bool,
 }
 
 impl Oscillator {
@@ -26,6 +31,7 @@ impl Oscillator {
             volume: 1.0,
             modulator_frequency_hz: frequency_hz * 0.5, // Default modulator at half carrier frequency
             enabled: true,
+            antialias: true,
         }
     }
 
@@ -144,6 +150,34 @@ impl Oscillator {
         self.generative_waveform_time_based(2, 2.0)
     }
 
+    // Naive (non-band-limited) variants used when `antialias` is false. These generate the
+    // discontinuous waveform directly from the phase, so harmonics above Nyquist fold back
+    // as aliasing — useful for hearing/seeing exactly what the band-limited path removes.
+    fn naive_square_time_based(&self) -> f32 {
+        let (phase, _) = self.polyblep_phase();
+        if phase < 0.5 {
+            1.0
+        } else {
+            -1.0
+        }
+    }
+
+    fn naive_saw_time_based(&self) -> f32 {
+        let (phase, _) = self.polyblep_phase();
+        (2.0 * phase - 1.0) as f32
+    }
+
+    fn naive_triangle_time_based(&self) -> f32 {
+        let (phase, _) = self.polyblep_phase();
+        let p = phase as f32;
+        // /\ shape over one period: -1 at phase 0, +1 at phase 0.5, back to -1 at phase 1.
+        if p < 0.5 {
+            4.0 * p - 1.0
+        } else {
+            3.0 - 4.0 * p
+        }
+    }
+
     fn ring_mod_wave_time_based(&self) -> f32 {
         let carrier = self.calculate_sine_output_from_freq(self.frequency_hz);
         let modulator = self.calculate_sine_output_from_freq(self.modulator_frequency_hz);
@@ -195,6 +229,16 @@ impl Oscillator {
         self.enabled
     }
 
+    /// Enable or disable band-limiting for Square/Saw/Triangle. When disabled, these
+    /// waveforms are generated naively and will alias above Nyquist.
+    pub fn set_antialias(&mut self, antialias: bool) {
+        self.antialias = antialias;
+    }
+
+    pub fn is_antialiased(&self) -> bool {
+        self.antialias
+    }
+
     pub fn tick(&mut self, current_time: f64) -> f32 {
         if !self.enabled {
             return 0.0;
@@ -212,9 +256,27 @@ impl Oscillator {
 
         let raw_output = match self.waveform {
             Waveform::Sine => self.sine_wave_time_based(),
-            Waveform::Square => self.square_wave_time_based(),
-            Waveform::Saw => self.saw_wave_time_based(),
-            Waveform::Triangle => self.triangle_wave_time_based(),
+            Waveform::Square => {
+                if self.antialias {
+                    self.square_wave_time_based()
+                } else {
+                    self.naive_square_time_based()
+                }
+            }
+            Waveform::Saw => {
+                if self.antialias {
+                    self.saw_wave_time_based()
+                } else {
+                    self.naive_saw_time_based()
+                }
+            }
+            Waveform::Triangle => {
+                if self.antialias {
+                    self.triangle_wave_time_based()
+                } else {
+                    self.naive_triangle_time_based()
+                }
+            }
             Waveform::RingMod => self.ring_mod_wave_time_based(),
             Waveform::Noise => self.noise_wave_time_based(),
         };

--- a/tests/aliasing.rs
+++ b/tests/aliasing.rs
@@ -1,0 +1,234 @@
+//! Numeric guardrail for oscillator anti-aliasing.
+//!
+//! Companion to `examples/aliasing_plots.rs` (which renders the visual proof). These tests
+//! assert that the band-limited PolyBLEP generators put dramatically less energy into
+//! aliased (inter-harmonic) bins than the naive baselines.
+//!
+//! The signals are generated with *coherent* sampling — the fundamental fits a whole number
+//! of cycles in the analysis window — so a plain rectangular-window DFT has no spectral
+//! leakage and every component lands on an exact bin. That lets us measure alias energy
+//! without rustfft or windowing.
+
+use std::f64::consts::TAU;
+
+use gooey::envelope::ADSRConfig;
+use gooey::gen::polyblep::{polyblep_saw, polyblep_square};
+use gooey::gen::{Oscillator, Waveform};
+use gooey::utils::{Oversampler, OversamplingMode};
+
+const SAMPLE_RATE: f32 = 48_000.0;
+const N: usize = 8192;
+/// Cycles-per-window of the fundamental. Prime, and chosen so `SAMPLE_RATE / f0` is
+/// non-integer, which keeps folded aliases off the true harmonic bins.
+const J: usize = 367;
+
+fn fundamental_hz() -> f32 {
+    J as f32 * SAMPLE_RATE / N as f32
+}
+
+/// Power in DFT bin `k` (|X_k|^2) via direct evaluation.
+fn bin_power(x: &[f32], k: usize) -> f64 {
+    let n = x.len();
+    let step = TAU * k as f64 / n as f64;
+    let (mut re, mut im) = (0.0_f64, 0.0_f64);
+    for (i, &s) in x.iter().enumerate() {
+        let phase = step * i as f64;
+        re += s as f64 * phase.cos();
+        im -= s as f64 * phase.sin();
+    }
+    re * re + im * im
+}
+
+/// Ratio of aliased/non-harmonic power to true-harmonic power.
+///
+/// `signal_bins` are the bins of the intended harmonics. Total positive-frequency power comes
+/// from Parseval (`sum|X_k|^2 = N * sum x^2`), so alias power = total − DC − harmonics.
+fn alias_to_signal_ratio(x: &[f32], signal_bins: &[usize]) -> f64 {
+    let n = x.len();
+    let sumsq: f64 = x.iter().map(|&s| (s as f64) * (s as f64)).sum();
+    let dc = {
+        let s: f64 = x.iter().map(|&v| v as f64).sum();
+        s * s
+    };
+    let total_positive = (n as f64 * sumsq - dc) / 2.0;
+    let signal: f64 = signal_bins.iter().map(|&k| bin_power(x, k)).sum();
+    let alias = (total_positive - signal).max(0.0);
+    alias / signal.max(1e-30)
+}
+
+fn render(naive: bool, square: bool) -> Vec<f32> {
+    let dt = fundamental_hz() as f64 / SAMPLE_RATE as f64;
+    let mut phase = 0.0_f64;
+    let mut out = Vec::with_capacity(N);
+    for _ in 0..N {
+        let s = match (naive, square) {
+            (true, false) => (2.0 * phase - 1.0) as f32,
+            (true, true) => {
+                if phase < 0.5 {
+                    1.0
+                } else {
+                    -1.0
+                }
+            }
+            (false, false) => polyblep_saw(phase, dt),
+            (false, true) => polyblep_square(phase, dt),
+        };
+        out.push(s);
+        phase = (phase + dt).rem_euclid(1.0);
+    }
+    out
+}
+
+/// Harmonic bins up to Nyquist. Saw uses all harmonics; square uses odd harmonics only.
+fn signal_bins(square: bool) -> Vec<usize> {
+    let nyquist_bin = N / 2;
+    (1..)
+        .map(|m| (m, m * J))
+        .take_while(|&(_, bin)| bin <= nyquist_bin)
+        .filter(|&(m, _)| !square || m % 2 == 1)
+        .map(|(_, bin)| bin)
+        .collect()
+}
+
+#[test]
+fn polyblep_saw_suppresses_aliasing() {
+    let bins = signal_bins(false);
+    let naive = alias_to_signal_ratio(&render(true, false), &bins);
+    let bandlimited = alias_to_signal_ratio(&render(false, false), &bins);
+    println!(
+        "saw @ {:.1} Hz: naive alias/signal = {:.4}, band-limited = {:.4}",
+        fundamental_hz(),
+        naive,
+        bandlimited
+    );
+
+    // Sanity: the naive baseline must actually alias, or the test setup is wrong.
+    assert!(
+        naive > 0.02,
+        "naive saw should show measurable aliasing, got {naive}"
+    );
+    // PolyBLEP must cut alias energy by at least ~6 dB versus naive (it is typically far more),
+    // and leave the band-limited output essentially clean.
+    assert!(
+        bandlimited < naive * 0.25,
+        "band-limited saw alias/signal {bandlimited} not <0.25x naive {naive}"
+    );
+    assert!(
+        bandlimited < 0.01,
+        "band-limited saw alias/signal {bandlimited} should be near-clean (<0.01)"
+    );
+}
+
+/// Render a coherent tone straight from the shipping `Oscillator`, exercising the public
+/// `set_antialias` toggle end-to-end. The fundamental does a whole number of cycles per N
+/// samples, so the analysis stays coherent regardless of the warmup offset.
+fn render_osc(waveform: Waveform, antialias: bool) -> Vec<f32> {
+    let mut osc = Oscillator::new(SAMPLE_RATE, fundamental_hz());
+    osc.waveform = waveform;
+    osc.set_antialias(antialias);
+    osc.set_adsr(ADSRConfig::new(0.0005, 0.0005, 1.0, 0.0005));
+    osc.set_volume(1.0);
+    osc.trigger(0.0);
+
+    let warmup = 2048usize;
+    let mut out = Vec::with_capacity(N);
+    for i in 0..(warmup + N) {
+        let s = osc.tick(i as f64 / SAMPLE_RATE as f64);
+        if i >= warmup {
+            out.push(s);
+        }
+    }
+    out
+}
+
+#[test]
+fn oscillator_antialias_toggle_changes_aliasing() {
+    // Defaults to band-limited.
+    assert!(Oscillator::new(SAMPLE_RATE, 440.0).is_antialiased());
+
+    let bins = signal_bins(false);
+    let antialiased = alias_to_signal_ratio(&render_osc(Waveform::Saw, true), &bins);
+    let naive = alias_to_signal_ratio(&render_osc(Waveform::Saw, false), &bins);
+    println!(
+        "Oscillator saw @ {:.1} Hz: antialias=on alias/signal = {:.4}, antialias=off = {:.4}",
+        fundamental_hz(),
+        antialiased,
+        naive
+    );
+
+    // Turning anti-aliasing off must measurably increase alias energy.
+    assert!(
+        naive > antialiased * 2.0,
+        "naive oscillator saw ({naive}) should alias far more than band-limited ({antialiased})"
+    );
+}
+
+/// Generate a naive square at `mode`'s oversampling factor and decimate via the engine's
+/// half-band `Oversampler` (the oscillator is the signal source; the input is unused).
+fn render_oversampled_naive_square(mode: OversamplingMode) -> Vec<f32> {
+    let sub_dt = (fundamental_hz() as f64 / SAMPLE_RATE as f64) / mode.factor() as f64;
+    let mut phase = 0.0f64;
+    let mut os = Oversampler::new(mode);
+
+    let warmup = 4096usize;
+    let mut out = Vec::with_capacity(N);
+    for i in 0..(warmup + N) {
+        let s = os.process(0.0, |_| {
+            let v = if phase < 0.5 { 1.0f32 } else { -1.0 };
+            phase = (phase + sub_dt).rem_euclid(1.0);
+            v
+        });
+        if i >= warmup {
+            out.push(s);
+        }
+    }
+    out
+}
+
+#[test]
+fn oversampling_reduces_naive_square_aliasing() {
+    let bins = signal_bins(true); // square: odd harmonics
+    let off = alias_to_signal_ratio(
+        &render_oversampled_naive_square(OversamplingMode::Off),
+        &bins,
+    );
+    let x4 = alias_to_signal_ratio(
+        &render_oversampled_naive_square(OversamplingMode::X4),
+        &bins,
+    );
+    println!("naive square generation: oversampling off alias/signal = {off:.4}, 4x = {x4:.4}");
+
+    // Off should be the fully-aliased naive baseline.
+    assert!(off > 0.02, "naive square (off) should alias, got {off}");
+    // Oversampled generation must cut alias energy substantially.
+    assert!(
+        x4 < off * 0.5,
+        "4x oversampled square ({x4}) should roughly halve naive alias energy ({off}) or better"
+    );
+}
+
+#[test]
+fn polyblep_square_suppresses_aliasing() {
+    let bins = signal_bins(true);
+    let naive = alias_to_signal_ratio(&render(true, true), &bins);
+    let bandlimited = alias_to_signal_ratio(&render(false, true), &bins);
+    println!(
+        "square @ {:.1} Hz: naive alias/signal = {:.4}, band-limited = {:.4}",
+        fundamental_hz(),
+        naive,
+        bandlimited
+    );
+
+    assert!(
+        naive > 0.02,
+        "naive square should show measurable aliasing, got {naive}"
+    );
+    assert!(
+        bandlimited < naive * 0.25,
+        "band-limited square alias/signal {bandlimited} not <0.25x naive {naive}"
+    );
+    assert!(
+        bandlimited < 0.01,
+        "band-limited square alias/signal {bandlimited} should be near-clean (<0.01)"
+    );
+}


### PR DESCRIPTION
Adds `examples/aliasing_plots.rs` (behind a new `plots` cargo feature) that renders spectrum and spectrogram PNGs — comparing naive vs PolyBLEP oscillators, oversampled generation (Off/2x/4x), and the nonlinear tanh path — into a gitignored `aliasing-plots/` directory so aliasing can be seen and proven rather than just heard. Adds an `antialias` toggle to `Oscillator` (`set_antialias`/`is_antialiased`, default on) so Square/Saw/Triangle can be generated naively for direct comparison. Adds `tests/aliasing.rs` numeric guardrails asserting that band-limiting and oversampling substantially reduce alias energy. Pulls in `plotters` and reuses `rustfft`/`hound` only under the optional `plots` feature, leaving default builds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)