### PR TITLE
Add gooey_engine_loop_set_position to preserve loop phase across swaps

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5471,6 +5471,24 @@ pub unsafe extern "C" fn gooey_engine_loop_restart(engine: *mut GooeyEngine, cha
     }
 }
 
+/// Set a loop channel's playhead to a normalized `[0, 1]` position within its
+/// loop region. Clamped into the active loop window; no-op if no buffer is loaded.
+/// Inverse of `gooey_engine_loop_get_position`. Lets a caller swap a channel's
+/// buffer and resume at the same phase instead of restarting at the loop start.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_set_position(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    normalized: f32,
+) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.set_position(channel as usize, normalized);
+    }
+}
+
 /// Get a loop channel's current playhead as a normalized `[0, 1]` position.
 /// Returns 0.0 for a null engine or empty/out-of-range channel.
 ///

--- a/src/mixer/loop_channel.rs
+++ b/src/mixer/loop_channel.rs
@@ -154,6 +154,18 @@ impl LoopChannel {
         }
     }
 
+    /// Set the playhead to a normalized [0, 1] position of the full buffer,
+    /// clamped into the active loop window. Inverse of `position_normalized()`.
+    /// No-op if no buffer is loaded.
+    pub fn set_position(&mut self, normalized: f32) {
+        if let Some(buffer) = &self.buffer {
+            let len = buffer.len() as f64;
+            let (lo, hi) = self.loop_bounds(len);
+            let target = normalized.clamp(0.0, 1.0) as f64 * len;
+            self.cursor = target.clamp(lo, hi);
+        }
+    }
+
     /// Set the mute/solo gate target. Called by the [`Mixer`] each block once
     /// the cross-channel solo state is known.
     pub(crate) fn set_active(&mut self, audible: bool) {
@@ -256,6 +268,27 @@ mod tests {
         ch.set_buffer(ramp_buffer(100));
         // cursor should be at 0.5 * 100 = 50.
         assert!((ch.position_normalized() - 0.5).abs() < 1e-3);
+    }
+
+    #[test]
+    fn set_position_round_trips() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_buffer(ramp_buffer(100));
+        ch.set_position(0.42);
+        assert!((ch.position_normalized() - 0.42).abs() < 1e-2);
+    }
+
+    #[test]
+    fn set_position_clamps_into_loop_window() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_buffer(ramp_buffer(100));
+        ch.set_loop_start(0.25);
+        ch.set_loop_end(0.75);
+        ch.set_position(0.9); // outside window -> clamped to hi
+        let p = ch.position_normalized();
+        assert!((0.25..=0.75 + 1e-3).contains(&p), "pos {p} out of window");
+        ch.set_position(0.0); // below window -> clamped to lo
+        assert!(ch.position_normalized() >= 0.25 - 1e-3);
     }
 
     #[test]

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -143,6 +143,12 @@ impl Mixer {
         }
     }
 
+    pub fn set_position(&mut self, channel: usize, normalized: f32) {
+        if let Some(ch) = self.channels.get_mut(channel) {
+            ch.set_position(normalized);
+        }
+    }
+
     // --- Per-channel effects ----------------------------------------------
 
     /// Append an effect to a channel. Returns the new effect's slot index, or


### PR DESCRIPTION
Adds a loop-channel playhead setter so a caller can swap a channel's buffer mid-playback and resume at the same phase instead of restarting at the loop start — the host needs this to keep auditioned loop variants on the beat. `LoopChannel::set_position` is the inverse of `position_normalized()`: it clamps a normalized `[0,1]` target into the active loop window (reusing `loop_bounds()`) and is a no-op when no buffer is loaded. A `Mixer::set_position` wrapper and the `gooey_engine_loop_set_position` FFI export are added (cbindgen regenerates `include/gooey.h`), following the same main-thread/audio-thread contract as the existing loop setters. Round-trip and loop-window clamp unit tests are included; `cargo test`, `fmt`, and `clippy` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)