### PR TITLE
Balance iOS distortion effects

### DIFF
--- a/src/effects/feedback_waveshaper.rs
+++ b/src/effects/feedback_waveshaper.rs
@@ -26,6 +26,14 @@ const ENV_RELEASE_MS: f32 = 120.0;
 /// blow-up as the envelope approaches zero and prevents extreme boost in silence.
 const ENV_FLOOR: f32 = 0.05;
 
+/// Feedback no longer needs to be fully loudness-neutral at high settings: in
+/// Ripple it is a selectable distortion color next to the tube saturator, so
+/// the top of the range should get comparably loud and aggressive while the
+/// lower range remains controlled.
+const FEEDBACK_COMPENSATION_TAMING: f32 = 0.25;
+const HIGH_END_MAKEUP_DB: f32 = 5.1;
+const MAX_COMPENSATION_GAIN: f32 = 3.0;
+
 /// Waveshaper with feedback loop for richer harmonic distortion
 ///
 /// The feedback path includes a one-pole lowpass filter (controllable cutoff)
@@ -133,13 +141,7 @@ impl FeedbackWaveshaper {
             self.env = 0.0;
         }
 
-        // Gain compensation: maintain consistent output level across all drive values.
-        // Since last_out is already compensated, the loop gain is feedback * compensation.
-        // Solving for equal loudness with and without feedback gives:
-        //   compensation = comp_no_fb / (1 + comp_no_fb * feedback)
-        let reference = self.env.max(ENV_FLOOR);
-        let comp_no_fb = reference.tanh() / (reference * self.drive).tanh();
-        let compensation = comp_no_fb / (1.0 + comp_no_fb * self.feedback);
+        let compensation = Self::gain_compensation(self.env, self.drive, self.feedback);
         let compensated = shaped * compensation;
 
         // DC block the output
@@ -239,6 +241,21 @@ impl FeedbackWaveshaper {
     #[inline]
     fn compute_env_coeff(time_ms: f32, sample_rate: f32) -> f32 {
         (-1.0 / (time_ms / 1000.0 * sample_rate)).exp()
+    }
+
+    #[inline]
+    fn gain_compensation(env: f32, drive: f32, feedback: f32) -> f32 {
+        let reference = env.max(ENV_FLOOR);
+        let driven_reference = (reference * drive).tanh().abs().max(1e-6);
+        let comp_no_fb = reference.tanh() / driven_reference;
+
+        let drive_norm = ((drive - 1.0) / 99.0).clamp(0.0, 1.0);
+        let feedback_norm = (feedback / 0.98).clamp(0.0, 1.0);
+        let high_end = drive_norm.powf(1.35) * feedback_norm.powf(2.0);
+        let high_end_makeup = 10.0_f32.powf(HIGH_END_MAKEUP_DB * high_end / 20.0);
+
+        let feedback_taming = 1.0 / (1.0 + comp_no_fb * feedback * FEEDBACK_COMPENSATION_TAMING);
+        (comp_no_fb * feedback_taming * high_end_makeup).min(MAX_COMPENSATION_GAIN)
     }
 
     #[inline]
@@ -407,11 +424,12 @@ mod tests {
 
     #[test]
     fn test_feedback_gain_compensation() {
-        // Verify that feedback doesn't significantly increase perceived loudness
+        // Feedback is allowed to add intentional loudness at high settings, but
+        // it should remain bounded so the feedback loop is musically useful.
         let input_signal: Vec<f32> = (0..4000).map(|i| (i as f32 * 0.1).sin() * 0.5).collect();
 
         let mut ws_no_fb = FeedbackWaveshaper::new(44100.0, 5.0, 0.0, 2000.0, 1.0);
-        let mut ws_fb = FeedbackWaveshaper::new(44100.0, 5.0, 0.7, 2000.0, 1.0);
+        let mut ws_fb = FeedbackWaveshaper::new(44100.0, 100.0, 0.98, 2000.0, 1.0);
 
         let rms_no_fb: f32 = input_signal
             .iter()
@@ -426,8 +444,9 @@ mod tests {
 
         let rms_ratio = (rms_fb / rms_no_fb).sqrt();
         assert!(
-            rms_ratio < 1.5,
-            "feedback increased RMS by {:.0}%, expected <50%",
+            rms_ratio > 1.0 && rms_ratio < 5.0,
+            "feedback RMS ratio should be intentionally louder but bounded; got {:.2}x ({:.0}%)",
+            rms_ratio,
             (rms_ratio - 1.0) * 100.0
         );
     }

--- a/tests/effect_distortion_balance.rs
+++ b/tests/effect_distortion_balance.rs
@@ -1,0 +1,128 @@
+use std::f64::consts::TAU;
+
+use gooey::effects::{Effect, FeedbackWaveshaper, TubeSaturation};
+
+const SAMPLE_RATE: f32 = 48_000.0;
+const N: usize = 8192;
+const WARMUP: usize = 8192;
+const FUNDAMENTAL_BIN: usize = 37;
+const INPUT_AMP: f32 = 0.5;
+
+fn fundamental_hz() -> f32 {
+    FUNDAMENTAL_BIN as f32 * SAMPLE_RATE / N as f32
+}
+
+fn render_input() -> Vec<f32> {
+    let mut out = Vec::with_capacity(N);
+    for i in WARMUP..(WARMUP + N) {
+        let phase = TAU * FUNDAMENTAL_BIN as f64 * i as f64 / N as f64;
+        out.push(phase.sin() as f32 * INPUT_AMP);
+    }
+    out
+}
+
+fn render_saturation(drive: f32, warmth: f32) -> Vec<f32> {
+    let sat = TubeSaturation::new(SAMPLE_RATE, drive, warmth, 1.0);
+    let mut out = Vec::with_capacity(N);
+    for i in 0..(WARMUP + N) {
+        let phase = TAU * fundamental_hz() as f64 * i as f64 / SAMPLE_RATE as f64;
+        let sample = phase.sin() as f32 * INPUT_AMP;
+        let processed = sat.process(sample);
+        if i >= WARMUP {
+            out.push(processed);
+        }
+    }
+    out
+}
+
+fn render_feedback(drive: f32, feedback: f32) -> Vec<f32> {
+    let mut ws = FeedbackWaveshaper::new(SAMPLE_RATE, drive, feedback, 2000.0, 1.0);
+    let mut out = Vec::with_capacity(N);
+    for i in 0..(WARMUP + N) {
+        let phase = TAU * fundamental_hz() as f64 * i as f64 / SAMPLE_RATE as f64;
+        let sample = phase.sin() as f32 * INPUT_AMP;
+        let processed = ws.process(sample);
+        if i >= WARMUP {
+            out.push(processed);
+        }
+    }
+    out
+}
+
+fn rms(samples: &[f32]) -> f64 {
+    let mean_square = samples
+        .iter()
+        .map(|&s| {
+            let s = s as f64;
+            s * s
+        })
+        .sum::<f64>()
+        / samples.len() as f64;
+    mean_square.sqrt()
+}
+
+fn gain_db(processed: &[f32], dry: &[f32]) -> f64 {
+    20.0 * (rms(processed) / rms(dry).max(1e-30)).log10()
+}
+
+fn bin_power(samples: &[f32], bin: usize) -> f64 {
+    let n = samples.len();
+    let step = TAU * bin as f64 / n as f64;
+    let (mut re, mut im) = (0.0_f64, 0.0_f64);
+    for (i, &s) in samples.iter().enumerate() {
+        let phase = step * i as f64;
+        re += s as f64 * phase.cos();
+        im -= s as f64 * phase.sin();
+    }
+    re * re + im * im
+}
+
+fn harmonic_distortion(samples: &[f32]) -> f64 {
+    let fundamental = bin_power(samples, FUNDAMENTAL_BIN).max(1e-30);
+    let harmonic_power = (2..=10)
+        .map(|harmonic| FUNDAMENTAL_BIN * harmonic)
+        .take_while(|&bin| bin < N / 2)
+        .map(|bin| bin_power(samples, bin))
+        .sum::<f64>();
+    (harmonic_power / fundamental).sqrt()
+}
+
+#[test]
+fn max_feedback_matches_saturation_gain_and_distortion() {
+    let dry = render_input();
+    let saturation = render_saturation(1.0, 0.5);
+    let feedback = render_feedback(100.0, 0.98);
+
+    let saturation_gain_db = gain_db(&saturation, &dry);
+    let feedback_gain_db = gain_db(&feedback, &dry);
+    let gain_diff_db = feedback_gain_db - saturation_gain_db;
+
+    assert!(
+        gain_diff_db.abs() <= 1.5,
+        "max feedback gain ({feedback_gain_db:.2} dB) should be within 1.5 dB of saturation ({saturation_gain_db:.2} dB); diff={gain_diff_db:.2} dB"
+    );
+
+    let saturation_distortion = harmonic_distortion(&saturation);
+    let feedback_distortion = harmonic_distortion(&feedback);
+
+    assert!(
+        feedback_distortion >= saturation_distortion * 0.9,
+        "max feedback distortion ({feedback_distortion:.4}) should be at least 90% of saturation ({saturation_distortion:.4})"
+    );
+}
+
+#[test]
+fn mid_feedback_stays_near_mid_saturation_gain() {
+    let dry = render_input();
+    let saturation = render_saturation(0.5, 0.4);
+    let feedback = render_feedback(50.0, 0.49);
+
+    let saturation_gain_db = gain_db(&saturation, &dry);
+    let feedback_gain_db = gain_db(&feedback, &dry);
+    let gain_diff_db = feedback_gain_db - saturation_gain_db;
+
+    assert!(
+        gain_diff_db.abs() <= 3.0,
+        "mid feedback gain ({feedback_gain_db:.2} dB) should stay within 3 dB of mid saturation ({saturation_gain_db:.2} dB); diff={gain_diff_db:.2} dB"
+    );
+}


### PR DESCRIPTION
Updates the feedback waveshaper compensation so high drive and feedback settings become louder and more extreme while remaining bounded and stable.
Adds deterministic distortion-balance tests comparing feedback waveshaper RMS gain and harmonic distortion against tube saturation at mid and max settings.
Keeps the existing FFI/API controls unchanged.

Validation: cargo test --test effect_distortion_balance; cargo test feedback_waveshaper; cargo test --no-default-features --features ios.