### PR TITLE
[codex] Finish drum kit channel refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,10 @@ name = "loop_mixer"
 required-features = ["native", "crossterm", "bounce"]
 
 [[example]]
+name = "multi_channel_submix"
+required-features = ["native", "crossterm"]
+
+[[example]]
 name = "antialias_validation"
 required-features = ["bounce"]
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ gooey_engine_free(engine);
 
 See `include/gooey.h` for complete API documentation.
 
+For apps migrating from the old flat instrument mix assumption to mixer graph
+submixing, see [docs/mixer-graph-migration.md](docs/mixer-graph-migration.md).
+
 ## License
 
 MIT

--- a/docs/mixer-graph-migration.md
+++ b/docs/mixer-graph-migration.md
@@ -1,0 +1,160 @@
+# Mixer Graph Migration Guide
+
+This guide is for host apps that currently treat libgooey as one flat instrument
+mix and do not yet model multi-channel submixing.
+
+## What Changed
+
+The engine still renders one interleaved stereo output buffer through
+`gooey_engine_render`, so audio callback integration does not need to change.
+Internally, instrument and loop sources now route through a host-configurable
+mixer graph before the master bus.
+
+Default graph layout:
+
+| Track | Name | Sources |
+| --- | --- | --- |
+| 0 | Drums | `SOURCE_DRUMKIT` |
+| 1 | Bass | `SOURCE_BASS` |
+| 2 | Synth | `SOURCE_POLYSYNTH` |
+| 3 | Loops | `SOURCE_GRANULATOR`, `SOURCE_LOOPMIXER` |
+
+The default layout is intended to preserve the old app behavior until the host
+starts changing track routing, track gain, mute/solo state, or track effects.
+
+## Minimal Migration
+
+Apps that only need the old flat mix can keep their current render path:
+
+```c
+GooeyEngine *engine = gooey_engine_new(44100.0f);
+
+// Existing instrument, sequencer, global-effect, and render calls still work.
+gooey_engine_set_bpm(engine, 120.0f);
+gooey_engine_sequencer_start(engine);
+gooey_engine_render(engine, output, frame_count);
+```
+
+Recommended additions:
+
+```c
+// Optional: confirm the default graph is present after engine creation.
+uint32_t tracks = gooey_engine_mixer_get_track_count(engine); // 4
+
+// Optional: reset to default if the host loads saved projects from mixed app versions.
+gooey_engine_mixer_reset_default_layout(engine);
+```
+
+## Adding A Submix UI
+
+Treat mixer graph tracks as app-level buses. A simple v1 UI can show:
+
+- Track name
+- Gain
+- Mute
+- Solo
+- Peak meter
+- Track effect count
+
+Example read loop:
+
+```c
+uint32_t count = gooey_engine_mixer_get_track_count(engine);
+for (uint32_t track = 0; track < count; track++) {
+    const char *name = gooey_engine_mixer_get_track_name(engine, track);
+    float gain = gooey_engine_mixer_get_track_gain(engine, track);
+    bool muted = gooey_engine_mixer_get_track_mute(engine, track);
+    bool soloed = gooey_engine_mixer_get_track_solo(engine, track);
+    float peak = gooey_engine_mixer_get_track_peak(engine, track); // read-and-reset
+}
+```
+
+Example write controls:
+
+```c
+gooey_engine_mixer_set_track_gain(engine, 0, 0.85f);
+gooey_engine_mixer_set_track_mute(engine, 1, true);
+gooey_engine_mixer_set_track_solo(engine, 0, true);
+```
+
+Track names returned by `gooey_engine_mixer_get_track_name` are owned by the
+engine. Do not free them. Treat the pointer as valid until the track is renamed,
+the graph layout is cleared/reset, or the engine is freed.
+
+## Custom Layouts
+
+Apps that want their own bus layout should clear the graph, add tracks, and route
+sources explicitly during project load or engine setup.
+
+```c
+gooey_engine_mixer_clear_layout(engine);
+
+int drums = gooey_engine_mixer_add_track(engine, "Drum Bus");
+int bass = gooey_engine_mixer_add_track(engine, "Bass Bus");
+int loops = gooey_engine_mixer_add_track(engine, "Loops");
+
+gooey_engine_mixer_route_source(engine, SOURCE_DRUMKIT, drums);
+gooey_engine_mixer_route_source(engine, SOURCE_BASS, bass);
+gooey_engine_mixer_route_source(engine, SOURCE_GRANULATOR, loops);
+gooey_engine_mixer_route_source(engine, SOURCE_LOOPMIXER, loops);
+```
+
+If a source is unrouted, it is silent:
+
+```c
+gooey_engine_mixer_unroute_source(engine, SOURCE_POLYSYNTH);
+```
+
+Route queries return `-1` for invalid or unrouted sources:
+
+```c
+int track = gooey_engine_mixer_get_source_route(engine, SOURCE_BASS);
+```
+
+## Track Effects
+
+Track effects use the same `EFFECT_*` ids and parameter ids as loop-channel
+effects.
+
+```c
+int slot = gooey_engine_track_effect_add(engine, 0, EFFECT_LOWPASS_FILTER);
+gooey_engine_track_effect_set_param(engine, 0, slot, FILTER_PARAM_CUTOFF, 800.0f);
+
+gooey_engine_track_effect_add(engine, 1, EFFECT_DELAY);
+gooey_engine_track_effect_set_param(engine, 1, 0, DELAY_PARAM_MIX, 0.25f);
+
+uint32_t effect_count = gooey_engine_track_effect_count(engine, 1);
+int effect_id = gooey_engine_track_effect_type_at(engine, 1, 0);
+```
+
+Invalid track/effect slots are safe no-ops or return `false`, `0`, or `-1`
+depending on the function.
+
+## Backward Compatibility Notes
+
+- `gooey_engine_render` still writes interleaved stereo frames.
+- Existing instrument APIs such as `gooey_engine_set_kick_param`,
+  `gooey_engine_trigger_instrument`, sequencer APIs, LFO APIs, and global effects
+  remain valid.
+- Per-instrument gain/mute/solo still applies inside the drum kit/bass voice
+  layer. Track gain/mute/solo applies later at the mixer graph bus layer.
+- The drum kit source is the sum of kick, snare, hi-hat, and tom. Apps that need
+  individual drum faders can keep using existing per-instrument gain controls.
+- Project files that do not store graph layout can rely on the default layout.
+  Project files that do store graph layout should recreate it with
+  `clear_layout` + `add_track` + `route_source`.
+
+## Manual Verification
+
+Run the included example:
+
+```bash
+cargo run --example multi_channel_submix --features native,crossterm
+```
+
+It creates two mixer graph tracks:
+
+- Track 1: a basic drum beat routed from `SOURCE_DRUMKIT`
+- Track 2: a bass-synth loop routed from `SOURCE_BASS`
+
+Use the terminal controls to adjust track gain, mute/solo, and track effects.

--- a/examples/multi_channel_submix.rs
+++ b/examples/multi_channel_submix.rs
@@ -1,0 +1,618 @@
+//! Multi-channel Submix - small CLI for verifying the mixer graph FFI.
+//!
+//! Track 1 is a basic drum beat (kick/snare/hihat/tom summed as `SOURCE_DRUMKIT`).
+//! Track 2 is a looping bass-synth pattern (`SOURCE_BASS`). The terminal controls
+//! let you submix those two graph tracks live with gain, mute, solo, and a small
+//! track-effect rack.
+//!
+//! Run with:
+//! cargo run --example multi_channel_submix --features native,crossterm
+
+#[cfg(feature = "native")]
+use cpal::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    FromSample, Sample, SizedSample, Stream, StreamConfig,
+};
+#[cfg(feature = "native")]
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyEvent},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
+};
+#[cfg(feature = "native")]
+use gooey::ffi::*;
+#[cfg(feature = "native")]
+use std::ffi::CString;
+#[cfg(feature = "native")]
+use std::io::{self, Write};
+#[cfg(feature = "native")]
+use std::sync::{Arc, Mutex};
+#[cfg(feature = "native")]
+use std::time::{Duration, Instant};
+
+#[cfg(feature = "native")]
+const TRACK_DRUMS: u32 = 0;
+#[cfg(feature = "native")]
+const TRACK_BASS: u32 = 1;
+#[cfg(feature = "native")]
+const TRACK_COUNT: usize = 2;
+#[cfg(feature = "native")]
+const DEFAULT_BPM: f32 = 116.0;
+
+#[cfg(feature = "native")]
+struct FfiEngine {
+    ptr: *mut GooeyEngine,
+}
+
+#[cfg(feature = "native")]
+unsafe impl Send for FfiEngine {}
+
+#[cfg(feature = "native")]
+impl FfiEngine {
+    fn new(sample_rate: f32) -> Self {
+        Self {
+            ptr: gooey_engine_new(sample_rate),
+        }
+    }
+
+    fn ptr(&self) -> *mut GooeyEngine {
+        self.ptr
+    }
+}
+
+#[cfg(feature = "native")]
+impl Drop for FfiEngine {
+    fn drop(&mut self) {
+        unsafe {
+            gooey_engine_free(self.ptr);
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+#[derive(Clone)]
+struct TrackUi {
+    name: &'static str,
+    gain: f32,
+    muted: bool,
+    soloed: bool,
+    peak: f32,
+    fx_knob: f32,
+}
+
+#[cfg(feature = "native")]
+struct AppState {
+    selected: usize,
+    bpm: f32,
+    running: bool,
+    tracks: [TrackUi; TRACK_COUNT],
+}
+
+#[cfg(feature = "native")]
+fn cstr(s: &str) -> CString {
+    CString::new(s).expect("track names do not contain null bytes")
+}
+
+#[cfg(feature = "native")]
+fn bool_pattern(steps: &[usize]) -> [bool; 16] {
+    let mut pattern = [false; 16];
+    for &step in steps {
+        pattern[step % 16] = true;
+    }
+    pattern
+}
+
+#[cfg(feature = "native")]
+fn configure_engine(engine: *mut GooeyEngine) {
+    unsafe {
+        gooey_engine_set_bpm(engine, DEFAULT_BPM);
+        gooey_engine_set_master_gain(engine, 0.85);
+
+        gooey_engine_mixer_clear_layout(engine);
+        let drums = cstr("Track 1 - Drum Beat");
+        let bass = cstr("Track 2 - Bass Loop");
+        assert_eq!(gooey_engine_mixer_add_track(engine, drums.as_ptr()), 0);
+        assert_eq!(gooey_engine_mixer_add_track(engine, bass.as_ptr()), 1);
+        assert!(gooey_engine_mixer_route_source(
+            engine,
+            SOURCE_DRUMKIT,
+            TRACK_DRUMS
+        ));
+        assert!(gooey_engine_mixer_route_source(
+            engine,
+            SOURCE_BASS,
+            TRACK_BASS
+        ));
+        gooey_engine_mixer_set_track_gain(engine, TRACK_DRUMS, 0.85);
+        gooey_engine_mixer_set_track_gain(engine, TRACK_BASS, 0.75);
+
+        // Kit pattern: a compact four-on-floor beat with hats and a tom pickup.
+        let kick = bool_pattern(&[0, 4, 8, 12]);
+        let snare = bool_pattern(&[4, 12]);
+        let hat = bool_pattern(&[0, 2, 4, 6, 8, 10, 12, 14]);
+        let tom = bool_pattern(&[14]);
+        gooey_engine_sequencer_set_instrument_pattern(engine, INSTRUMENT_KICK, kick.as_ptr());
+        gooey_engine_sequencer_set_instrument_pattern(engine, INSTRUMENT_SNARE, snare.as_ptr());
+        gooey_engine_sequencer_set_instrument_pattern(engine, INSTRUMENT_HIHAT, hat.as_ptr());
+        gooey_engine_sequencer_set_instrument_pattern(engine, INSTRUMENT_TOM, tom.as_ptr());
+        for step in 0..16 {
+            gooey_engine_sequencer_set_instrument_step_velocity(
+                engine,
+                INSTRUMENT_HIHAT,
+                step,
+                if step % 4 == 0 { 0.55 } else { 0.35 },
+            );
+        }
+
+        // Bass synth loop: six triggered notes over one bar. Per-step MIDI notes
+        // make the bass line loop without external audio files.
+        gooey_engine_load_bass_preset(engine, BASS_PRESET_SUB);
+        gooey_engine_set_bass_param(engine, BASS_PARAM_VOLUME, 0.78);
+        gooey_engine_set_bass_param(engine, BASS_PARAM_AMP_DECAY, 0.42);
+        gooey_engine_set_bass_param(engine, BASS_PARAM_FILTER_CUTOFF, 0.38);
+        let bass_pattern = bool_pattern(&[0, 3, 6, 8, 10, 13]);
+        let bass_notes: [u8; 16] = [
+            36,
+            STEP_NOTE_NONE,
+            STEP_NOTE_NONE,
+            36,
+            STEP_NOTE_NONE,
+            STEP_NOTE_NONE,
+            43,
+            STEP_NOTE_NONE,
+            34,
+            STEP_NOTE_NONE,
+            36,
+            STEP_NOTE_NONE,
+            STEP_NOTE_NONE,
+            31,
+            STEP_NOTE_NONE,
+            STEP_NOTE_NONE,
+        ];
+        gooey_engine_sequencer_set_instrument_pattern(
+            engine,
+            INSTRUMENT_BASS,
+            bass_pattern.as_ptr(),
+        );
+        gooey_engine_sequencer_set_instrument_note_pattern(
+            engine,
+            INSTRUMENT_BASS,
+            bass_notes.as_ptr(),
+        );
+        for step in [0_u32, 3, 6, 8, 10, 13] {
+            gooey_engine_sequencer_set_instrument_step_velocity(
+                engine,
+                INSTRUMENT_BASS,
+                step,
+                if step == 0 { 0.95 } else { 0.75 },
+            );
+        }
+
+        gooey_engine_sequencer_start(engine);
+    }
+}
+
+#[cfg(feature = "native")]
+fn bar(value: f32, width: usize) -> String {
+    let filled = (value.clamp(0.0, 1.0) * width as f32).round() as usize;
+    let mut s = String::with_capacity(width);
+    for i in 0..width {
+        s.push(if i < filled { '#' } else { '-' });
+    }
+    s
+}
+
+#[cfg(feature = "native")]
+fn effect_name(id: i32) -> &'static str {
+    match id as u32 {
+        EFFECT_LOWPASS_FILTER => "filter",
+        EFFECT_DELAY => "delay",
+        EFFECT_REVERB => "reverb",
+        _ => "fx",
+    }
+}
+
+#[cfg(feature = "native")]
+fn sync_track_state(engine: *mut GooeyEngine, state: &mut AppState) {
+    unsafe {
+        state.bpm = gooey_engine_get_bpm(engine);
+        state.running = gooey_engine_sequencer_get_current_step(engine) >= 0;
+        for (i, track) in state.tracks.iter_mut().enumerate() {
+            let track_idx = i as u32;
+            track.gain = gooey_engine_mixer_get_track_gain(engine, track_idx);
+            track.muted = gooey_engine_mixer_get_track_mute(engine, track_idx);
+            track.soloed = gooey_engine_mixer_get_track_solo(engine, track_idx);
+            track.peak = gooey_engine_mixer_get_track_peak(engine, track_idx);
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+fn render_display(engine: *mut GooeyEngine, state: &AppState) {
+    execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0)).unwrap();
+
+    let step = unsafe { gooey_engine_sequencer_get_current_step(engine) };
+    print!("=== Multi-channel Submix (MixerGraph FFI) ===\r\n");
+    print!(
+        "BPM {:.0}  sequencer {}  current step {}\r\n\r\n",
+        state.bpm,
+        if state.running { "RUNNING" } else { "STOPPED" },
+        if step >= 0 {
+            format!("{:02}", step + 1)
+        } else {
+            "--".to_string()
+        }
+    );
+
+    for (idx, track) in state.tracks.iter().enumerate() {
+        let marker = if idx == state.selected { '>' } else { ' ' };
+        let mute = if track.muted { "M" } else { "." };
+        let solo = if track.soloed { "S" } else { "." };
+        let source = if idx == TRACK_DRUMS as usize {
+            "SOURCE_DRUMKIT"
+        } else {
+            "SOURCE_BASS"
+        };
+        let fx_count = unsafe { gooey_engine_track_effect_count(engine, idx as u32) };
+
+        print!("{marker} {}  {}{}  {source}\r\n", track.name, mute, solo);
+        print!(
+            "    gain [{}] {:.2}   peak [{}] {:.2}\r\n",
+            bar(track.gain / 2.0, 18),
+            track.gain,
+            bar(track.peak, 18),
+            track.peak,
+        );
+        if fx_count == 0 {
+            print!("    fx: (none)\r\n");
+        } else {
+            let mut chain = String::new();
+            for slot in 0..fx_count {
+                let id = unsafe { gooey_engine_track_effect_type_at(engine, idx as u32, slot) };
+                if slot > 0 {
+                    chain.push_str(" -> ");
+                }
+                chain.push_str(effect_name(id));
+            }
+            print!("    fx: {chain}  knob {:.0}%\r\n", track.fx_knob * 100.0);
+        }
+        print!("\r\n");
+    }
+
+    print!("Up/Down select track    Left/Right track gain    m mute    s solo\r\n");
+    print!(
+        "f add filter    d add delay    v add reverb    c clear track fx    k/l tweak last fx\r\n"
+    );
+    print!("Space start/stop sequencer    b/B BPM -/+5    q quit\r\n");
+    io::stdout().flush().unwrap();
+}
+
+#[cfg(feature = "native")]
+fn apply_last_fx_knob(engine: *mut GooeyEngine, track: u32, knob: f32) {
+    unsafe {
+        let count = gooey_engine_track_effect_count(engine, track);
+        if count == 0 {
+            return;
+        }
+        let slot = count - 1;
+        let effect_id = gooey_engine_track_effect_type_at(engine, track, slot);
+        match effect_id as u32 {
+            EFFECT_LOWPASS_FILTER => {
+                let cutoff = 200.0 + knob * (18_000.0 - 200.0);
+                gooey_engine_track_effect_set_param(
+                    engine,
+                    track,
+                    slot,
+                    FILTER_PARAM_CUTOFF,
+                    cutoff,
+                );
+            }
+            EFFECT_DELAY => {
+                gooey_engine_track_effect_set_param(engine, track, slot, DELAY_PARAM_MIX, knob);
+                gooey_engine_track_effect_set_param(
+                    engine,
+                    track,
+                    slot,
+                    DELAY_PARAM_FEEDBACK,
+                    knob * 0.65,
+                );
+            }
+            EFFECT_REVERB => {
+                gooey_engine_track_effect_set_param(engine, track, slot, REVERB_PARAM_MIX, knob);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+fn build_output_stream(
+    engine: Arc<Mutex<FfiEngine>>,
+    device: &cpal::Device,
+    config: &StreamConfig,
+    sample_format: cpal::SampleFormat,
+) -> anyhow::Result<Stream> {
+    match sample_format {
+        cpal::SampleFormat::I8 => make_stream::<i8>(engine, device, config),
+        cpal::SampleFormat::I16 => make_stream::<i16>(engine, device, config),
+        cpal::SampleFormat::I32 => make_stream::<i32>(engine, device, config),
+        cpal::SampleFormat::I64 => make_stream::<i64>(engine, device, config),
+        cpal::SampleFormat::U8 => make_stream::<u8>(engine, device, config),
+        cpal::SampleFormat::U16 => make_stream::<u16>(engine, device, config),
+        cpal::SampleFormat::U32 => make_stream::<u32>(engine, device, config),
+        cpal::SampleFormat::U64 => make_stream::<u64>(engine, device, config),
+        cpal::SampleFormat::F32 => make_stream::<f32>(engine, device, config),
+        cpal::SampleFormat::F64 => make_stream::<f64>(engine, device, config),
+        format => Err(anyhow::anyhow!("unsupported sample format {format}")),
+    }
+}
+
+#[cfg(feature = "native")]
+fn make_stream<T>(
+    engine: Arc<Mutex<FfiEngine>>,
+    device: &cpal::Device,
+    config: &StreamConfig,
+) -> anyhow::Result<Stream>
+where
+    T: SizedSample + FromSample<f32>,
+{
+    let channels = config.channels as usize;
+    let err_fn = |err| eprintln!("audio stream error: {err}");
+    let stream = device.build_output_stream(
+        config,
+        move |output: &mut [T], _| {
+            render_audio(output, channels, &engine);
+        },
+        err_fn,
+        None,
+    )?;
+    Ok(stream)
+}
+
+#[cfg(feature = "native")]
+fn render_audio<T>(output: &mut [T], channels: usize, engine: &Arc<Mutex<FfiEngine>>)
+where
+    T: Sample + FromSample<f32>,
+{
+    let frames = output.len() / channels;
+    let mut interleaved = vec![0.0_f32; frames * GOOEY_OUTPUT_CHANNELS as usize];
+
+    match engine.try_lock() {
+        Ok(engine) => unsafe {
+            gooey_engine_render(engine.ptr(), interleaved.as_mut_ptr(), frames as u32);
+        },
+        Err(_) => {
+            for sample in output.iter_mut() {
+                *sample = T::from_sample(0.0);
+            }
+            return;
+        }
+    }
+
+    for (frame_idx, frame) in output.chunks_mut(channels).enumerate() {
+        let l = interleaved[frame_idx * 2];
+        let r = interleaved[frame_idx * 2 + 1];
+        match frame.len() {
+            0 => {}
+            1 => frame[0] = T::from_sample(0.5 * (l + r)),
+            _ => {
+                frame[0] = T::from_sample(l);
+                frame[1] = T::from_sample(r);
+                if frame.len() > 2 {
+                    let mono = T::from_sample(0.5 * (l + r));
+                    for sample in &mut frame[2..] {
+                        *sample = mono;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+fn main() -> anyhow::Result<()> {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or_else(|| anyhow::anyhow!("no default output device"))?;
+    let supported_config = device.default_output_config()?;
+    let config: StreamConfig = supported_config.clone().into();
+    let sample_rate = config.sample_rate.0 as f32;
+
+    println!("Output device: {}", device.name()?);
+    println!("Output config: {:?}", supported_config);
+
+    let ffi_engine = FfiEngine::new(sample_rate);
+    configure_engine(ffi_engine.ptr());
+    let engine = Arc::new(Mutex::new(ffi_engine));
+
+    let stream = build_output_stream(
+        engine.clone(),
+        &device,
+        &config,
+        supported_config.sample_format(),
+    )?;
+    stream.play()?;
+
+    let mut state = AppState {
+        selected: 0,
+        bpm: DEFAULT_BPM,
+        running: true,
+        tracks: [
+            TrackUi {
+                name: "Track 1 - Drum Beat",
+                gain: 0.85,
+                muted: false,
+                soloed: false,
+                peak: 0.0,
+                fx_knob: 0.5,
+            },
+            TrackUi {
+                name: "Track 2 - Bass Loop",
+                gain: 0.75,
+                muted: false,
+                soloed: false,
+                peak: 0.0,
+                fx_knob: 0.5,
+            },
+        ],
+    };
+
+    execute!(io::stdout(), Clear(ClearType::All), cursor::Hide)?;
+    enable_raw_mode()?;
+
+    let mut last_redraw = Instant::now();
+    let mut needs_redraw = true;
+
+    let result = loop {
+        if needs_redraw || last_redraw.elapsed() > Duration::from_millis(80) {
+            if let Ok(engine) = engine.lock() {
+                sync_track_state(engine.ptr(), &mut state);
+                render_display(engine.ptr(), &state);
+            }
+            needs_redraw = false;
+            last_redraw = Instant::now();
+        }
+
+        if event::poll(Duration::from_millis(16))? {
+            if let Event::Key(KeyEvent { code, .. }) = event::read()? {
+                let selected_track = state.selected as u32;
+                if let Ok(engine) = engine.lock() {
+                    match code {
+                        KeyCode::Up => state.selected = state.selected.saturating_sub(1),
+                        KeyCode::Down => state.selected = (state.selected + 1).min(TRACK_COUNT - 1),
+                        KeyCode::Left | KeyCode::Right => {
+                            let delta = if code == KeyCode::Left { -0.05 } else { 0.05 };
+                            let current = unsafe {
+                                gooey_engine_mixer_get_track_gain(engine.ptr(), selected_track)
+                            };
+                            unsafe {
+                                gooey_engine_mixer_set_track_gain(
+                                    engine.ptr(),
+                                    selected_track,
+                                    current + delta,
+                                );
+                            }
+                        }
+                        KeyCode::Char('m') => {
+                            let muted = unsafe {
+                                gooey_engine_mixer_get_track_mute(engine.ptr(), selected_track)
+                            };
+                            unsafe {
+                                gooey_engine_mixer_set_track_mute(
+                                    engine.ptr(),
+                                    selected_track,
+                                    !muted,
+                                );
+                            }
+                        }
+                        KeyCode::Char('s') => {
+                            let soloed = unsafe {
+                                gooey_engine_mixer_get_track_solo(engine.ptr(), selected_track)
+                            };
+                            unsafe {
+                                gooey_engine_mixer_set_track_solo(
+                                    engine.ptr(),
+                                    selected_track,
+                                    !soloed,
+                                );
+                            }
+                        }
+                        KeyCode::Char('f') => {
+                            unsafe {
+                                gooey_engine_track_effect_add(
+                                    engine.ptr(),
+                                    selected_track,
+                                    EFFECT_LOWPASS_FILTER,
+                                );
+                            }
+                            apply_last_fx_knob(
+                                engine.ptr(),
+                                selected_track,
+                                state.tracks[state.selected].fx_knob,
+                            );
+                        }
+                        KeyCode::Char('d') => {
+                            unsafe {
+                                gooey_engine_track_effect_add(
+                                    engine.ptr(),
+                                    selected_track,
+                                    EFFECT_DELAY,
+                                );
+                            }
+                            apply_last_fx_knob(
+                                engine.ptr(),
+                                selected_track,
+                                state.tracks[state.selected].fx_knob,
+                            );
+                        }
+                        KeyCode::Char('v') => {
+                            unsafe {
+                                gooey_engine_track_effect_add(
+                                    engine.ptr(),
+                                    selected_track,
+                                    EFFECT_REVERB,
+                                );
+                            }
+                            apply_last_fx_knob(
+                                engine.ptr(),
+                                selected_track,
+                                state.tracks[state.selected].fx_knob,
+                            );
+                        }
+                        KeyCode::Char('c') => unsafe {
+                            gooey_engine_track_effect_clear(engine.ptr(), selected_track);
+                        },
+                        KeyCode::Char('k') | KeyCode::Char('l') => {
+                            let delta = if code == KeyCode::Char('k') {
+                                -0.05
+                            } else {
+                                0.05
+                            };
+                            state.tracks[state.selected].fx_knob =
+                                (state.tracks[state.selected].fx_knob + delta).clamp(0.0, 1.0);
+                            apply_last_fx_knob(
+                                engine.ptr(),
+                                selected_track,
+                                state.tracks[state.selected].fx_knob,
+                            );
+                        }
+                        KeyCode::Char(' ') => unsafe {
+                            if state.running {
+                                gooey_engine_sequencer_stop(engine.ptr());
+                            } else {
+                                gooey_engine_sequencer_start(engine.ptr());
+                            }
+                            state.running = !state.running;
+                        },
+                        KeyCode::Char('b') | KeyCode::Char('B') => {
+                            let delta = if code == KeyCode::Char('b') {
+                                -5.0
+                            } else {
+                                5.0
+                            };
+                            let bpm = (state.bpm + delta).clamp(50.0, 180.0);
+                            unsafe {
+                                gooey_engine_set_bpm(engine.ptr(), bpm);
+                            }
+                        }
+                        KeyCode::Char('q') | KeyCode::Char('Q') | KeyCode::Esc => break Ok(()),
+                        _ => {}
+                    }
+                }
+                needs_redraw = true;
+            }
+        }
+    };
+
+    disable_raw_mode()?;
+    execute!(io::stdout(), cursor::Show)?;
+    println!("\nQuitting...");
+    result
+}
+
+#[cfg(not(feature = "native"))]
+fn main() {
+    println!("This example requires the 'native' and 'crossterm' features.");
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,10 +14,13 @@ use crate::instruments::{
     BassConfig, BassSynth, Granulator, HiHat2, HiHat2Config, KickConfig, KickDrum, PolySynth,
     PolySynthConfig, SampleBuffer, SnareConfig, SnareDrum, Tom2, Tom2Config,
 };
-use crate::mixer::{Mixer, PitchMode, StereoSampleBuffer};
+use crate::mixer::graph::{
+    SOURCE_BASS, SOURCE_DRUMKIT, SOURCE_GRANULATOR, SOURCE_LOOPMIXER, SOURCE_POLYSYNTH,
+};
+use crate::mixer::{Mixer, MixerGraph, PitchMode, StereoSampleBuffer};
 use crate::music::{apply_voicing, available_voicings, Key, NoteName, ScaleType, VoicingType};
 use crate::utils::{PresetBlender, SmoothedParam};
-use std::ffi::{c_char, c_void, CString};
+use std::ffi::{c_char, c_void, CStr, CString};
 use std::slice;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
@@ -573,12 +576,99 @@ impl ChannelBlender {
 ///
 /// Parameter smoothing is handled internally by each instrument,
 /// so all parameter changes are automatically smoothed to prevent clicks/pops.
-pub struct GooeyEngine {
-    // Per-channel instruments (each can hold any synth type)
-    channels: [ChannelInstrument; NUM_INSTRUMENTS],
+/// Number of drum voices in the kit (kick, snare, hihat, tom). Bass is a
+/// separate top-level voice, so the addressable voice space
+/// (`NUM_INSTRUMENTS` = 5) is the kit voices plus bass at index 4.
+const KIT_VOICE_COUNT: usize = 4;
 
-    // Per-channel sequencers (sample-accurate, synchronized)
-    sequencers: [Sequencer; NUM_INSTRUMENTS],
+/// One voice's complete per-channel state: the instrument plus its sequencer,
+/// preset blender, mixer strip (fader / mute-solo / pan / peak), manual-trigger
+/// latch, and per-step MIDI-note frequency save slot. This bundles what were
+/// previously parallel `[_; NUM_INSTRUMENTS]` arrays into a single owned column
+/// so voices can be grouped into a `DrumKit` collection and routed as sources.
+struct VoiceStrip {
+    instrument: ChannelInstrument,
+    sequencer: Sequencer,
+    blender: ChannelBlender,
+    blend_enabled: bool,
+    blend_x: f32,
+    blend_y: f32,
+    blend_corner_presets: [u32; 4],
+    /// Mixer fader (0.0–1.0), applied after synthesis/blend; the blend system
+    /// cannot override it. Was `instrument_channel_gains[i]`.
+    channel_gain: SmoothedParam,
+    /// Smoothed mute/solo multiplier for click-free transitions. Was
+    /// `instrument_gains[i]`.
+    mute_gain: SmoothedParam,
+    /// Stereo pan (0.0 = left, 0.5 = center, 1.0 = right), equal-power. Was
+    /// `instrument_pans[i]`.
+    pan: SmoothedParam,
+    muted: AtomicBool,
+    soloed: AtomicBool,
+    /// Peak amplitude since last read (f32 bits, read-and-reset by UI). Was
+    /// `channel_peaks[i]`.
+    peak: AtomicU32,
+    trigger_pending: AtomicBool,
+    trigger_velocity: AtomicU32, // f32 bits stored atomically
+    /// Saved global frequency for restoring after per-step MIDI note overrides.
+    saved_global_freq: Option<f32>,
+}
+
+impl VoiceStrip {
+    /// Build a voice from its instrument and a fresh sequencer. `instrument_type`
+    /// selects the default preset blender and corner presets.
+    fn new(
+        instrument: ChannelInstrument,
+        sequencer: Sequencer,
+        instrument_type: u32,
+        sample_rate: f32,
+    ) -> Self {
+        Self {
+            instrument,
+            sequencer,
+            blender: ChannelBlender::default_for_type(instrument_type),
+            blend_enabled: false,
+            blend_x: 0.5,
+            blend_y: 0.5,
+            blend_corner_presets: ChannelBlender::default_corner_preset_ids(instrument_type),
+            channel_gain: SmoothedParam::new(1.0, 0.0, 1.0, sample_rate, 10.0),
+            mute_gain: SmoothedParam::new(1.0, 0.0, 1.0, sample_rate, 10.0),
+            pan: SmoothedParam::new(0.5, 0.0, 1.0, sample_rate, 10.0),
+            muted: AtomicBool::new(false),
+            soloed: AtomicBool::new(false),
+            peak: AtomicU32::new(0.0_f32.to_bits()),
+            trigger_pending: AtomicBool::new(false),
+            trigger_velocity: AtomicU32::new(1.0_f32.to_bits()),
+            saved_global_freq: None,
+        }
+    }
+
+    /// Record a new peak (read-and-reset by the UI). `level` is a pre-pan mono
+    /// magnitude. Uses the same compare-and-store pattern as the old
+    /// `channel_peaks` array.
+    fn record_peak(&self, level: f32) {
+        let prev = f32::from_bits(self.peak.load(Ordering::Relaxed));
+        if level > prev {
+            self.peak.store(level.to_bits(), Ordering::Relaxed);
+        }
+    }
+}
+
+/// A submixable collection of drum voices (kick, snare, hihat, tom). Each voice
+/// keeps its own sequencer, blender, and mixer strip; the whole kit is routed as
+/// one source (`SourceId::DrumKit`) in the mixer graph. Bass is intentionally not
+/// a member — it is a melodic voice routed as its own source.
+struct DrumKit {
+    voices: [VoiceStrip; KIT_VOICE_COUNT],
+}
+
+pub struct GooeyEngine {
+    // Drum voices (kick, snare, hihat, tom) grouped as one submixable kit.
+    kit: DrumKit,
+
+    // Bass voice — a melodic instrument routed as its own source, sibling to the
+    // kit. Addressed as legacy instrument index 4.
+    bass: VoiceStrip,
 
     /// Global effects. Applied in the order described by `effect_order`,
     /// followed by the optional limiter which is always last.
@@ -617,45 +707,11 @@ pub struct GooeyEngine {
     /// Smoothed gain applied to the complete instrument sum before global effects.
     master_gain: SmoothedParam,
 
-    // Per-channel manual trigger flags and velocities
-    trigger_pending: [AtomicBool; NUM_INSTRUMENTS],
-    trigger_velocity: [AtomicU32; NUM_INSTRUMENTS], // f32 bits stored atomically
-
-    // Per-channel peak amplitude since last read (f32 bits stored atomically, read-and-reset by UI)
-    channel_peaks: [AtomicU32; NUM_INSTRUMENTS],
-
     // LFO pool (8 LFOs with multi-target routing)
     lfos: [Lfo; LFO_COUNT],
     lfo_enabled: [bool; LFO_COUNT],
     lfo_routes: [Vec<LfoRoute>; LFO_COUNT],
     lfo_next_route_id: [u32; LFO_COUNT],
-
-    // Per-channel mute/solo state
-    instrument_muted: [AtomicBool; NUM_INSTRUMENTS],
-    instrument_soloed: [AtomicBool; NUM_INSTRUMENTS],
-
-    // Smoothed gain multipliers for click-free mute/solo transitions
-    instrument_gains: [SmoothedParam; NUM_INSTRUMENTS],
-
-    // Per-channel gain (0.0–1.0), applied after synthesis and blending.
-    // Acts as a mixer fader that the blend system cannot override.
-    instrument_channel_gains: [SmoothedParam; NUM_INSTRUMENTS],
-
-    // Per-channel stereo pan (0.0 = left, 0.5 = center, 1.0 = right), applied
-    // at the stereo seam with an equal-power law. Smoothed for click-free moves.
-    instrument_pans: [SmoothedParam; NUM_INSTRUMENTS],
-
-    // Per-channel preset blend state (2D X/Y pad interpolation)
-    blenders: [ChannelBlender; NUM_INSTRUMENTS],
-    blend_enabled: [bool; INSTRUMENT_COUNT as usize],
-    blend_x: [f32; INSTRUMENT_COUNT as usize],
-    blend_y: [f32; INSTRUMENT_COUNT as usize],
-    blend_corner_presets: [[u32; 4]; INSTRUMENT_COUNT as usize],
-
-    // Per-channel saved global frequency for restoring after per-step MIDI note overrides.
-    // When a step with a note fires, the instrument's current frequency param is saved here.
-    // When a step without a note fires, the saved value is restored and cleared.
-    saved_global_freq: [Option<f32>; NUM_INSTRUMENTS],
 
     // Pending MIDI events from the most recent render pass (pre-allocated, no audio-thread alloc)
     pending_midi_events: Vec<GooeyMidiEvent>,
@@ -676,6 +732,13 @@ pub struct GooeyEngine {
     // into the master bus before the global effects chain. The `gooey_engine_loop_*`
     // FFI functions expose control over this.
     mixer: Mixer,
+
+    // Host-defined mixer graph: named submix tracks, each with a strip
+    // (gain / balance / mute-solo / peak) and its own effect rack. Sources
+    // (drum kit, bass, poly, granulator, loop mixer) route into tracks, which
+    // sum to the master bus. Controlled via `gooey_engine_mixer_*` and
+    // `gooey_engine_track_effect_*`.
+    graph: MixerGraph,
 
     // When true, an external source (e.g. Ableton Link) owns the tempo.
     // The host should check this flag to decide whether local BPM changes
@@ -736,23 +799,44 @@ impl GooeyEngine {
     fn new(sample_rate: f32) -> Self {
         let bpm = 120.0;
 
-        // Create channel instruments (default: ch0=kick, ch1=snare, ch2=hihat, ch3=tom, ch4=bass)
-        let channels = [
-            ChannelInstrument::Kick(KickDrum::new(sample_rate)),
-            ChannelInstrument::Snare(SnareDrum::new(sample_rate)),
-            ChannelInstrument::HiHat(HiHat2::new(sample_rate)),
-            ChannelInstrument::Tom(Tom2::new(sample_rate)),
-            ChannelInstrument::Bass(BassSynth::new(sample_rate)),
-        ];
+        // Drum kit: four voices (kick, snare, hihat, tom), each with its own
+        // 16-step sequencer, blender, and mixer strip.
+        let kit = DrumKit {
+            voices: [
+                VoiceStrip::new(
+                    ChannelInstrument::Kick(KickDrum::new(sample_rate)),
+                    Sequencer::with_pattern(bpm, sample_rate, vec![false; 16], "kick"),
+                    INSTRUMENT_KICK,
+                    sample_rate,
+                ),
+                VoiceStrip::new(
+                    ChannelInstrument::Snare(SnareDrum::new(sample_rate)),
+                    Sequencer::with_pattern(bpm, sample_rate, vec![false; 16], "snare"),
+                    INSTRUMENT_SNARE,
+                    sample_rate,
+                ),
+                VoiceStrip::new(
+                    ChannelInstrument::HiHat(HiHat2::new(sample_rate)),
+                    Sequencer::with_pattern(bpm, sample_rate, vec![false; 16], "hihat"),
+                    INSTRUMENT_HIHAT,
+                    sample_rate,
+                ),
+                VoiceStrip::new(
+                    ChannelInstrument::Tom(Tom2::new(sample_rate)),
+                    Sequencer::with_pattern(bpm, sample_rate, vec![false; 16], "tom"),
+                    INSTRUMENT_TOM,
+                    sample_rate,
+                ),
+            ],
+        };
 
-        // Create a 16-step sequencer for each channel
-        let sequencers = [
-            Sequencer::with_pattern(bpm, sample_rate, vec![false; 16], "kick"),
-            Sequencer::with_pattern(bpm, sample_rate, vec![false; 16], "snare"),
-            Sequencer::with_pattern(bpm, sample_rate, vec![false; 16], "hihat"),
-            Sequencer::with_pattern(bpm, sample_rate, vec![false; 16], "tom"),
+        // Bass voice — routed as its own source (legacy instrument index 4).
+        let bass = VoiceStrip::new(
+            ChannelInstrument::Bass(BassSynth::new(sample_rate)),
             Sequencer::with_pattern(bpm, sample_rate, vec![false; 16], "bass"),
-        ];
+            INSTRUMENT_BASS,
+            sample_rate,
+        );
 
         // Create delay with default settings (quarter note timing, no feedback, no mix, filter open)
         let delay = DelayEffect::new(sample_rate, DelayTiming::Quarter, bpm, 0.0, 0.0, 20000.0);
@@ -786,18 +870,9 @@ impl GooeyEngine {
         let lfos = std::array::from_fn(|_| Lfo::with_sample_rate(sample_rate));
         let lfo_routes: [Vec<LfoRoute>; LFO_COUNT] = std::array::from_fn(|_| Vec::new());
 
-        // Create per-channel preset blenders with default corner presets
-        let blenders = [
-            ChannelBlender::default_for_type(INSTRUMENT_KICK),
-            ChannelBlender::default_for_type(INSTRUMENT_SNARE),
-            ChannelBlender::default_for_type(INSTRUMENT_HIHAT),
-            ChannelBlender::default_for_type(INSTRUMENT_TOM),
-            ChannelBlender::default_for_type(INSTRUMENT_BASS),
-        ];
-
         Self {
-            channels,
-            sequencers,
+            kit,
+            bass,
             delay,
             delay_enabled: false,
             lowpass_filter,
@@ -826,43 +901,11 @@ impl GooeyEngine {
             current_time: 0.0,
             // Match the native Engine's default summing headroom.
             master_gain: SmoothedParam::new(DEFAULT_MASTER_GAIN, 0.0, 2.0, sample_rate, 30.0),
-            trigger_pending: std::array::from_fn(|_| AtomicBool::new(false)),
-            trigger_velocity: std::array::from_fn(|_| AtomicU32::new(1.0_f32.to_bits())),
-            channel_peaks: std::array::from_fn(|_| AtomicU32::new(0.0_f32.to_bits())),
             // LFO pool
             lfos,
             lfo_enabled: [false; LFO_COUNT],
             lfo_routes,
             lfo_next_route_id: [0; LFO_COUNT],
-            // Mute/solo state (all unmuted, none soloed by default)
-            instrument_muted: std::array::from_fn(|_| AtomicBool::new(false)),
-            instrument_soloed: std::array::from_fn(|_| AtomicBool::new(false)),
-            // Smoothed gains for click-free mute/solo transitions (10ms smoothing)
-            instrument_gains: std::array::from_fn(|_| {
-                SmoothedParam::new(1.0, 0.0, 1.0, sample_rate, 10.0)
-            }),
-            // Per-instrument channel gains (default 1.0 = unity, 10ms smoothing)
-            instrument_channel_gains: std::array::from_fn(|_| {
-                SmoothedParam::new(1.0, 0.0, 1.0, sample_rate, 10.0)
-            }),
-            // Per-instrument stereo pan (default 0.5 = center, 10ms smoothing)
-            instrument_pans: std::array::from_fn(|_| {
-                SmoothedParam::new(0.5, 0.0, 1.0, sample_rate, 10.0)
-            }),
-            // Preset blend state
-            blenders,
-            blend_enabled: [false; INSTRUMENT_COUNT as usize],
-            blend_x: [0.5; INSTRUMENT_COUNT as usize],
-            blend_y: [0.5; INSTRUMENT_COUNT as usize],
-            blend_corner_presets: [
-                ChannelBlender::default_corner_preset_ids(INSTRUMENT_KICK),
-                ChannelBlender::default_corner_preset_ids(INSTRUMENT_SNARE),
-                ChannelBlender::default_corner_preset_ids(INSTRUMENT_HIHAT),
-                ChannelBlender::default_corner_preset_ids(INSTRUMENT_TOM),
-                ChannelBlender::default_corner_preset_ids(INSTRUMENT_BASS),
-            ],
-            // Per-step note override: saved global frequency for restore
-            saved_global_freq: [None; NUM_INSTRUMENTS],
             // MIDI event buffer (pre-allocated for audio thread safety)
             pending_midi_events: Vec::with_capacity(MIDI_EVENT_CAPACITY),
             // Sequencer triggers enabled by default (internal sequencer drives instruments)
@@ -880,6 +923,10 @@ impl GooeyEngine {
             ),
             // Multi-channel stereo loop mixer (empty until the host loads loops).
             mixer: Mixer::new(sample_rate),
+            // Host-defined mixer graph, seeded with the default 4-track layout
+            // (Drums / Bass / Synth / Loops). Bit-identical to the flat mix until
+            // the host adjusts a track strip, rack, or routing.
+            graph: MixerGraph::with_default_layout(sample_rate, bpm),
             // External sync (e.g. Ableton Link)
             link_enabled: AtomicBool::new(false),
             // Error state
@@ -948,6 +995,38 @@ impl GooeyEngine {
     /// signal path is mono, so left and right are currently identical (see the
     /// "stereo seam" near the end of the per-frame loop), but the engine writes
     /// two-channel output so hosts (and future stereo features) consume stereo.
+    /// Borrow a voice by legacy instrument index: 0..=3 are the kit drum voices
+    /// (kick, snare, hihat, tom), 4 is bass. Returns `None` for out-of-range.
+    fn voice(&self, idx: usize) -> Option<&VoiceStrip> {
+        match idx {
+            i if i < KIT_VOICE_COUNT => self.kit.voices.get(i),
+            i if i == KIT_VOICE_COUNT => Some(&self.bass),
+            _ => None,
+        }
+    }
+
+    /// Mutable counterpart to [`voice`](Self::voice).
+    fn voice_mut(&mut self, idx: usize) -> Option<&mut VoiceStrip> {
+        match idx {
+            i if i < KIT_VOICE_COUNT => self.kit.voices.get_mut(i),
+            i if i == KIT_VOICE_COUNT => Some(&mut self.bass),
+            _ => None,
+        }
+    }
+
+    /// Iterate all addressable voices in index order (kit drums then bass).
+    fn voices_iter(&self) -> impl Iterator<Item = &VoiceStrip> {
+        self.kit.voices.iter().chain(std::iter::once(&self.bass))
+    }
+
+    /// Mutable counterpart to [`voices_iter`](Self::voices_iter).
+    fn voices_iter_mut(&mut self) -> impl Iterator<Item = &mut VoiceStrip> {
+        self.kit
+            .voices
+            .iter_mut()
+            .chain(std::iter::once(&mut self.bass))
+    }
+
     fn render(&mut self, buffer: &mut [f32]) {
         // Clear pending MIDI events from previous render pass
         self.pending_midi_events.clear();
@@ -971,8 +1050,8 @@ impl GooeyEngine {
                 // Drain any pending manual triggers so they don't latch and fire
                 // late once the arm resolves; the trigger API contract is "fires
                 // on the next render call", and this render produced silence.
-                for ch in 0..NUM_INSTRUMENTS {
-                    self.trigger_pending[ch].store(false, Ordering::Release);
+                for voice in self.voices_iter() {
+                    voice.trigger_pending.store(false, Ordering::Release);
                 }
                 for sample in buffer.iter_mut() {
                     *sample = 0.0;
@@ -985,28 +1064,36 @@ impl GooeyEngine {
         // Check for pending manual triggers with velocity (all channels)
         // Manual triggers fire at sample_offset 0 (start of buffer)
         for ch in 0..NUM_INSTRUMENTS {
-            if self.trigger_pending[ch].swap(false, Ordering::Acquire) {
-                let velocity = f32::from_bits(self.trigger_velocity[ch].load(Ordering::Acquire));
+            let fired = self.voice(ch).and_then(|v| {
+                if v.trigger_pending.swap(false, Ordering::Acquire) {
+                    Some(f32::from_bits(v.trigger_velocity.load(Ordering::Acquire)))
+                } else {
+                    None
+                }
+            });
+            if let Some(velocity) = fired {
                 self.push_midi_event(ch as u32, velocity, 0);
-                self.channels[ch].trigger_with_velocity(self.current_time, velocity);
+                let time = self.current_time;
+                if let Some(voice) = self.voice_mut(ch) {
+                    voice.instrument.trigger_with_velocity(time, velocity);
+                }
             }
         }
 
         let sample_period = 1.0 / self.sample_rate as f64;
 
         // Update mute/solo gain targets (check once per buffer for efficiency)
-        let any_soloed = self
-            .instrument_soloed
-            .iter()
-            .any(|s| s.load(Ordering::Relaxed));
-        for i in 0..NUM_INSTRUMENTS {
+        let any_soloed = self.voices_iter().any(|v| v.soloed.load(Ordering::Relaxed));
+        for voice in self.voices_iter_mut() {
             let target = Self::calculate_instrument_gain(
-                self.instrument_muted[i].load(Ordering::Relaxed),
-                self.instrument_soloed[i].load(Ordering::Relaxed),
+                voice.muted.load(Ordering::Relaxed),
+                voice.soloed.load(Ordering::Relaxed),
                 any_soloed,
             );
-            self.instrument_gains[i].set_target(target);
+            voice.mute_gain.set_target(target);
         }
+        // Recompute per-track mute/solo targets (scoped across tracks) once per buffer.
+        self.graph.update_mute_solo_targets();
 
         let mut sample_offset: u32 = 0;
         for frame in buffer.chunks_mut(2) {
@@ -1026,9 +1113,9 @@ impl GooeyEngine {
                 // arm_fires_at locally and pending_arm_host_time on the
                 // engine ensures we only fire once per render.
                 if let Some(pending) = self.pending_arm_host_time.take() {
-                    for seq in &mut self.sequencers {
-                        seq.set_beat_position(pending.beat_position);
-                        seq.start();
+                    for voice in self.voices_iter_mut() {
+                        voice.sequencer.set_beat_position(pending.beat_position);
+                        voice.sequencer.start();
                     }
                 }
                 arm_fires_at = None;
@@ -1038,43 +1125,49 @@ impl GooeyEngine {
             let mut seq_triggers: [Option<(f32, Option<SequencerBlendSetting>, Option<u8>)>;
                 NUM_INSTRUMENTS] = [None; NUM_INSTRUMENTS];
             for ch in 0..NUM_INSTRUMENTS {
-                seq_triggers[ch] = self.sequencers[ch]
-                    .tick_with_settings()
-                    .map(|trigger| (trigger.velocity, trigger.blend, trigger.note));
+                if let Some(voice) = self.voice_mut(ch) {
+                    seq_triggers[ch] = voice
+                        .sequencer
+                        .tick_with_settings()
+                        .map(|trigger| (trigger.velocity, trigger.blend, trigger.note));
+                }
             }
 
             // Apply triggers with velocity after all sequencers have been ticked.
             if self.sequencer_triggers_enabled.load(Ordering::Relaxed) {
+                let time = self.current_time;
                 for ch in 0..NUM_INSTRUMENTS {
                     if let Some((velocity, blend, note)) = seq_triggers[ch] {
                         self.apply_sequencer_blend_setting(ch as u32, blend);
-                        // Snap params only when a blend was actually applied,
-                        // so we don't clobber in-flight UI/LFO smoothing.
-                        if blend.is_some() || self.blend_enabled[ch] {
-                            self.channels[ch].snap_params();
-                        }
-                        // Apply per-step MIDI note frequency override (sample-accurate).
-                        // When a step has a note, save the global freq and override.
-                        // When a step has no note, restore the saved global freq.
-                        if let Some(midi_note) = note {
-                            let instr_type = self.channels[ch].instrument_type();
-                            if let Some((freq_min, freq_max)) =
-                                Self::freq_range_for_instrument(instr_type)
-                            {
-                                if self.saved_global_freq[ch].is_none() {
-                                    self.saved_global_freq[ch] = self.channels[ch].get_freq_param();
-                                }
-                                let normalized = Self::midi_note_to_normalized_freq(
-                                    midi_note, freq_min, freq_max,
-                                );
-                                self.channels[ch].set_param(0, normalized);
-                                self.channels[ch].snap_params();
+                        if let Some(voice) = self.voice_mut(ch) {
+                            // Snap params only when a blend was actually applied,
+                            // so we don't clobber in-flight UI/LFO smoothing.
+                            if blend.is_some() || voice.blend_enabled {
+                                voice.instrument.snap_params();
                             }
-                        } else if let Some(saved) = self.saved_global_freq[ch].take() {
-                            self.channels[ch].set_param(0, saved);
-                            self.channels[ch].snap_params();
+                            // Apply per-step MIDI note frequency override (sample-accurate).
+                            // When a step has a note, save the global freq and override.
+                            // When a step has no note, restore the saved global freq.
+                            if let Some(midi_note) = note {
+                                let instr_type = voice.instrument.instrument_type();
+                                if let Some((freq_min, freq_max)) =
+                                    Self::freq_range_for_instrument(instr_type)
+                                {
+                                    if voice.saved_global_freq.is_none() {
+                                        voice.saved_global_freq = voice.instrument.get_freq_param();
+                                    }
+                                    let normalized = Self::midi_note_to_normalized_freq(
+                                        midi_note, freq_min, freq_max,
+                                    );
+                                    voice.instrument.set_param(0, normalized);
+                                    voice.instrument.snap_params();
+                                }
+                            } else if let Some(saved) = voice.saved_global_freq.take() {
+                                voice.instrument.set_param(0, saved);
+                                voice.instrument.snap_params();
+                            }
+                            voice.instrument.trigger_with_velocity(time, velocity);
                         }
-                        self.channels[ch].trigger_with_velocity(self.current_time, velocity);
                         self.push_midi_event(ch as u32, velocity, sample_offset);
                     }
                 }
@@ -1103,40 +1196,47 @@ impl GooeyEngine {
             // each effect can process true left/right. Effects are stereo-aware
             // (per-channel state); with every channel centered and no stereo
             // effect engaged the two channels stay identical.
+            // Sum each voice into its source frame: kit voices (0..KIT_VOICE_COUNT)
+            // form the DrumKit source, bass forms the Bass source. Per-voice gain,
+            // mute/solo, pan, and peak metering are unchanged; only the routing
+            // target differs. `channel_outs` still feeds the compressor sidechain.
             let mut channel_outs = [0.0_f32; NUM_INSTRUMENTS];
-            let mut stereo_pre = StereoFrame::default();
-            for ch in 0..NUM_INSTRUMENTS {
-                let ch_out = self.channels[ch].tick(self.current_time)
-                    * self.instrument_channel_gains[ch].tick()
-                    * self.instrument_gains[ch].tick();
+            let mut kit_frame = StereoFrame::default();
+            let mut bass_frame = StereoFrame::default();
+            let time = self.current_time;
+            for (ch, voice) in self.voices_iter_mut().enumerate() {
+                let ch_out = voice.instrument.tick(time)
+                    * voice.channel_gain.tick()
+                    * voice.mute_gain.tick();
                 channel_outs[ch] = ch_out;
 
-                let panned = StereoFrame::panned(ch_out, self.instrument_pans[ch].tick());
-                stereo_pre.l += panned.l;
-                stereo_pre.r += panned.r;
-
-                // Track per-channel peak for UI metering (pre-pan mono level)
-                let abs_out = ch_out.abs();
-                let prev_peak = f32::from_bits(self.channel_peaks[ch].load(Ordering::Relaxed));
-                if abs_out > prev_peak {
-                    self.channel_peaks[ch].store(abs_out.to_bits(), Ordering::Relaxed);
+                let panned = StereoFrame::panned(ch_out, voice.pan.tick());
+                if ch < KIT_VOICE_COUNT {
+                    kit_frame += panned;
+                } else {
+                    bass_frame += panned;
                 }
+
+                // Track per-voice peak for UI metering (pre-pan mono level)
+                voice.record_peak(ch_out.abs());
             }
 
-            // Poly synth and granulator have no pan control yet — place them at
-            // center for consistency with the equal-power law used above.
-            let center =
-                self.poly_synth.tick(self.current_time) + self.granulator.tick(self.current_time);
-            let center = StereoFrame::panned(center, 0.5);
-            stereo_pre.l += center.l;
-            stereo_pre.r += center.r;
+            // Poly synth and granulator have no pan control yet — center them
+            // for consistency with the equal-power law used above.
+            let poly_frame = StereoFrame::panned(self.poly_synth.tick(time), 0.5);
+            let gran_frame = StereoFrame::panned(self.granulator.tick(time), 0.5);
+            // Loop mixer is already stereo, with its own per-channel effects.
+            let loop_frame = self.mixer.tick(self.sample_rate);
 
-            // Panned instrument sum is the pre-master mix.
-            let mut stereo = stereo_pre;
-
-            // Sum the loop mixer (already stereo, with its own per-channel
-            // effects) into the master bus.
-            stereo += self.mixer.tick(self.sample_rate);
+            // Scatter each source into its routed track, then apply per-track
+            // strip (gain × mute/solo, balance) + effect rack and sum to master.
+            self.graph.clear_scratch();
+            self.graph.scatter(SOURCE_DRUMKIT, kit_frame);
+            self.graph.scatter(SOURCE_BASS, bass_frame);
+            self.graph.scatter(SOURCE_POLYSYNTH, poly_frame);
+            self.graph.scatter(SOURCE_GRANULATOR, gran_frame);
+            self.graph.scatter(SOURCE_LOOPMIXER, loop_frame);
+            let mut stereo = self.graph.mix_down();
 
             // Apply master headroom to the full mix (instruments + loops) before
             // the optional global effects + limiter, so the master fader scales
@@ -1222,8 +1322,12 @@ impl GooeyEngine {
         }
 
         let idx = channel as usize;
-        if idx < NUM_INSTRUMENTS && self.blend_enabled[idx] {
-            self.apply_blend_position(channel, self.blend_x[idx], self.blend_y[idx]);
+        if let Some((x, y)) = self
+            .voice(idx)
+            .filter(|v| v.blend_enabled)
+            .map(|v| (v.blend_x, v.blend_y))
+        {
+            self.apply_blend_position(channel, x, y);
         }
     }
 
@@ -1231,8 +1335,8 @@ impl GooeyEngine {
         let x = x.clamp(0.0, 1.0);
         let y = y.clamp(0.0, 1.0);
         let idx = channel as usize;
-        if idx < NUM_INSTRUMENTS {
-            self.blenders[idx].blend_and_apply(&mut self.channels[idx], x, y);
+        if let Some(voice) = self.voice_mut(idx) {
+            voice.blender.blend_and_apply(&mut voice.instrument, x, y);
         }
     }
 
@@ -1252,9 +1356,8 @@ impl GooeyEngine {
 
     /// Apply LFO modulation to a channel's instrument parameter by index
     fn apply_modulation_by_index(&mut self, channel: u32, param: u32, value: f32) {
-        let idx = channel as usize;
-        if idx < NUM_INSTRUMENTS {
-            self.channels[idx].apply_modulation(param, value);
+        if let Some(voice) = self.voice_mut(channel as usize) {
+            voice.instrument.apply_modulation(param, value);
         }
     }
 
@@ -1281,11 +1384,18 @@ impl GooeyEngine {
         1.0
     }
 
-    /// Find the first channel holding the given instrument type.
-    fn find_channel_by_type(&self, instrument_type: u32) -> Option<usize> {
-        self.channels
-            .iter()
-            .position(|ch| ch.instrument_type() == instrument_type)
+    /// Borrow the first voice's instrument matching the given type.
+    fn instrument_by_type(&self, instrument_type: u32) -> Option<&ChannelInstrument> {
+        self.voices_iter()
+            .map(|v| &v.instrument)
+            .find(|i| i.instrument_type() == instrument_type)
+    }
+
+    /// Mutable counterpart to [`instrument_by_type`](Self::instrument_by_type).
+    fn instrument_by_type_mut(&mut self, instrument_type: u32) -> Option<&mut ChannelInstrument> {
+        self.voices_iter_mut()
+            .map(|v| &mut v.instrument)
+            .find(|i| i.instrument_type() == instrument_type)
     }
 
     /// Get a KickConfig preset by ID
@@ -2114,36 +2224,36 @@ pub unsafe extern "C" fn gooey_engine_set_channel_instrument_type(
         return;
     }
     let engine = &mut *engine;
-    let idx = channel as usize;
-    if idx >= NUM_INSTRUMENTS {
+    let sample_rate = engine.sample_rate;
+    let Some(voice) = engine.voice_mut(channel as usize) else {
         return;
-    }
+    };
 
     // No-op if already the requested type
-    if engine.channels[idx].instrument_type() == instrument_type {
+    if voice.instrument.instrument_type() == instrument_type {
         return;
     }
 
     let new_instrument = match instrument_type {
-        INSTRUMENT_KICK => ChannelInstrument::Kick(KickDrum::new(engine.sample_rate)),
-        INSTRUMENT_SNARE => ChannelInstrument::Snare(SnareDrum::new(engine.sample_rate)),
-        INSTRUMENT_HIHAT => ChannelInstrument::HiHat(HiHat2::new(engine.sample_rate)),
-        INSTRUMENT_TOM => ChannelInstrument::Tom(Tom2::new(engine.sample_rate)),
-        INSTRUMENT_BASS => ChannelInstrument::Bass(BassSynth::new(engine.sample_rate)),
+        INSTRUMENT_KICK => ChannelInstrument::Kick(KickDrum::new(sample_rate)),
+        INSTRUMENT_SNARE => ChannelInstrument::Snare(SnareDrum::new(sample_rate)),
+        INSTRUMENT_HIHAT => ChannelInstrument::HiHat(HiHat2::new(sample_rate)),
+        INSTRUMENT_TOM => ChannelInstrument::Tom(Tom2::new(sample_rate)),
+        INSTRUMENT_BASS => ChannelInstrument::Bass(BassSynth::new(sample_rate)),
         _ => return,
     };
 
-    engine.channels[idx] = new_instrument;
-    engine.blenders[idx] = ChannelBlender::default_for_type(instrument_type);
-    engine.blend_corner_presets[idx] = ChannelBlender::default_corner_preset_ids(instrument_type);
+    voice.instrument = new_instrument;
+    voice.blender = ChannelBlender::default_for_type(instrument_type);
+    voice.blend_corner_presets = ChannelBlender::default_corner_preset_ids(instrument_type);
 
     // If blend is enabled, re-apply position with the new blender
-    if engine.blend_enabled[idx] {
-        let x = engine.blend_x[idx];
-        let y = engine.blend_y[idx];
-        engine.blenders[idx].blend_and_apply(&mut engine.channels[idx], x, y);
+    if voice.blend_enabled {
+        let x = voice.blend_x;
+        let y = voice.blend_y;
+        voice.blender.blend_and_apply(&mut voice.instrument, x, y);
     }
-    // channel gain, mute, solo, sequencer pattern all preserved (separate arrays)
+    // channel gain, mute, solo, sequencer pattern all preserved on the voice
 }
 
 /// Returns the current instrument type for a channel.
@@ -2169,11 +2279,10 @@ pub unsafe extern "C" fn gooey_engine_get_channel_instrument_type(
         return 0xFFFFFFFF;
     }
     let engine = &*engine;
-    let idx = channel as usize;
-    if idx >= NUM_INSTRUMENTS {
-        return 0xFFFFFFFF;
+    match engine.voice(channel as usize) {
+        Some(voice) => voice.instrument.instrument_type(),
+        None => 0xFFFFFFFF,
     }
-    engine.channels[idx].instrument_type()
 }
 
 /// Set a parameter on a channel's instrument, regardless of what synth type it holds.
@@ -2203,11 +2312,9 @@ pub unsafe extern "C" fn gooey_engine_set_channel_param(
         return;
     }
     let engine = &mut *engine;
-    let idx = channel as usize;
-    if idx >= NUM_INSTRUMENTS {
-        return;
+    if let Some(voice) = engine.voice_mut(channel as usize) {
+        voice.instrument.set_param(param, value);
     }
-    engine.channels[idx].set_param(param, value);
 }
 
 /// Set the tuning offset for a channel (0.0 = −12 semitones, 0.5 = neutral, 1.0 = +12 semitones).
@@ -2227,11 +2334,10 @@ pub unsafe extern "C" fn gooey_engine_set_channel_tuning(
         return;
     }
     let engine = &mut *engine;
-    let idx = channel as usize;
-    if idx >= NUM_INSTRUMENTS {
+    let Some(voice) = engine.voice_mut(channel as usize) else {
         return;
-    }
-    let tuning_param = match engine.channels[idx].instrument_type() {
+    };
+    let tuning_param = match voice.instrument.instrument_type() {
         INSTRUMENT_KICK => KICK_PARAM_TUNING,
         INSTRUMENT_SNARE => SNARE_PARAM_TUNING,
         INSTRUMENT_HIHAT => HIHAT_PARAM_TUNING,
@@ -2239,7 +2345,7 @@ pub unsafe extern "C" fn gooey_engine_set_channel_tuning(
         INSTRUMENT_BASS => BASS_PARAM_TUNING,
         _ => return,
     };
-    engine.channels[idx].set_param(tuning_param, value);
+    voice.instrument.set_param(tuning_param, value);
 }
 
 /// Get the current tuning value for a channel (0.0–1.0).
@@ -2257,11 +2363,10 @@ pub unsafe extern "C" fn gooey_engine_get_channel_tuning(
         return 0.5;
     }
     let engine = &*engine;
-    let idx = channel as usize;
-    if idx >= NUM_INSTRUMENTS {
-        return 0.5;
+    match engine.voice(channel as usize) {
+        Some(voice) => voice.instrument.get_tuning(),
+        None => 0.5,
     }
-    engine.channels[idx].get_tuning()
 }
 
 /// Trigger a specific channel (regardless of what instrument type it holds).
@@ -2297,11 +2402,12 @@ pub unsafe extern "C" fn gooey_engine_trigger_channel_with_velocity(
     velocity: f32,
 ) {
     if let Some(engine) = engine.as_ref() {
-        let idx = channel as usize;
-        if idx < NUM_INSTRUMENTS {
+        if let Some(voice) = engine.voice(channel as usize) {
             let vel_clamped = velocity.clamp(0.0, 1.0);
-            engine.trigger_velocity[idx].store(vel_clamped.to_bits(), Ordering::Release);
-            engine.trigger_pending[idx].store(true, Ordering::Release);
+            voice
+                .trigger_velocity
+                .store(vel_clamped.to_bits(), Ordering::Release);
+            voice.trigger_pending.store(true, Ordering::Release);
         }
     }
 }
@@ -2329,11 +2435,12 @@ pub unsafe extern "C" fn gooey_engine_trigger_instrument_with_velocity(
     velocity: f32,
 ) {
     if let Some(engine) = engine.as_ref() {
-        let idx = instrument as usize;
-        if idx < NUM_INSTRUMENTS {
+        if let Some(voice) = engine.voice(instrument as usize) {
             let vel_clamped = velocity.clamp(0.0, 1.0);
-            engine.trigger_velocity[idx].store(vel_clamped.to_bits(), Ordering::Release);
-            engine.trigger_pending[idx].store(true, Ordering::Release);
+            voice
+                .trigger_velocity
+                .store(vel_clamped.to_bits(), Ordering::Release);
+            voice.trigger_pending.store(true, Ordering::Release);
         }
     }
 }
@@ -2383,8 +2490,8 @@ pub unsafe extern "C" fn gooey_engine_get_channel_peaks(
 ) {
     if let Some(engine) = engine.as_ref() {
         let n = (count as usize).min(NUM_INSTRUMENTS);
-        for i in 0..n {
-            let bits = engine.channel_peaks[i].swap(0.0_f32.to_bits(), Ordering::Relaxed);
+        for (i, voice) in engine.voices_iter().take(n).enumerate() {
+            let bits = voice.peak.swap(0.0_f32.to_bits(), Ordering::Relaxed);
             *out_peaks.add(i) = f32::from_bits(bits);
         }
     }
@@ -2400,7 +2507,9 @@ pub unsafe extern "C" fn gooey_engine_get_channel_peaks(
 #[no_mangle]
 pub unsafe extern "C" fn gooey_engine_trigger_kick(engine: *mut GooeyEngine) {
     if let Some(engine) = engine.as_ref() {
-        engine.trigger_pending[INSTRUMENT_KICK as usize].store(true, Ordering::Release);
+        if let Some(voice) = engine.voice(INSTRUMENT_KICK as usize) {
+            voice.trigger_pending.store(true, Ordering::Release);
+        }
     }
 }
 
@@ -2434,8 +2543,8 @@ pub unsafe extern "C" fn gooey_engine_set_kick_param(
         return;
     }
     let engine = &mut *engine;
-    if let Some(ch) = engine.find_channel_by_type(INSTRUMENT_KICK) {
-        engine.channels[ch].set_param(param, value);
+    if let Some(instr) = engine.instrument_by_type_mut(INSTRUMENT_KICK) {
+        instr.set_param(param, value);
     }
 }
 
@@ -2467,8 +2576,8 @@ pub unsafe extern "C" fn gooey_engine_get_kick_param(
         return f32::NAN;
     }
     let engine = &*engine;
-    match engine.find_channel_by_type(INSTRUMENT_KICK) {
-        Some(ch) => engine.channels[ch].get_param(param),
+    match engine.instrument_by_type(INSTRUMENT_KICK) {
+        Some(instr) => instr.get_param(param),
         None => f32::NAN,
     }
 }
@@ -2500,8 +2609,8 @@ pub unsafe extern "C" fn gooey_engine_set_hihat_param(
         return;
     }
     let engine = &mut *engine;
-    if let Some(ch) = engine.find_channel_by_type(INSTRUMENT_HIHAT) {
-        engine.channels[ch].set_param(param, value);
+    if let Some(instr) = engine.instrument_by_type_mut(INSTRUMENT_HIHAT) {
+        instr.set_param(param, value);
     }
 }
 
@@ -2530,8 +2639,8 @@ pub unsafe extern "C" fn gooey_engine_get_hihat_param(
         return f32::NAN;
     }
     let engine = &*engine;
-    match engine.find_channel_by_type(INSTRUMENT_HIHAT) {
-        Some(ch) => engine.channels[ch].get_param(param),
+    match engine.instrument_by_type(INSTRUMENT_HIHAT) {
+        Some(instr) => instr.get_param(param),
         None => f32::NAN,
     }
 }
@@ -2578,8 +2687,8 @@ pub unsafe extern "C" fn gooey_engine_set_snare_param(
         return;
     }
     let engine = &mut *engine;
-    if let Some(ch) = engine.find_channel_by_type(INSTRUMENT_SNARE) {
-        engine.channels[ch].set_param(param, value);
+    if let Some(instr) = engine.instrument_by_type_mut(INSTRUMENT_SNARE) {
+        instr.set_param(param, value);
     }
 }
 
@@ -2609,8 +2718,8 @@ pub unsafe extern "C" fn gooey_engine_get_snare_param(
         return f32::NAN;
     }
     let engine = &*engine;
-    match engine.find_channel_by_type(INSTRUMENT_SNARE) {
-        Some(ch) => engine.channels[ch].get_param(param),
+    match engine.instrument_by_type(INSTRUMENT_SNARE) {
+        Some(instr) => instr.get_param(param),
         None => f32::NAN,
     }
 }
@@ -2646,8 +2755,8 @@ pub unsafe extern "C" fn gooey_engine_set_tom_param(
         return;
     }
     let engine = &mut *engine;
-    if let Some(ch) = engine.find_channel_by_type(INSTRUMENT_TOM) {
-        engine.channels[ch].set_param(param, value);
+    if let Some(instr) = engine.instrument_by_type_mut(INSTRUMENT_TOM) {
+        instr.set_param(param, value);
     }
 }
 
@@ -2674,8 +2783,8 @@ pub unsafe extern "C" fn gooey_engine_get_tom_param(engine: *const GooeyEngine, 
         return f32::NAN;
     }
     let engine = &*engine;
-    match engine.find_channel_by_type(INSTRUMENT_TOM) {
-        Some(ch) => engine.channels[ch].get_param(param),
+    match engine.instrument_by_type(INSTRUMENT_TOM) {
+        Some(instr) => instr.get_param(param),
         None => f32::NAN,
     }
 }
@@ -2718,8 +2827,8 @@ pub unsafe extern "C" fn gooey_engine_set_bass_param(
         return;
     }
     let engine = &mut *engine;
-    if let Some(ch) = engine.find_channel_by_type(INSTRUMENT_BASS) {
-        engine.channels[ch].set_param(param, value);
+    if let Some(instr) = engine.instrument_by_type_mut(INSTRUMENT_BASS) {
+        instr.set_param(param, value);
     }
 }
 
@@ -2741,10 +2850,9 @@ pub unsafe extern "C" fn gooey_engine_load_bass_preset(engine: *mut GooeyEngine,
     }
     let engine = &mut *engine;
     if let Some(config) = GooeyEngine::bass_preset_by_id(preset_id) {
-        if let Some(ch) = engine.find_channel_by_type(INSTRUMENT_BASS) {
-            if let ChannelInstrument::Bass(ref mut bass) = engine.channels[ch] {
-                bass.set_config(config);
-            }
+        if let Some(ChannelInstrument::Bass(bass)) = engine.instrument_by_type_mut(INSTRUMENT_BASS)
+        {
+            bass.set_config(config);
         }
     }
 }
@@ -3147,7 +3255,7 @@ pub unsafe extern "C" fn gooey_engine_set_bpm(engine: *mut GooeyEngine, bpm: f32
 
     let engine = &mut *engine;
     engine.bpm = bpm;
-    for seq in &mut engine.sequencers {
+    for seq in engine.sequencers_iter_mut() {
         seq.set_bpm(bpm);
     }
 
@@ -3161,6 +3269,9 @@ pub unsafe extern "C" fn gooey_engine_set_bpm(engine: *mut GooeyEngine, bpm: f32
 
     // Seed BPM for any future note-synced per-channel loop effects.
     engine.mixer.set_bpm(bpm);
+
+    // Propagate BPM to note-synced effects in per-track racks.
+    engine.graph.set_bpm(bpm);
 }
 
 /// Get the current BPM.
@@ -3238,7 +3349,9 @@ pub unsafe extern "C" fn gooey_engine_sequencer_get_beat_position(
         return 0.0;
     }
     let engine = &*engine;
-    let seq = &engine.sequencers[0];
+    let Some(seq) = engine.reference_sequencer() else {
+        return 0.0;
+    };
 
     let step = seq.current_step() as f64;
 
@@ -3272,7 +3385,7 @@ pub unsafe extern "C" fn gooey_engine_set_swing(engine: *mut GooeyEngine, swing:
     let engine = &mut *engine;
     let clamped = swing.clamp(0.0, 1.0);
     engine.swing = clamped;
-    for seq in &mut engine.sequencers {
+    for seq in engine.sequencers_iter_mut() {
         seq.set_swing(clamped);
     }
 }
@@ -3309,7 +3422,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_start(engine: *mut GooeyEngine) 
 
     let engine = &mut *engine;
     engine.pending_arm_host_time = None;
-    for seq in &mut engine.sequencers {
+    for seq in engine.sequencers_iter_mut() {
         seq.start();
     }
 }
@@ -3328,7 +3441,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_stop(engine: *mut GooeyEngine) {
 
     let engine = &mut *engine;
     engine.pending_arm_host_time = None;
-    for seq in &mut engine.sequencers {
+    for seq in engine.sequencers_iter_mut() {
         seq.stop();
     }
 }
@@ -3347,7 +3460,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_reset(engine: *mut GooeyEngine) 
 
     let engine = &mut *engine;
     engine.pending_arm_host_time = None;
-    for seq in &mut engine.sequencers {
+    for seq in engine.sequencers_iter_mut() {
         seq.reset();
     }
 }
@@ -3382,7 +3495,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_set_beat_position(
 
     let engine = &mut *engine;
     engine.pending_arm_host_time = None;
-    for seq in &mut engine.sequencers {
+    for seq in engine.sequencers_iter_mut() {
         seq.set_beat_position(beat_position);
     }
 }
@@ -3463,7 +3576,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_start_at_host_time(
         start_host_time,
         beat_position,
     });
-    for seq in &mut engine.sequencers {
+    for seq in engine.sequencers_iter_mut() {
         seq.cancel_arm();
         seq.stop();
     }
@@ -3489,7 +3602,9 @@ pub unsafe extern "C" fn gooey_engine_sequencer_set_step(
     }
 
     let engine = &mut *engine;
-    engine.sequencers[INSTRUMENT_KICK as usize].set_step(step as usize, enabled);
+    if let Some(seq) = engine.sequencer_for_instrument(INSTRUMENT_KICK) {
+        seq.set_step(step as usize, enabled);
+    }
 }
 
 /// Get the current sequencer step (uses kick sequencer, all are synchronized)
@@ -3506,10 +3621,9 @@ pub unsafe extern "C" fn gooey_engine_sequencer_get_current_step(engine: *mut Go
     }
 
     let engine = &*engine;
-    if engine.sequencers[0].is_running() {
-        engine.sequencers[0].current_step() as i32
-    } else {
-        -1
+    match engine.reference_sequencer() {
+        Some(seq) if seq.is_running() => seq.current_step() as i32,
+        _ => -1,
     }
 }
 
@@ -3538,10 +3652,9 @@ pub unsafe extern "C" fn gooey_engine_sequencer_get_step_with_lookahead(
     }
 
     let engine = &*engine;
-    if engine.sequencers[0].is_running() {
-        engine.sequencers[0].step_at_lookahead(lookahead_samples as u64) as i32
-    } else {
-        -1
+    match engine.reference_sequencer() {
+        Some(seq) if seq.is_running() => seq.step_at_lookahead(lookahead_samples as u64) as i32,
+        _ => -1,
     }
 }
 
@@ -3552,21 +3665,23 @@ pub unsafe extern "C" fn gooey_engine_sequencer_get_step_with_lookahead(
 /// Helper to get a mutable reference to an instrument's sequencer
 impl GooeyEngine {
     fn sequencer_for_instrument(&mut self, instrument: u32) -> Option<&mut Sequencer> {
-        let idx = instrument as usize;
-        if idx < NUM_INSTRUMENTS {
-            Some(&mut self.sequencers[idx])
-        } else {
-            None
-        }
+        self.voice_mut(instrument as usize)
+            .map(|v| &mut v.sequencer)
     }
 
     fn sequencer_for_instrument_ref(&self, instrument: u32) -> Option<&Sequencer> {
-        let idx = instrument as usize;
-        if idx < NUM_INSTRUMENTS {
-            Some(&self.sequencers[idx])
-        } else {
-            None
-        }
+        self.voice(instrument as usize).map(|v| &v.sequencer)
+    }
+
+    /// Iterate all voice sequencers in index order (kit drums then bass).
+    fn sequencers_iter_mut(&mut self) -> impl Iterator<Item = &mut Sequencer> {
+        self.voices_iter_mut().map(|v| &mut v.sequencer)
+    }
+
+    /// Borrow the reference sequencer (voice 0 / kick). All sequencers are kept
+    /// sample-synchronized, so any voice can serve as the position reference.
+    fn reference_sequencer(&self) -> Option<&Sequencer> {
+        self.voice(0).map(|v| &v.sequencer)
     }
 }
 
@@ -4758,10 +4873,12 @@ pub unsafe extern "C" fn gooey_engine_set_instrument_mute(
     instrument: u32,
     muted: bool,
 ) {
-    if engine.is_null() || instrument as usize >= NUM_INSTRUMENTS {
+    if engine.is_null() {
         return;
     }
-    (*engine).instrument_muted[instrument as usize].store(muted, Ordering::Release);
+    if let Some(voice) = (*engine).voice(instrument as usize) {
+        voice.muted.store(muted, Ordering::Release);
+    }
 }
 
 /// Get the mute state for an instrument
@@ -4780,10 +4897,12 @@ pub unsafe extern "C" fn gooey_engine_get_instrument_mute(
     engine: *const GooeyEngine,
     instrument: u32,
 ) -> bool {
-    if engine.is_null() || instrument as usize >= NUM_INSTRUMENTS {
+    if engine.is_null() {
         return false;
     }
-    (*engine).instrument_muted[instrument as usize].load(Ordering::Acquire)
+    (*engine)
+        .voice(instrument as usize)
+        .is_some_and(|v| v.muted.load(Ordering::Acquire))
 }
 
 /// Set the solo state for an instrument
@@ -4805,10 +4924,12 @@ pub unsafe extern "C" fn gooey_engine_set_instrument_solo(
     instrument: u32,
     soloed: bool,
 ) {
-    if engine.is_null() || instrument as usize >= NUM_INSTRUMENTS {
+    if engine.is_null() {
         return;
     }
-    (*engine).instrument_soloed[instrument as usize].store(soloed, Ordering::Release);
+    if let Some(voice) = (*engine).voice(instrument as usize) {
+        voice.soloed.store(soloed, Ordering::Release);
+    }
 }
 
 /// Get the solo state for an instrument
@@ -4827,10 +4948,12 @@ pub unsafe extern "C" fn gooey_engine_get_instrument_solo(
     engine: *const GooeyEngine,
     instrument: u32,
 ) -> bool {
-    if engine.is_null() || instrument as usize >= NUM_INSTRUMENTS {
+    if engine.is_null() {
         return false;
     }
-    (*engine).instrument_soloed[instrument as usize].load(Ordering::Acquire)
+    (*engine)
+        .voice(instrument as usize)
+        .is_some_and(|v| v.soloed.load(Ordering::Acquire))
 }
 
 // =============================================================================
@@ -4856,11 +4979,13 @@ pub unsafe extern "C" fn gooey_engine_set_instrument_gain(
     instrument: u32,
     gain: f32,
 ) {
-    if engine.is_null() || instrument as usize >= NUM_INSTRUMENTS {
+    if engine.is_null() {
         return;
     }
     let gain = gain.clamp(0.0, 1.0);
-    (*engine).instrument_channel_gains[instrument as usize].set_target(gain);
+    if let Some(voice) = (*engine).voice_mut(instrument as usize) {
+        voice.channel_gain.set_target(gain);
+    }
 }
 
 /// Get the channel gain for an instrument
@@ -4879,10 +5004,12 @@ pub unsafe extern "C" fn gooey_engine_get_instrument_gain(
     engine: *const GooeyEngine,
     instrument: u32,
 ) -> f32 {
-    if engine.is_null() || instrument as usize >= NUM_INSTRUMENTS {
+    if engine.is_null() {
         return 1.0;
     }
-    (*engine).instrument_channel_gains[instrument as usize].target()
+    (*engine)
+        .voice(instrument as usize)
+        .map_or(1.0, |v| v.channel_gain.target())
 }
 
 /// Set the stereo pan for an instrument.
@@ -4901,11 +5028,13 @@ pub unsafe extern "C" fn gooey_engine_set_instrument_pan(
     instrument: u32,
     pan: f32,
 ) {
-    if engine.is_null() || instrument as usize >= NUM_INSTRUMENTS {
+    if engine.is_null() {
         return;
     }
     let pan = pan.clamp(0.0, 1.0);
-    (*engine).instrument_pans[instrument as usize].set_target(pan);
+    if let Some(voice) = (*engine).voice_mut(instrument as usize) {
+        voice.pan.set_target(pan);
+    }
 }
 
 /// Get the stereo pan for an instrument
@@ -4924,10 +5053,12 @@ pub unsafe extern "C" fn gooey_engine_get_instrument_pan(
     engine: *const GooeyEngine,
     instrument: u32,
 ) -> f32 {
-    if engine.is_null() || instrument as usize >= NUM_INSTRUMENTS {
+    if engine.is_null() {
         return 0.5;
     }
-    (*engine).instrument_pans[instrument as usize].target()
+    (*engine)
+        .voice(instrument as usize)
+        .map_or(0.5, |v| v.pan.target())
 }
 
 // =============================================================================
@@ -4951,13 +5082,9 @@ pub unsafe extern "C" fn gooey_engine_blend_enable(engine: *mut GooeyEngine, ins
         return;
     }
     let engine = &mut *engine;
-    let idx = instrument as usize;
-
-    if idx >= INSTRUMENT_COUNT as usize {
-        return;
+    if let Some(voice) = engine.voice_mut(instrument as usize) {
+        voice.blend_enabled = true;
     }
-
-    engine.blend_enabled[idx] = true;
 }
 
 /// Disable preset blend mode for an instrument
@@ -4974,13 +5101,9 @@ pub unsafe extern "C" fn gooey_engine_blend_disable(engine: *mut GooeyEngine, in
         return;
     }
     let engine = &mut *engine;
-    let idx = instrument as usize;
-
-    if idx >= INSTRUMENT_COUNT as usize {
-        return;
+    if let Some(voice) = engine.voice_mut(instrument as usize) {
+        voice.blend_enabled = false;
     }
-
-    engine.blend_enabled[idx] = false;
 }
 
 /// Check if preset blend mode is enabled for an instrument
@@ -5003,13 +5126,9 @@ pub unsafe extern "C" fn gooey_engine_blend_is_enabled(
         return false;
     }
     let engine = &*engine;
-    let idx = instrument as usize;
-
-    if idx >= INSTRUMENT_COUNT as usize {
-        return false;
-    }
-
-    engine.blend_enabled[idx]
+    engine
+        .voice(instrument as usize)
+        .is_some_and(|v| v.blend_enabled)
 }
 
 /// Set the X/Y blend position for an instrument
@@ -5047,23 +5166,18 @@ pub unsafe extern "C" fn gooey_engine_blend_set_position(
         return;
     }
     let engine = &mut *engine;
-    let idx = instrument as usize;
-
-    if idx >= INSTRUMENT_COUNT as usize {
+    let Some(voice) = engine.voice_mut(instrument as usize) else {
+        return;
+    };
+    if !voice.blend_enabled {
         return;
     }
-    if !engine.blend_enabled[idx] {
-        return;
-    }
 
-    engine.blend_x[idx] = x.clamp(0.0, 1.0);
-    engine.blend_y[idx] = y.clamp(0.0, 1.0);
+    voice.blend_x = x.clamp(0.0, 1.0);
+    voice.blend_y = y.clamp(0.0, 1.0);
 
-    engine.blenders[idx].blend_and_apply(
-        &mut engine.channels[idx],
-        engine.blend_x[idx],
-        engine.blend_y[idx],
-    );
+    let (x, y) = (voice.blend_x, voice.blend_y);
+    voice.blender.blend_and_apply(&mut voice.instrument, x, y);
 }
 
 /// Get the current X blend position for an instrument
@@ -5086,13 +5200,9 @@ pub unsafe extern "C" fn gooey_engine_blend_get_position_x(
         return -1.0;
     }
     let engine = &*engine;
-    let idx = instrument as usize;
-
-    if idx >= INSTRUMENT_COUNT as usize {
-        return -1.0;
-    }
-
-    engine.blend_x[idx]
+    engine
+        .voice(instrument as usize)
+        .map_or(-1.0, |v| v.blend_x)
 }
 
 /// Get the current Y blend position for an instrument
@@ -5115,13 +5225,9 @@ pub unsafe extern "C" fn gooey_engine_blend_get_position_y(
         return -1.0;
     }
     let engine = &*engine;
-    let idx = instrument as usize;
-
-    if idx >= INSTRUMENT_COUNT as usize {
-        return -1.0;
-    }
-
-    engine.blend_y[idx]
+    engine
+        .voice(instrument as usize)
+        .map_or(-1.0, |v| v.blend_y)
 }
 
 /// Set a corner preset by preset ID
@@ -5148,18 +5254,14 @@ pub unsafe extern "C" fn gooey_engine_blend_set_corner_preset(
         return;
     }
     let engine = &mut *engine;
-    let idx = instrument as usize;
     let corner_idx = corner as usize;
-
-    if idx >= INSTRUMENT_COUNT as usize {
-        return;
-    }
     if corner_idx >= 4 {
         return;
     }
-
-    engine.blend_corner_presets[idx][corner_idx] = preset_id;
-    engine.blenders[idx].set_corner_preset(corner, preset_id);
+    if let Some(voice) = engine.voice_mut(instrument as usize) {
+        voice.blend_corner_presets[corner_idx] = preset_id;
+        voice.blender.set_corner_preset(corner, preset_id);
+    }
 }
 
 /// Get the preset ID at a corner
@@ -5184,17 +5286,13 @@ pub unsafe extern "C" fn gooey_engine_blend_get_corner_preset(
         return 0xFFFFFFFF;
     }
     let engine = &*engine;
-    let idx = instrument as usize;
     let corner_idx = corner as usize;
-
-    if idx >= INSTRUMENT_COUNT as usize {
-        return 0xFFFFFFFF;
-    }
     if corner_idx >= 4 {
         return 0xFFFFFFFF;
     }
-
-    engine.blend_corner_presets[idx][corner_idx]
+    engine
+        .voice(instrument as usize)
+        .map_or(0xFFFFFFFF, |v| v.blend_corner_presets[corner_idx])
 }
 
 /// Reset blend corners to default presets
@@ -5217,15 +5315,11 @@ pub unsafe extern "C" fn gooey_engine_blend_reset_corners(
         return;
     }
     let engine = &mut *engine;
-    let idx = instrument as usize;
-
-    if idx >= INSTRUMENT_COUNT as usize {
-        return;
+    if let Some(voice) = engine.voice_mut(instrument as usize) {
+        let inst_type = voice.instrument.instrument_type();
+        voice.blender = ChannelBlender::default_for_type(inst_type);
+        voice.blend_corner_presets = ChannelBlender::default_corner_preset_ids(inst_type);
     }
-
-    let inst_type = engine.channels[idx].instrument_type();
-    engine.blenders[idx] = ChannelBlender::default_for_type(inst_type);
-    engine.blend_corner_presets[idx] = ChannelBlender::default_corner_preset_ids(inst_type);
 }
 
 // =============================================================================
@@ -6175,21 +6269,17 @@ impl GooeyEngine {
 
         // Reset engine to a clean state
         self.current_time = 0.0;
-        for seq in &mut self.sequencers {
+        for seq in self.sequencers_iter_mut() {
             seq.reset();
             seq.start();
         }
         for lfo in &mut self.lfos {
             lfo.reset();
         }
-        for gain in &mut self.instrument_gains {
-            gain.snap();
-        }
-        for gain in &mut self.instrument_channel_gains {
-            gain.snap();
-        }
-        for pan in &mut self.instrument_pans {
-            pan.snap();
+        for voice in self.voices_iter_mut() {
+            voice.mute_gain.snap();
+            voice.channel_gain.snap();
+            voice.pan.snap();
         }
         self.master_gain.snap();
 
@@ -6216,7 +6306,7 @@ impl GooeyEngine {
             remaining -= frames;
         }
 
-        for seq in &mut self.sequencers {
+        for seq in self.sequencers_iter_mut() {
             seq.stop();
         }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6702,6 +6702,7 @@ impl GooeyEngine {
             voice.channel_gain.snap();
             voice.pan.snap();
         }
+        self.graph.snap_strip_params();
         self.master_gain.snap();
 
         // Render in chunks using the same path as real-time playback. `render`

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,9 +14,6 @@ use crate::instruments::{
     BassConfig, BassSynth, Granulator, HiHat2, HiHat2Config, KickConfig, KickDrum, PolySynth,
     PolySynthConfig, SampleBuffer, SnareConfig, SnareDrum, Tom2, Tom2Config,
 };
-use crate::mixer::graph::{
-    SOURCE_BASS, SOURCE_DRUMKIT, SOURCE_GRANULATOR, SOURCE_LOOPMIXER, SOURCE_POLYSYNTH,
-};
 use crate::mixer::{Mixer, MixerGraph, PitchMode, StereoSampleBuffer};
 use crate::music::{apply_voicing, available_voicings, Key, NoteName, ScaleType, VoicingType};
 use crate::utils::{PresetBlender, SmoothedParam};
@@ -1787,6 +1784,19 @@ const DEFAULT_MASTER_GAIN: f32 = 0.25;
 
 /// Number of stereo loop-mixer channels (see `gooey_engine_loop_*`).
 pub const LOOP_CHANNEL_COUNT: u32 = crate::mixer::LOOP_CHANNEL_COUNT as u32;
+
+/// Mixer graph source: the drum kit (kick/snare/hihat/tom summed).
+pub const SOURCE_DRUMKIT: u32 = crate::mixer::graph::SOURCE_DRUMKIT;
+/// Mixer graph source: the bass voice.
+pub const SOURCE_BASS: u32 = crate::mixer::graph::SOURCE_BASS;
+/// Mixer graph source: the polyphonic synth.
+pub const SOURCE_POLYSYNTH: u32 = crate::mixer::graph::SOURCE_POLYSYNTH;
+/// Mixer graph source: the granulator.
+pub const SOURCE_GRANULATOR: u32 = crate::mixer::graph::SOURCE_GRANULATOR;
+/// Mixer graph source: the stereo loop mixer.
+pub const SOURCE_LOOPMIXER: u32 = crate::mixer::graph::SOURCE_LOOPMIXER;
+/// Number of routable mixer graph sources.
+pub const SOURCE_COUNT: u32 = crate::mixer::graph::SOURCE_COUNT as u32;
 
 // =============================================================================
 // Preset blend constants
@@ -5586,6 +5596,417 @@ pub unsafe extern "C" fn gooey_engine_granulator_set_buffer(
         }
         Err(_) => false,
     }
+}
+
+// =============================================================================
+// Mixer graph: host-defined source routing, submix tracks, and track effects
+// =============================================================================
+//
+// The mixer graph sits above the drum kit, bass, poly synth, granulator, and
+// loop mixer. Hosts can create named tracks, route sources to tracks, adjust
+// track strips, and add track-level effects. Graph mutation is intended to be
+// serialized with rendering, matching the existing loop-effect API contract.
+
+/// Restore the default graph layout: Drums, Bass, Synth, Loops.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_reset_default_layout(engine: *mut GooeyEngine) {
+    if let Some(engine) = engine.as_mut() {
+        engine.graph = MixerGraph::with_default_layout(engine.sample_rate, engine.bpm);
+    }
+}
+
+/// Clear every graph track and source route. All graph-routed sources become silent.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_clear_layout(engine: *mut GooeyEngine) {
+    if let Some(engine) = engine.as_mut() {
+        engine.graph.reset();
+    }
+}
+
+/// Add a named mixer track. Returns the new track index, or -1 on failure.
+///
+/// # Safety
+/// `name` must point to a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_add_track(
+    engine: *mut GooeyEngine,
+    name: *const c_char,
+) -> i32 {
+    match (engine.as_mut(), name.as_ref()) {
+        (Some(engine), Some(_)) => {
+            let name = CStr::from_ptr(name).to_owned();
+            engine.graph.add_track(name) as i32
+        }
+        _ => -1,
+    }
+}
+
+/// Return the number of mixer graph tracks.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_get_track_count(engine: *const GooeyEngine) -> u32 {
+    engine
+        .as_ref()
+        .map_or(0, |engine| engine.graph.track_count() as u32)
+}
+
+/// Return a track's engine-owned name pointer, or null for a bad track index.
+///
+/// The pointer remains valid until the track is renamed, the layout is cleared,
+/// or the engine is freed.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_get_track_name(
+    engine: *const GooeyEngine,
+    track: u32,
+) -> *const c_char {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.graph.track_name(track as usize))
+        .map_or(std::ptr::null(), CStr::as_ptr)
+}
+
+/// Rename a mixer track. Returns false for null input or a bad track index.
+///
+/// # Safety
+/// `name` must point to a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_set_track_name(
+    engine: *mut GooeyEngine,
+    track: u32,
+    name: *const c_char,
+) -> bool {
+    match (engine.as_mut(), name.as_ref()) {
+        (Some(engine), Some(_)) => {
+            let name = CStr::from_ptr(name).to_owned();
+            engine.graph.set_track_name(track as usize, name)
+        }
+        _ => false,
+    }
+}
+
+/// Find the first track with `name`. Returns -1 if none is found.
+///
+/// # Safety
+/// `name` must point to a valid null-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_find_track(
+    engine: *const GooeyEngine,
+    name: *const c_char,
+) -> i32 {
+    match (engine.as_ref(), name.as_ref()) {
+        (Some(engine), Some(_)) => {
+            let name = CStr::from_ptr(name);
+            engine
+                .graph
+                .track_index_by_name(name)
+                .map_or(-1, |track| track as i32)
+        }
+        _ => -1,
+    }
+}
+
+/// Route an engine source (`SOURCE_*`) to a mixer track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_route_source(
+    engine: *mut GooeyEngine,
+    source: u32,
+    track: u32,
+) -> bool {
+    match engine.as_mut() {
+        Some(engine) => engine.graph.route(source, track as usize),
+        None => false,
+    }
+}
+
+/// Unroute an engine source. Returns false for invalid or already-unrouted sources.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_unroute_source(
+    engine: *mut GooeyEngine,
+    source: u32,
+) -> bool {
+    match engine.as_mut() {
+        Some(engine) => engine.graph.unroute(source),
+        None => false,
+    }
+}
+
+/// Return the track a source is routed to, or -1 if invalid/unrouted.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_get_source_route(
+    engine: *const GooeyEngine,
+    source: u32,
+) -> i32 {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.graph.route_of(source))
+        .map_or(-1, |track| track as i32)
+}
+
+/// Set a track fader gain (`0.0..=2.0`).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_set_track_gain(
+    engine: *mut GooeyEngine,
+    track: u32,
+    gain: f32,
+) {
+    if let Some(engine) = engine.as_mut() {
+        engine.graph.set_track_gain(track as usize, gain);
+    }
+}
+
+/// Get a track fader gain, or 1.0 for null/bad track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_get_track_gain(
+    engine: *const GooeyEngine,
+    track: u32,
+) -> f32 {
+    engine
+        .as_ref()
+        .map_or(1.0, |engine| engine.graph.track_gain(track as usize))
+}
+
+/// Set a track stereo balance (`0.0` left, `0.5` center, `1.0` right).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_set_track_pan(
+    engine: *mut GooeyEngine,
+    track: u32,
+    pan: f32,
+) {
+    if let Some(engine) = engine.as_mut() {
+        engine.graph.set_track_pan(track as usize, pan);
+    }
+}
+
+/// Get a track stereo balance, or 0.5 for null/bad track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_get_track_pan(
+    engine: *const GooeyEngine,
+    track: u32,
+) -> f32 {
+    engine
+        .as_ref()
+        .map_or(0.5, |engine| engine.graph.track_pan(track as usize))
+}
+
+/// Mute or unmute a track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_set_track_mute(
+    engine: *mut GooeyEngine,
+    track: u32,
+    muted: bool,
+) {
+    if let Some(engine) = engine.as_ref() {
+        engine.graph.set_track_mute(track as usize, muted);
+    }
+}
+
+/// Return a track's mute state, or false for null/bad track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_get_track_mute(
+    engine: *const GooeyEngine,
+    track: u32,
+) -> bool {
+    engine
+        .as_ref()
+        .is_some_and(|engine| engine.graph.track_mute(track as usize))
+}
+
+/// Solo or un-solo a track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_set_track_solo(
+    engine: *mut GooeyEngine,
+    track: u32,
+    soloed: bool,
+) {
+    if let Some(engine) = engine.as_ref() {
+        engine.graph.set_track_solo(track as usize, soloed);
+    }
+}
+
+/// Return a track's solo state, or false for null/bad track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_get_track_solo(
+    engine: *const GooeyEngine,
+    track: u32,
+) -> bool {
+    engine
+        .as_ref()
+        .is_some_and(|engine| engine.graph.track_solo(track as usize))
+}
+
+/// Read and reset a track's post-strip peak. Returns 0.0 for null/bad track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_mixer_get_track_peak(
+    engine: *const GooeyEngine,
+    track: u32,
+) -> f32 {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.graph.track_peak_swap(track as usize))
+        .unwrap_or(0.0)
+}
+
+/// Append an effect to a mixer track. Returns the new slot, or -1 on failure.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_track_effect_add(
+    engine: *mut GooeyEngine,
+    track: u32,
+    effect_id: u32,
+) -> i32 {
+    match engine.as_mut() {
+        Some(engine) => engine
+            .graph
+            .effect_add(track as usize, effect_id)
+            .map_or(-1, |slot| slot as i32),
+        None => -1,
+    }
+}
+
+/// Remove an effect from a mixer track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_track_effect_remove(
+    engine: *mut GooeyEngine,
+    track: u32,
+    slot: u32,
+) -> bool {
+    match engine.as_mut() {
+        Some(engine) => engine.graph.effect_remove(track as usize, slot as usize),
+        None => false,
+    }
+}
+
+/// Move an effect within a mixer track's rack.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_track_effect_move(
+    engine: *mut GooeyEngine,
+    track: u32,
+    slot: u32,
+    new_position: u32,
+) -> bool {
+    match engine.as_mut() {
+        Some(engine) => {
+            engine
+                .graph
+                .effect_move(track as usize, slot as usize, new_position as usize)
+        }
+        None => false,
+    }
+}
+
+/// Clear all effects from a mixer track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_track_effect_clear(engine: *mut GooeyEngine, track: u32) {
+    if let Some(engine) = engine.as_mut() {
+        engine.graph.effect_clear(track as usize);
+    }
+}
+
+/// Set a parameter on a mixer track effect.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_track_effect_set_param(
+    engine: *mut GooeyEngine,
+    track: u32,
+    slot: u32,
+    param: u32,
+    value: f32,
+) {
+    if let Some(engine) = engine.as_ref() {
+        engine
+            .graph
+            .effect_set_param(track as usize, slot as usize, param, value);
+    }
+}
+
+/// Return the number of effects on a mixer track.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_track_effect_count(
+    engine: *const GooeyEngine,
+    track: u32,
+) -> u32 {
+    engine
+        .as_ref()
+        .map_or(0, |engine| engine.graph.effect_count(track as usize) as u32)
+}
+
+/// Return the `EFFECT_*` id at a mixer track effect slot, or -1.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_track_effect_type_at(
+    engine: *const GooeyEngine,
+    track: u32,
+    slot: u32,
+) -> i32 {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.graph.effect_type_at(track as usize, slot as usize))
+        .map_or(-1, |id| id as i32)
 }
 
 // =============================================================================

--- a/src/mixer/graph.rs
+++ b/src/mixer/graph.rs
@@ -292,7 +292,9 @@ impl MixerGraph {
     }
 
     pub fn effect_type_at(&self, track: usize, slot: usize) -> Option<u32> {
-        self.tracks.get(track).and_then(|t| t.rack.effect_type_at(slot))
+        self.tracks
+            .get(track)
+            .and_then(|t| t.rack.effect_type_at(slot))
     }
 
     /// Propagate a new tempo to every track's note-synced effects.
@@ -357,5 +359,109 @@ impl MixerGraph {
             master += f;
         }
         master
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ffi::{EFFECT_DELAY, EFFECT_LOWPASS_FILTER, EFFECT_REVERB};
+
+    const SR: f32 = 44_100.0;
+    const BPM: f32 = 120.0;
+
+    #[test]
+    fn default_layout_has_expected_tracks_and_routes() {
+        let graph = MixerGraph::with_default_layout(SR, BPM);
+
+        assert_eq!(graph.track_count(), 4);
+        assert_eq!(graph.track_name(0).unwrap().to_str().unwrap(), "Drums");
+        assert_eq!(graph.track_name(1).unwrap().to_str().unwrap(), "Bass");
+        assert_eq!(graph.track_name(2).unwrap().to_str().unwrap(), "Synth");
+        assert_eq!(graph.track_name(3).unwrap().to_str().unwrap(), "Loops");
+        assert_eq!(graph.route_of(SOURCE_DRUMKIT), Some(0));
+        assert_eq!(graph.route_of(SOURCE_BASS), Some(1));
+        assert_eq!(graph.route_of(SOURCE_POLYSYNTH), Some(2));
+        assert_eq!(graph.route_of(SOURCE_GRANULATOR), Some(3));
+        assert_eq!(graph.route_of(SOURCE_LOOPMIXER), Some(3));
+    }
+
+    #[test]
+    fn routing_rejects_invalid_source_or_track() {
+        let mut graph = MixerGraph::new(SR, BPM);
+        let track = graph.add_track(CString::new("A").unwrap());
+
+        assert!(graph.route(SOURCE_DRUMKIT, track));
+        assert!(!graph.route(SOURCE_COUNT as u32, track));
+        assert!(!graph.route(SOURCE_BASS, track + 1));
+        assert_eq!(graph.route_of(SOURCE_COUNT as u32), None);
+        assert!(graph.unroute(SOURCE_DRUMKIT));
+        assert!(!graph.unroute(SOURCE_DRUMKIT));
+        assert!(!graph.unroute(SOURCE_COUNT as u32));
+    }
+
+    #[test]
+    fn strip_controls_clamp_and_default_on_bad_index() {
+        let mut graph = MixerGraph::new(SR, BPM);
+        let track = graph.add_track(CString::new("A").unwrap());
+
+        graph.set_track_gain(track, 3.0);
+        assert_eq!(graph.track_gain(track), 2.0);
+        graph.set_track_gain(track, -1.0);
+        assert_eq!(graph.track_gain(track), 0.0);
+        assert_eq!(graph.track_gain(track + 1), 1.0);
+
+        graph.set_track_pan(track, 2.0);
+        assert_eq!(graph.track_pan(track), 1.0);
+        graph.set_track_pan(track, -1.0);
+        assert_eq!(graph.track_pan(track), 0.0);
+        assert_eq!(graph.track_pan(track + 1), 0.5);
+
+        graph.set_track_mute(track, true);
+        graph.set_track_solo(track, true);
+        assert!(graph.track_mute(track));
+        assert!(graph.track_solo(track));
+        assert!(!graph.track_mute(track + 1));
+        assert!(!graph.track_solo(track + 1));
+    }
+
+    #[test]
+    fn effect_rack_adds_moves_removes_and_clears() {
+        let mut graph = MixerGraph::new(SR, BPM);
+        let track = graph.add_track(CString::new("A").unwrap());
+
+        assert_eq!(graph.effect_add(track, EFFECT_DELAY), Some(0));
+        assert_eq!(graph.effect_add(track, EFFECT_LOWPASS_FILTER), Some(1));
+        assert_eq!(graph.effect_add(track, EFFECT_REVERB), Some(2));
+        assert_eq!(graph.effect_count(track), 3);
+
+        assert!(graph.effect_move(track, 2, 0));
+        assert_eq!(graph.effect_type_at(track, 0), Some(EFFECT_REVERB));
+        assert_eq!(graph.effect_type_at(track, 1), Some(EFFECT_DELAY));
+        assert_eq!(graph.effect_type_at(track, 2), Some(EFFECT_LOWPASS_FILTER));
+
+        assert!(graph.effect_remove(track, 1));
+        assert_eq!(graph.effect_count(track), 2);
+        assert!(!graph.effect_remove(track, 99));
+
+        graph.effect_clear(track);
+        assert_eq!(graph.effect_count(track), 0);
+        assert_eq!(graph.effect_add(track + 1, EFFECT_DELAY), None);
+    }
+
+    #[test]
+    fn mix_down_records_and_resets_track_peak() {
+        let mut graph = MixerGraph::new(SR, BPM);
+        let track = graph.add_track(CString::new("A").unwrap());
+        assert!(graph.route(SOURCE_DRUMKIT, track));
+
+        graph.clear_scratch();
+        graph.scatter(SOURCE_DRUMKIT, StereoFrame { l: 0.25, r: -0.5 });
+        let out = graph.mix_down();
+
+        assert_eq!(out, StereoFrame { l: 0.25, r: -0.5 });
+        assert_eq!(graph.track_peak_swap(track), Some(0.5));
+        assert_eq!(graph.track_peak_swap(track), Some(0.0));
+        assert_eq!(graph.track_peak_swap(track + 1), None);
     }
 }

--- a/src/mixer/graph.rs
+++ b/src/mixer/graph.rs
@@ -1,0 +1,361 @@
+//! Host-defined mixer graph: named submix [`Track`]s fed by engine
+//! [`SourceId`]s.
+//!
+//! Where the loop [`Mixer`](crate::mixer::Mixer) owns a fixed set of loop
+//! channels, the `MixerGraph` sits one layer up: it owns an arbitrary,
+//! host-defined set of named tracks and a routing table mapping each engine
+//! source (the drum kit, bass, poly synth, granulator, loop mixer) to a track.
+//! Each track is a mixer strip — gain, stereo balance, mute/solo, peak meter —
+//! plus its own reorderable [`EffectChain`] rack. Tracks sum to the master bus,
+//! which the host engine then scales by master gain and runs through the global
+//! effects + limiter.
+//!
+//! Real-time contract: the audio thread never grows the graph. Track creation,
+//! routing, and rack edits are config-time operations (host-serialized with the
+//! render call, exactly like the loop-effect API). The per-sample path
+//! ([`scatter`](MixerGraph::scatter) / [`mix_down`](MixerGraph::mix_down)) only
+//! touches pre-sized storage and never allocates.
+
+use std::ffi::{CStr, CString};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use crate::frame::StereoFrame;
+use crate::mixer::EffectChain;
+use crate::utils::SmoothedParam;
+
+/// Source: the drum kit (kick/snare/hihat/tom summed).
+pub const SOURCE_DRUMKIT: u32 = 0;
+/// Source: the bass voice.
+pub const SOURCE_BASS: u32 = 1;
+/// Source: the polyphonic synth.
+pub const SOURCE_POLYSYNTH: u32 = 2;
+/// Source: the granulator.
+pub const SOURCE_GRANULATOR: u32 = 3;
+/// Source: the loop mixer (all loop channels summed).
+pub const SOURCE_LOOPMIXER: u32 = 4;
+/// Number of routable engine sources.
+pub const SOURCE_COUNT: usize = 5;
+
+/// Maximum track gain (allows up to +6 dB of makeup on a submix).
+const MAX_TRACK_GAIN: f32 = 2.0;
+
+/// Apply a stereo balance to an already-stereo frame. `pan` is 0.0 (hard left)
+/// .. 0.5 (center) .. 1.0 (hard right). Center is a true identity, so a
+/// default-centered track sums bit-identically to an un-panned mix.
+fn balanced(frame: StereoFrame, pan: f32) -> StereoFrame {
+    let pan = pan.clamp(0.0, 1.0);
+    let left_gain = (2.0 * (1.0 - pan)).min(1.0);
+    let right_gain = (2.0 * pan).min(1.0);
+    StereoFrame {
+        l: frame.l * left_gain,
+        r: frame.r * right_gain,
+    }
+}
+
+/// A named submix bus: a mixer strip (gain / balance / mute-solo / peak) plus a
+/// reorderable effect rack. Sources routed to this track are summed, run through
+/// the strip and rack, then added to the master bus.
+pub struct Track {
+    name: CString,
+    /// Fader, 0.0..=[`MAX_TRACK_GAIN`], 10 ms smoothing.
+    gain: SmoothedParam,
+    /// Stereo balance, 0.0..=1.0 (0.5 = center), 10 ms smoothing.
+    pan: SmoothedParam,
+    /// Click-free mute/solo multiplier (target 0.0 or 1.0).
+    mute_gain: SmoothedParam,
+    muted: AtomicBool,
+    soloed: AtomicBool,
+    /// Post-strip peak since last read (f32 bits, read-and-reset by UI).
+    peak: AtomicU32,
+    /// Track-level effect rack (reused from the loop-channel effect model).
+    rack: EffectChain,
+}
+
+impl Track {
+    fn new(name: CString, sample_rate: f32) -> Self {
+        Self {
+            name,
+            gain: SmoothedParam::new(1.0, 0.0, MAX_TRACK_GAIN, sample_rate, 10.0),
+            pan: SmoothedParam::new(0.5, 0.0, 1.0, sample_rate, 10.0),
+            mute_gain: SmoothedParam::new(1.0, 0.0, 1.0, sample_rate, 10.0),
+            muted: AtomicBool::new(false),
+            soloed: AtomicBool::new(false),
+            peak: AtomicU32::new(0.0_f32.to_bits()),
+            rack: EffectChain::new(),
+        }
+    }
+
+    fn record_peak(&self, level: f32) {
+        let prev = f32::from_bits(self.peak.load(Ordering::Relaxed));
+        if level > prev {
+            self.peak.store(level.to_bits(), Ordering::Relaxed);
+        }
+    }
+}
+
+/// A host-defined set of tracks plus the source→track routing table.
+pub struct MixerGraph {
+    tracks: Vec<Track>,
+    /// `routes[source_kind]` = target track index (or `None` = source is muted).
+    routes: [Option<usize>; SOURCE_COUNT],
+    /// Per-track accumulator, always `tracks.len()` long. Resized only when the
+    /// layout changes (config time); cleared and summed each sample.
+    scratch: Vec<StereoFrame>,
+    sample_rate: f32,
+    bpm: f32,
+}
+
+impl MixerGraph {
+    /// Create an empty graph (no tracks, every source unrouted/silent).
+    pub fn new(sample_rate: f32, bpm: f32) -> Self {
+        Self {
+            tracks: Vec::new(),
+            routes: [None; SOURCE_COUNT],
+            scratch: Vec::new(),
+            sample_rate,
+            bpm,
+        }
+    }
+
+    /// Create the default 4-track layout used out of the box: "Drums", "Bass",
+    /// "Synth", "Loops" at unity gain / centered / no rack, with DrumKit→0,
+    /// Bass→1, PolySynth→2, and Granulator+LoopMixer→3. With this layout the
+    /// summed output is bit-identical to a flat instrument+loop mix.
+    pub fn with_default_layout(sample_rate: f32, bpm: f32) -> Self {
+        let mut graph = Self::new(sample_rate, bpm);
+        let drums = graph.add_track(CString::new("Drums").unwrap());
+        let bass = graph.add_track(CString::new("Bass").unwrap());
+        let synth = graph.add_track(CString::new("Synth").unwrap());
+        let loops = graph.add_track(CString::new("Loops").unwrap());
+        graph.route(SOURCE_DRUMKIT, drums);
+        graph.route(SOURCE_BASS, bass);
+        graph.route(SOURCE_POLYSYNTH, synth);
+        graph.route(SOURCE_GRANULATOR, loops);
+        graph.route(SOURCE_LOOPMIXER, loops);
+        graph
+    }
+
+    /// Reset to an empty layout (no tracks, no routes).
+    pub fn reset(&mut self) {
+        self.tracks.clear();
+        self.scratch.clear();
+        self.routes = [None; SOURCE_COUNT];
+    }
+
+    /// Append a named track. Returns its index. Grows the render scratch so the
+    /// audio thread never allocates.
+    pub fn add_track(&mut self, name: CString) -> usize {
+        self.tracks.push(Track::new(name, self.sample_rate));
+        self.scratch.push(StereoFrame::default());
+        self.tracks.len() - 1
+    }
+
+    pub fn track_count(&self) -> usize {
+        self.tracks.len()
+    }
+
+    /// Borrow a track's name (valid until the track is renamed/removed or the
+    /// graph is reset). `None` for an out-of-range index.
+    pub fn track_name(&self, track: usize) -> Option<&CStr> {
+        self.tracks.get(track).map(|t| t.name.as_c_str())
+    }
+
+    /// Rename a track. Returns `false` for an out-of-range index.
+    pub fn set_track_name(&mut self, track: usize, name: CString) -> bool {
+        match self.tracks.get_mut(track) {
+            Some(t) => {
+                t.name = name;
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// First track index whose name equals `name`, if any.
+    pub fn track_index_by_name(&self, name: &CStr) -> Option<usize> {
+        self.tracks.iter().position(|t| t.name.as_c_str() == name)
+    }
+
+    // --- strip controls (all clamp; no-op on bad index) ---
+
+    pub fn set_track_gain(&mut self, track: usize, gain: f32) {
+        if let Some(t) = self.tracks.get_mut(track) {
+            t.gain.set_target(gain.clamp(0.0, MAX_TRACK_GAIN));
+        }
+    }
+
+    pub fn track_gain(&self, track: usize) -> f32 {
+        self.tracks.get(track).map_or(1.0, |t| t.gain.target())
+    }
+
+    pub fn set_track_pan(&mut self, track: usize, pan: f32) {
+        if let Some(t) = self.tracks.get_mut(track) {
+            t.pan.set_target(pan.clamp(0.0, 1.0));
+        }
+    }
+
+    pub fn track_pan(&self, track: usize) -> f32 {
+        self.tracks.get(track).map_or(0.5, |t| t.pan.target())
+    }
+
+    pub fn set_track_mute(&self, track: usize, muted: bool) {
+        if let Some(t) = self.tracks.get(track) {
+            t.muted.store(muted, Ordering::Release);
+        }
+    }
+
+    pub fn track_mute(&self, track: usize) -> bool {
+        self.tracks
+            .get(track)
+            .is_some_and(|t| t.muted.load(Ordering::Acquire))
+    }
+
+    pub fn set_track_solo(&self, track: usize, soloed: bool) {
+        if let Some(t) = self.tracks.get(track) {
+            t.soloed.store(soloed, Ordering::Release);
+        }
+    }
+
+    pub fn track_solo(&self, track: usize) -> bool {
+        self.tracks
+            .get(track)
+            .is_some_and(|t| t.soloed.load(Ordering::Acquire))
+    }
+
+    /// Read-and-reset a track's post-strip peak. `None` for a bad index.
+    pub fn track_peak_swap(&self, track: usize) -> Option<f32> {
+        self.tracks
+            .get(track)
+            .map(|t| f32::from_bits(t.peak.swap(0.0_f32.to_bits(), Ordering::Relaxed)))
+    }
+
+    // --- routing ---
+
+    /// Route a source to a track. Returns `false` for a bad source kind or
+    /// track index.
+    pub fn route(&mut self, source_kind: u32, track: usize) -> bool {
+        if (source_kind as usize) < SOURCE_COUNT && track < self.tracks.len() {
+            self.routes[source_kind as usize] = Some(track);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Unroute a source (it becomes silent). Returns `true` if it was routed.
+    pub fn unroute(&mut self, source_kind: u32) -> bool {
+        if (source_kind as usize) < SOURCE_COUNT {
+            self.routes[source_kind as usize].take().is_some()
+        } else {
+            false
+        }
+    }
+
+    /// Track a source currently routes to, if any.
+    pub fn route_of(&self, source_kind: u32) -> Option<usize> {
+        self.routes.get(source_kind as usize).copied().flatten()
+    }
+
+    // --- track effect rack (mirrors the loop-effect API) ---
+
+    pub fn effect_add(&mut self, track: usize, effect_id: u32) -> Option<usize> {
+        let (sr, bpm) = (self.sample_rate, self.bpm);
+        self.tracks.get_mut(track)?.rack.add(effect_id, sr, bpm)
+    }
+
+    pub fn effect_remove(&mut self, track: usize, slot: usize) -> bool {
+        self.tracks
+            .get_mut(track)
+            .is_some_and(|t| t.rack.remove(slot))
+    }
+
+    pub fn effect_move(&mut self, track: usize, slot: usize, new_position: usize) -> bool {
+        self.tracks
+            .get_mut(track)
+            .is_some_and(|t| t.rack.move_effect(slot, new_position))
+    }
+
+    pub fn effect_clear(&mut self, track: usize) {
+        if let Some(t) = self.tracks.get_mut(track) {
+            t.rack.clear();
+        }
+    }
+
+    pub fn effect_set_param(&self, track: usize, slot: usize, param: u32, value: f32) {
+        if let Some(t) = self.tracks.get(track) {
+            t.rack.set_param(slot, param, value);
+        }
+    }
+
+    pub fn effect_count(&self, track: usize) -> usize {
+        self.tracks.get(track).map_or(0, |t| t.rack.len())
+    }
+
+    pub fn effect_type_at(&self, track: usize, slot: usize) -> Option<u32> {
+        self.tracks.get(track).and_then(|t| t.rack.effect_type_at(slot))
+    }
+
+    /// Propagate a new tempo to every track's note-synced effects.
+    pub fn set_bpm(&mut self, bpm: f32) {
+        self.bpm = bpm;
+        for t in &self.tracks {
+            t.rack.set_bpm(bpm);
+        }
+    }
+
+    // --- render path (allocation-free) ---
+
+    /// Zero every per-track accumulator. Call once at the top of each sample.
+    pub fn clear_scratch(&mut self) {
+        for s in &mut self.scratch {
+            *s = StereoFrame::default();
+        }
+    }
+
+    /// Add a source's stereo frame into its routed track's accumulator. No-op if
+    /// the source is unrouted.
+    pub fn scatter(&mut self, source_kind: u32, frame: StereoFrame) {
+        if let Some(track) = self.route_of(source_kind) {
+            if let Some(slot) = self.scratch.get_mut(track) {
+                *slot += frame;
+            }
+        }
+    }
+
+    /// Recompute per-track mute/solo targets. Call once per buffer. Solo is
+    /// scoped across tracks: any soloed track silences the un-soloed ones.
+    pub fn update_mute_solo_targets(&mut self) {
+        let any_soloed = self.tracks.iter().any(|t| t.soloed.load(Ordering::Relaxed));
+        for t in &mut self.tracks {
+            let muted = t.muted.load(Ordering::Relaxed);
+            let soloed = t.soloed.load(Ordering::Relaxed);
+            let target = if soloed {
+                1.0
+            } else if any_soloed || muted {
+                0.0
+            } else {
+                1.0
+            };
+            t.mute_gain.set_target(target);
+        }
+    }
+
+    /// Apply each track's strip (gain × mute/solo, balance) and effect rack to
+    /// its accumulated frame, capture its post-strip peak, and return the summed
+    /// master frame. Allocation-free.
+    pub fn mix_down(&mut self) -> StereoFrame {
+        let MixerGraph {
+            tracks, scratch, ..
+        } = self;
+        let mut master = StereoFrame::default();
+        for (i, track) in tracks.iter_mut().enumerate() {
+            let gain = track.gain.tick() * track.mute_gain.tick();
+            let mut f = scratch[i].scaled(gain);
+            f = balanced(f, track.pan.tick());
+            f = track.rack.process(f);
+            track.record_peak(f.l.abs().max(f.r.abs()));
+            master += f;
+        }
+        master
+    }
+}

--- a/src/mixer/graph.rs
+++ b/src/mixer/graph.rs
@@ -342,6 +342,18 @@ impl MixerGraph {
         }
     }
 
+    /// Snap every track strip smoother to its current target. This is useful for
+    /// offline renders that reset time and should honor just-applied host strip
+    /// changes from sample zero instead of replaying a real-time fade.
+    pub fn snap_strip_params(&mut self) {
+        self.update_mute_solo_targets();
+        for t in &mut self.tracks {
+            t.gain.snap();
+            t.pan.snap();
+            t.mute_gain.snap();
+        }
+    }
+
     /// Apply each track's strip (gain × mute/solo, balance) and effect rack to
     /// its accumulated frame, capture its post-strip peak, and return the summed
     /// master frame. Allocation-free.
@@ -463,5 +475,34 @@ mod tests {
         assert_eq!(graph.track_peak_swap(track), Some(0.5));
         assert_eq!(graph.track_peak_swap(track), Some(0.0));
         assert_eq!(graph.track_peak_swap(track + 1), None);
+    }
+
+    #[test]
+    fn snap_strip_params_applies_current_targets_immediately() {
+        let mut graph = MixerGraph::new(SR, BPM);
+        let track = graph.add_track(CString::new("A").unwrap());
+        assert!(graph.route(SOURCE_DRUMKIT, track));
+
+        graph.set_track_gain(track, 0.5);
+        graph.set_track_pan(track, 0.0);
+        graph.snap_strip_params();
+
+        graph.clear_scratch();
+        graph.scatter(SOURCE_DRUMKIT, StereoFrame::mono(1.0));
+        assert_eq!(graph.mix_down(), StereoFrame { l: 0.5, r: 0.0 });
+
+        graph.set_track_mute(track, true);
+        graph.snap_strip_params();
+        graph.clear_scratch();
+        graph.scatter(SOURCE_DRUMKIT, StereoFrame::mono(1.0));
+        assert_eq!(graph.mix_down(), StereoFrame::default());
+
+        let solo_track = graph.add_track(CString::new("B").unwrap());
+        graph.set_track_mute(track, false);
+        graph.set_track_solo(solo_track, true);
+        graph.snap_strip_params();
+        graph.clear_scratch();
+        graph.scatter(SOURCE_DRUMKIT, StereoFrame::mono(1.0));
+        assert_eq!(graph.mix_down(), StereoFrame::default());
     }
 }

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -9,11 +9,13 @@
 //! engine adds to its master bus before the global effects + limiter.
 
 pub mod effect_chain;
+pub mod graph;
 pub mod loop_channel;
 pub mod stereo_buffer;
 mod wsola;
 
 pub use effect_chain::{ChannelEffect, EffectChain};
+pub use graph::MixerGraph;
 pub use loop_channel::{LoopChannel, PitchMode};
 pub use stereo_buffer::StereoSampleBuffer;
 

--- a/tests/mixer_graph.rs
+++ b/tests/mixer_graph.rs
@@ -53,6 +53,19 @@ unsafe fn render_tail_peak(engine: *mut GooeyEngine, frames: usize) -> f32 {
     })
 }
 
+unsafe fn bounce(engine: *mut GooeyEngine, bars: u32) -> Vec<f32> {
+    let mut len = 0;
+    let ptr = gooey_engine_bounce_to_buffer(engine, bars, &mut len);
+    assert!(!ptr.is_null(), "bounce should return a buffer");
+    let out = std::slice::from_raw_parts(ptr, len as usize).to_vec();
+    gooey_engine_free_buffer(ptr, len);
+    out
+}
+
+fn max_abs(buffer: &[f32]) -> f32 {
+    buffer.iter().map(|sample| sample.abs()).fold(0.0, f32::max)
+}
+
 unsafe fn track_name(engine: *const GooeyEngine, track: u32) -> String {
     let ptr = gooey_engine_mixer_get_track_name(engine, track);
     assert!(!ptr.is_null(), "track {track} should have a name");
@@ -365,5 +378,44 @@ fn track_peaks_report_and_reset_after_render() {
         assert_eq!(gooey_engine_mixer_get_track_peak(engine, 0), 0.0);
 
         gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn offline_bounce_snaps_recent_mixer_strip_changes() {
+    unsafe {
+        let gain_engine = gooey_engine_new(SAMPLE_RATE);
+        gooey_engine_sequencer_set_step(gain_engine, 0, true);
+        gooey_engine_mixer_set_track_gain(gain_engine, 0, 0.0);
+        let gain_bounce = bounce(gain_engine, 1);
+        assert_eq!(gain_bounce.len(), 88_200);
+        assert!(
+            max_abs(&gain_bounce) < 1e-6,
+            "track gain should silence from sample zero in offline bounce, peak {}",
+            max_abs(&gain_bounce)
+        );
+        gooey_engine_free(gain_engine);
+
+        let mute_engine = gooey_engine_new(SAMPLE_RATE);
+        gooey_engine_sequencer_set_step(mute_engine, 0, true);
+        gooey_engine_mixer_set_track_mute(mute_engine, 0, true);
+        let mute_bounce = bounce(mute_engine, 1);
+        assert!(
+            max_abs(&mute_bounce) < 1e-6,
+            "track mute should silence from sample zero in offline bounce, peak {}",
+            max_abs(&mute_bounce)
+        );
+        gooey_engine_free(mute_engine);
+
+        let solo_engine = gooey_engine_new(SAMPLE_RATE);
+        gooey_engine_sequencer_set_step(solo_engine, 0, true);
+        gooey_engine_mixer_set_track_solo(solo_engine, 1, true);
+        let solo_bounce = bounce(solo_engine, 1);
+        assert!(
+            max_abs(&solo_bounce) < 1e-6,
+            "soloing another track should silence drums from sample zero in offline bounce, peak {}",
+            max_abs(&solo_bounce)
+        );
+        gooey_engine_free(solo_engine);
     }
 }

--- a/tests/mixer_graph.rs
+++ b/tests/mixer_graph.rs
@@ -1,0 +1,369 @@
+//! End-to-end tests for the host-facing mixer graph FFI.
+
+use std::ffi::{CStr, CString};
+
+use gooey::ffi::*;
+
+const SAMPLE_RATE: f32 = 44_100.0;
+
+fn cstr(s: &str) -> CString {
+    CString::new(s).unwrap()
+}
+
+fn stereo_sine(seconds: f32, hz: f32) -> Vec<f32> {
+    let frames = (SAMPLE_RATE * seconds) as usize;
+    let mut out = Vec::with_capacity(frames * 2);
+    for i in 0..frames {
+        let s = (i as f32 / SAMPLE_RATE * hz * std::f32::consts::TAU).sin() * 0.5;
+        out.push(s);
+        out.push(s);
+    }
+    out
+}
+
+unsafe fn load_loop(engine: *mut GooeyEngine, hz: f32) {
+    let samples = stereo_sine(0.5, hz);
+    let frames = (samples.len() / 2) as u32;
+    assert!(gooey_engine_loop_load(
+        engine,
+        0,
+        samples.as_ptr(),
+        frames,
+        2,
+        SAMPLE_RATE,
+    ));
+    gooey_engine_loop_set_playing(engine, 0, true);
+}
+
+unsafe fn render_peak(engine: *mut GooeyEngine, frames: usize) -> f32 {
+    let mut buffer = vec![0.0_f32; frames * 2];
+    gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+    buffer.iter().fold(0.0, |acc, sample| {
+        assert!(sample.is_finite(), "render output must stay finite");
+        acc.max(sample.abs())
+    })
+}
+
+unsafe fn render_tail_peak(engine: *mut GooeyEngine, frames: usize) -> f32 {
+    let mut buffer = vec![0.0_f32; frames * 2];
+    gooey_engine_render(engine, buffer.as_mut_ptr(), frames as u32);
+    buffer[frames..].iter().fold(0.0, |acc, sample| {
+        assert!(sample.is_finite(), "render output must stay finite");
+        acc.max(sample.abs())
+    })
+}
+
+unsafe fn track_name(engine: *const GooeyEngine, track: u32) -> String {
+    let ptr = gooey_engine_mixer_get_track_name(engine, track);
+    assert!(!ptr.is_null(), "track {track} should have a name");
+    CStr::from_ptr(ptr).to_str().unwrap().to_owned()
+}
+
+#[test]
+fn default_layout_names_routes_and_source_constants() {
+    unsafe {
+        assert_eq!(SOURCE_DRUMKIT, 0);
+        assert_eq!(SOURCE_BASS, 1);
+        assert_eq!(SOURCE_POLYSYNTH, 2);
+        assert_eq!(SOURCE_GRANULATOR, 3);
+        assert_eq!(SOURCE_LOOPMIXER, 4);
+        assert_eq!(SOURCE_COUNT, 5);
+
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        assert_eq!(gooey_engine_mixer_get_track_count(engine), 4);
+        assert_eq!(track_name(engine, 0), "Drums");
+        assert_eq!(track_name(engine, 1), "Bass");
+        assert_eq!(track_name(engine, 2), "Synth");
+        assert_eq!(track_name(engine, 3), "Loops");
+        assert!(gooey_engine_mixer_get_track_name(engine, 99).is_null());
+
+        assert_eq!(
+            gooey_engine_mixer_get_source_route(engine, SOURCE_DRUMKIT),
+            0
+        );
+        assert_eq!(gooey_engine_mixer_get_source_route(engine, SOURCE_BASS), 1);
+        assert_eq!(
+            gooey_engine_mixer_get_source_route(engine, SOURCE_POLYSYNTH),
+            2
+        );
+        assert_eq!(
+            gooey_engine_mixer_get_source_route(engine, SOURCE_GRANULATOR),
+            3
+        );
+        assert_eq!(
+            gooey_engine_mixer_get_source_route(engine, SOURCE_LOOPMIXER),
+            3
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn layout_editing_round_trips_and_reset_restores_defaults() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        gooey_engine_mixer_clear_layout(engine);
+        assert_eq!(gooey_engine_mixer_get_track_count(engine), 0);
+        assert_eq!(
+            gooey_engine_mixer_get_source_route(engine, SOURCE_DRUMKIT),
+            -1
+        );
+
+        let drums = cstr("Drums A");
+        let track = gooey_engine_mixer_add_track(engine, drums.as_ptr());
+        assert_eq!(track, 0);
+        assert_eq!(track_name(engine, 0), "Drums A");
+        assert_eq!(gooey_engine_mixer_find_track(engine, drums.as_ptr()), 0);
+
+        let renamed = cstr("Kit Bus");
+        assert!(gooey_engine_mixer_set_track_name(
+            engine,
+            0,
+            renamed.as_ptr()
+        ));
+        assert_eq!(track_name(engine, 0), "Kit Bus");
+        assert_eq!(gooey_engine_mixer_find_track(engine, drums.as_ptr()), -1);
+        assert_eq!(gooey_engine_mixer_find_track(engine, renamed.as_ptr()), 0);
+
+        gooey_engine_mixer_reset_default_layout(engine);
+        assert_eq!(gooey_engine_mixer_get_track_count(engine), 4);
+        assert_eq!(track_name(engine, 0), "Drums");
+        assert_eq!(
+            gooey_engine_mixer_get_source_route(engine, SOURCE_DRUMKIT),
+            0
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn routing_and_invalid_inputs_are_safe() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        let bus = cstr("Extra");
+        let extra = gooey_engine_mixer_add_track(engine, bus.as_ptr()) as u32;
+
+        assert!(gooey_engine_mixer_route_source(
+            engine,
+            SOURCE_LOOPMIXER,
+            extra
+        ));
+        assert_eq!(
+            gooey_engine_mixer_get_source_route(engine, SOURCE_LOOPMIXER),
+            extra as i32
+        );
+        assert!(gooey_engine_mixer_unroute_source(engine, SOURCE_LOOPMIXER));
+        assert_eq!(
+            gooey_engine_mixer_get_source_route(engine, SOURCE_LOOPMIXER),
+            -1
+        );
+        assert!(!gooey_engine_mixer_unroute_source(engine, SOURCE_LOOPMIXER));
+        assert!(!gooey_engine_mixer_route_source(engine, SOURCE_COUNT, 0));
+        assert!(!gooey_engine_mixer_route_source(engine, SOURCE_DRUMKIT, 99));
+
+        assert_eq!(gooey_engine_mixer_get_track_count(std::ptr::null()), 0);
+        assert_eq!(
+            gooey_engine_mixer_add_track(std::ptr::null_mut(), bus.as_ptr()),
+            -1
+        );
+        assert_eq!(gooey_engine_mixer_add_track(engine, std::ptr::null()), -1);
+        assert!(!gooey_engine_mixer_set_track_name(
+            engine,
+            0,
+            std::ptr::null()
+        ));
+        assert_eq!(gooey_engine_mixer_find_track(engine, std::ptr::null()), -1);
+        assert!(!gooey_engine_mixer_route_source(
+            std::ptr::null_mut(),
+            SOURCE_DRUMKIT,
+            0
+        ));
+        assert_eq!(
+            gooey_engine_mixer_get_source_route(std::ptr::null(), SOURCE_DRUMKIT),
+            -1
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn track_strip_controls_round_trip_and_clamp() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        gooey_engine_mixer_set_track_gain(engine, 0, 3.0);
+        assert_eq!(gooey_engine_mixer_get_track_gain(engine, 0), 2.0);
+        gooey_engine_mixer_set_track_gain(engine, 0, -1.0);
+        assert_eq!(gooey_engine_mixer_get_track_gain(engine, 0), 0.0);
+        assert_eq!(gooey_engine_mixer_get_track_gain(engine, 99), 1.0);
+
+        gooey_engine_mixer_set_track_pan(engine, 0, 2.0);
+        assert_eq!(gooey_engine_mixer_get_track_pan(engine, 0), 1.0);
+        gooey_engine_mixer_set_track_pan(engine, 0, -1.0);
+        assert_eq!(gooey_engine_mixer_get_track_pan(engine, 0), 0.0);
+        assert_eq!(gooey_engine_mixer_get_track_pan(engine, 99), 0.5);
+
+        gooey_engine_mixer_set_track_mute(engine, 0, true);
+        gooey_engine_mixer_set_track_solo(engine, 0, true);
+        assert!(gooey_engine_mixer_get_track_mute(engine, 0));
+        assert!(gooey_engine_mixer_get_track_solo(engine, 0));
+        assert!(!gooey_engine_mixer_get_track_mute(engine, 99));
+        assert!(!gooey_engine_mixer_get_track_solo(engine, 99));
+        assert_eq!(gooey_engine_mixer_get_track_peak(engine, 99), 0.0);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn track_effect_chain_edit_operations() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        assert_eq!(
+            gooey_engine_track_effect_add(engine, 0, EFFECT_LOWPASS_FILTER),
+            0
+        );
+        assert_eq!(gooey_engine_track_effect_add(engine, 0, EFFECT_DELAY), 1);
+        assert_eq!(gooey_engine_track_effect_add(engine, 0, EFFECT_REVERB), 2);
+        assert_eq!(gooey_engine_track_effect_count(engine, 0), 3);
+
+        assert!(gooey_engine_track_effect_move(engine, 0, 2, 0));
+        assert_eq!(
+            gooey_engine_track_effect_type_at(engine, 0, 0),
+            EFFECT_REVERB as i32
+        );
+        assert_eq!(
+            gooey_engine_track_effect_type_at(engine, 0, 1),
+            EFFECT_LOWPASS_FILTER as i32
+        );
+
+        gooey_engine_track_effect_set_param(engine, 0, 1, FILTER_PARAM_CUTOFF, 300.0);
+        assert!(gooey_engine_track_effect_remove(engine, 0, 1));
+        assert_eq!(gooey_engine_track_effect_count(engine, 0), 2);
+        assert!(!gooey_engine_track_effect_remove(engine, 0, 99));
+
+        gooey_engine_track_effect_clear(engine, 0);
+        assert_eq!(gooey_engine_track_effect_count(engine, 0), 0);
+        assert_eq!(gooey_engine_track_effect_type_at(engine, 0, 0), -1);
+        assert_eq!(gooey_engine_track_effect_add(engine, 99, EFFECT_DELAY), -1);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn track_gain_and_mute_silence_only_their_routed_source() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        load_loop(engine, 220.0);
+
+        let audible_loop = render_tail_peak(engine, 8192);
+        assert!(audible_loop > 1e-3);
+
+        gooey_engine_mixer_set_track_mute(engine, 3, true);
+        let muted_loop = render_tail_peak(engine, 8192);
+        assert!(
+            muted_loop < audible_loop * 0.02,
+            "muted loop track should silence loop source: audible {audible_loop}, muted {muted_loop}"
+        );
+
+        gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
+        let kick = render_peak(engine, 2048);
+        assert!(
+            kick > 1e-4,
+            "drum track should remain audible while loop track is muted: {kick}"
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn rerouting_source_changes_which_track_controls_it() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        load_loop(engine, 330.0);
+
+        let default = render_tail_peak(engine, 8192);
+        assert!(default > 1e-3);
+
+        gooey_engine_mixer_set_track_gain(engine, 3, 0.0);
+        let muted_default_route = render_tail_peak(engine, 8192);
+        assert!(muted_default_route < default * 0.02);
+
+        let new_track = gooey_engine_mixer_add_track(engine, cstr("Loop Bus").as_ptr()) as u32;
+        assert!(gooey_engine_mixer_route_source(
+            engine,
+            SOURCE_LOOPMIXER,
+            new_track
+        ));
+        let rerouted = render_tail_peak(engine, 8192);
+        assert!(
+            rerouted > default * 0.5,
+            "new track at unity should restore rerouted loop: default {default}, rerouted {rerouted}"
+        );
+
+        gooey_engine_mixer_set_track_gain(engine, new_track, 0.0);
+        let muted_new_route = render_tail_peak(engine, 8192);
+        assert!(muted_new_route < rerouted * 0.02);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn track_effect_changes_only_audio_routed_to_that_track() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        load_loop(engine, 6_000.0);
+
+        let dry = render_tail_peak(engine, 8192);
+        assert!(dry > 1e-3);
+
+        let slot = gooey_engine_track_effect_add(engine, 3, EFFECT_LOWPASS_FILTER);
+        assert_eq!(slot, 0);
+        gooey_engine_track_effect_set_param(engine, 3, 0, FILTER_PARAM_CUTOFF, 300.0);
+        let _ = render_tail_peak(engine, 8192);
+        let filtered = render_tail_peak(engine, 8192);
+        assert!(
+            filtered < dry * 0.6,
+            "track lowpass should attenuate bright loop: dry {dry}, filtered {filtered}"
+        );
+
+        let dry_track = gooey_engine_mixer_add_track(engine, cstr("Dry Loop").as_ptr()) as u32;
+        assert!(gooey_engine_mixer_route_source(
+            engine,
+            SOURCE_LOOPMIXER,
+            dry_track
+        ));
+        let rerouted_dry = render_tail_peak(engine, 8192);
+        assert!(
+            rerouted_dry > filtered * 1.5,
+            "rerouted loop should bypass old track effect: filtered {filtered}, rerouted {rerouted_dry}"
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn track_peaks_report_and_reset_after_render() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+
+        gooey_engine_trigger_instrument(engine, INSTRUMENT_KICK);
+        let audible = render_peak(engine, 2048);
+        assert!(audible > 1e-4);
+
+        let peak = gooey_engine_mixer_get_track_peak(engine, 0);
+        assert!(peak > 1e-4, "drum track peak should be nonzero: {peak}");
+        assert_eq!(gooey_engine_mixer_get_track_peak(engine, 0), 0.0);
+
+        gooey_engine_free(engine);
+    }
+}


### PR DESCRIPTION
Refactors the FFI engine voice state into drum-kit and bass voice strips, then routes drum kit, bass, synth, granulator, and loop mixer sources through a new host-defined MixerGraph. Exposes mixer graph layout, routing, track strip, metering, and track-effect controls through C FFI. Adds focused graph unit tests plus end-to-end FFI/audio coverage for default routes, invalid inputs, rerouting, track effects, mute/gain, and peak reset behavior. Validated with `cargo test --all-targets` and `cargo check --no-default-features --features ios --all-targets`.