### PR TITLE
Add Stage 1 performance recording for live chord pads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,10 @@ name = "multi_channel_submix"
 required-features = ["native", "crossterm"]
 
 [[example]]
+name = "performance_record"
+required-features = ["native", "crossterm"]
+
+[[example]]
 name = "antialias_validation"
 required-features = ["bounce"]
 

--- a/examples/performance_record.rs
+++ b/examples/performance_record.rs
@@ -1,0 +1,596 @@
+//! Performance Recording Demo — basic CLI for Stage 1 chord clip capture.
+//!
+//! Plays a simple drum loop, lets you press chord pads (1–7), and record them
+//! into a looping clip with punch-out or overdub modes.
+//!
+//! Run with:
+//!   cargo run --example performance_record --features native,crossterm
+
+#[cfg(feature = "native")]
+use cpal::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    FromSample, Sample, SizedSample, Stream, StreamConfig,
+};
+#[cfg(feature = "native")]
+use crossterm::{
+    cursor,
+    event::{
+        self, Event, KeyCode, KeyEvent, KeyEventKind, KeyboardEnhancementFlags,
+        PushKeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+    },
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
+};
+#[cfg(feature = "native")]
+use gooey::ffi::*;
+#[cfg(feature = "native")]
+use std::cell::RefCell;
+#[cfg(feature = "native")]
+use std::io::{self, Write};
+#[cfg(feature = "native")]
+use std::sync::{Arc, Mutex};
+#[cfg(feature = "native")]
+use std::time::{Duration, Instant};
+
+#[cfg(feature = "native")]
+const DEFAULT_BPM: f32 = 120.0;
+#[cfg(feature = "native")]
+const DEGREE_LABELS: [&str; 7] = ["I", "II", "III", "IV", "V", "VI", "VII"];
+#[cfg(feature = "native")]
+const UI_REFRESH: Duration = Duration::from_millis(100);
+
+/// Snapshot of engine state for UI drawing. Taken under a short lock so the
+/// audio thread is not blocked (or forced to output silence) during terminal I/O.
+#[cfg(feature = "native")]
+struct UiSnapshot {
+    armed: bool,
+    recording: bool,
+    mode: u32,
+    event_count: u32,
+    length_steps: u32,
+    step: i32,
+    beat: f64,
+    events: Vec<(u32, u32, u32, f32)>, // start, dur, degree, velocity
+}
+
+#[cfg(feature = "native")]
+struct FfiEngine {
+    ptr: *mut GooeyEngine,
+}
+
+#[cfg(feature = "native")]
+unsafe impl Send for FfiEngine {}
+
+#[cfg(feature = "native")]
+impl FfiEngine {
+    fn new(sample_rate: f32) -> Self {
+        Self {
+            ptr: gooey_engine_new(sample_rate),
+        }
+    }
+
+    fn ptr(&self) -> *mut GooeyEngine {
+        self.ptr
+    }
+}
+
+#[cfg(feature = "native")]
+impl Drop for FfiEngine {
+    fn drop(&mut self) {
+        unsafe {
+            gooey_engine_free(self.ptr);
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+struct AppState {
+    playing: bool,
+    holding_degree: Option<u32>,
+    root: u32,
+    scale: u32, // 0 major, 1 minor
+    octave: i32,
+    preset: u32,
+}
+
+#[cfg(feature = "native")]
+fn bool_pattern(steps: &[usize]) -> [bool; 16] {
+    let mut pattern = [false; 16];
+    for &step in steps {
+        pattern[step % 16] = true;
+    }
+    pattern
+}
+
+#[cfg(feature = "native")]
+fn configure_engine(engine: *mut GooeyEngine) {
+    unsafe {
+        gooey_engine_set_bpm(engine, DEFAULT_BPM);
+        gooey_engine_set_master_gain(engine, 0.85);
+
+        // Simple four-on-floor so you can hear loop boundaries while recording.
+        let kick = bool_pattern(&[0, 4, 8, 12]);
+        let snare = bool_pattern(&[4, 12]);
+        let hat = bool_pattern(&[0, 2, 4, 6, 8, 10, 12, 14]);
+        gooey_engine_sequencer_set_instrument_pattern(engine, INSTRUMENT_KICK, kick.as_ptr());
+        gooey_engine_sequencer_set_instrument_pattern(engine, INSTRUMENT_SNARE, snare.as_ptr());
+        gooey_engine_sequencer_set_instrument_pattern(engine, INSTRUMENT_HIHAT, hat.as_ptr());
+        for step in 0..16u32 {
+            gooey_engine_sequencer_set_instrument_step_velocity(
+                engine,
+                INSTRUMENT_HIHAT,
+                step,
+                if step % 4 == 0 { 0.5 } else { 0.3 },
+            );
+        }
+
+        // Default record mode: punch-out (one bar then auto-disarm).
+        gooey_engine_perf_set_record_mode(engine, PERF_RECORD_MODE_PUNCH_OUT);
+        gooey_engine_perf_set_record_armed(engine, false);
+
+        // Start transport so the first arm can wait for loop start cleanly.
+        gooey_engine_sequencer_start(engine);
+    }
+}
+
+#[cfg(feature = "native")]
+fn mode_label(mode: u32) -> &'static str {
+    if mode == PERF_RECORD_MODE_OVERDUB {
+        "OVERDUB"
+    } else {
+        "PUNCH-OUT"
+    }
+}
+
+#[cfg(feature = "native")]
+fn scale_label(scale: u32) -> &'static str {
+    if scale == 0 {
+        "Major"
+    } else {
+        "Minor"
+    }
+}
+
+#[cfg(feature = "native")]
+fn root_label(root: u32) -> &'static str {
+    const NAMES: [&str; 12] = [
+        "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
+    ];
+    NAMES[(root as usize) % 12]
+}
+
+#[cfg(feature = "native")]
+fn snapshot_ui(engine: *mut GooeyEngine) -> UiSnapshot {
+    unsafe {
+        let event_count = gooey_engine_perf_get_event_count(engine);
+        let show = event_count.min(12);
+        let mut events = Vec::with_capacity(show as usize);
+        for i in 0..show {
+            let mut start = 0u32;
+            let mut dur = 0u32;
+            let mut degree = 0u32;
+            let mut velocity = 0.0f32;
+            if gooey_engine_perf_get_event(
+                engine,
+                i,
+                &mut start,
+                &mut dur,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut degree,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut velocity,
+            ) {
+                events.push((start, dur, degree, velocity));
+            }
+        }
+        UiSnapshot {
+            armed: gooey_engine_perf_is_record_armed(engine),
+            recording: gooey_engine_perf_is_recording(engine),
+            mode: gooey_engine_perf_get_record_mode(engine),
+            event_count,
+            length_steps: gooey_engine_perf_get_length_steps(engine),
+            step: gooey_engine_sequencer_get_current_step(engine),
+            beat: gooey_engine_sequencer_get_beat_position(engine),
+            events,
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+fn draw_ui(snap: &UiSnapshot, state: &AppState) -> io::Result<()> {
+    // Raw mode: newlines must be \r\n or the cursor only moves down (staircase layout).
+    execute!(
+        io::stdout(),
+        cursor::MoveTo(0, 0),
+        Clear(ClearType::FromCursorDown)
+    )?;
+
+    print!("=== Performance Recording Demo ===\r\n");
+    print!("\r\n");
+    print!(
+        "Transport: {}   BPM: {:.0}   step: {:>2}/{}   beat: {:.2}\r\n",
+        if state.playing { "PLAY" } else { "STOP" },
+        DEFAULT_BPM,
+        snap.step.max(0),
+        snap.length_steps,
+        snap.beat
+    );
+    print!(
+        "Key: {} {}   Octave: {}   Preset: pad\r\n",
+        root_label(state.root),
+        scale_label(state.scale),
+        state.octave
+    );
+    print!("\r\n");
+
+    let rec_status = if snap.recording {
+        "RECORDING"
+    } else if snap.armed {
+        "ARMED (wait for loop)"
+    } else {
+        "idle"
+    };
+    print!(
+        "Record: {:<22}  mode: {}\r\n",
+        rec_status,
+        mode_label(snap.mode)
+    );
+    print!("Clip events: {}\r\n", snap.event_count);
+    print!("\r\n");
+
+    print!("Pads: ");
+    for (i, label) in DEGREE_LABELS.iter().enumerate() {
+        if state.holding_degree == Some(i as u32) {
+            print!("[{}] ", label);
+        } else {
+            print!(" {}  ", label);
+        }
+    }
+    print!("\r\n");
+    print!("Keys: 1-7 hold chords\r\n");
+    print!("\r\n");
+
+    print!("Recorded events:\r\n");
+    if snap.events.is_empty() {
+        print!("  (empty)\r\n");
+    } else {
+        for (i, (start, dur, degree, velocity)) in snap.events.iter().enumerate() {
+            let deg = DEGREE_LABELS
+                .get(*degree as usize)
+                .copied()
+                .unwrap_or("?");
+            let start_step = *start as f32 / 24.0;
+            let dur_steps = *dur as f32 / 24.0;
+            print!(
+                "  [{i}] {deg:<3}  start~{start_step:.1} steps  gate~{dur_steps:.1}  vel={velocity:.2}\r\n"
+            );
+        }
+        if snap.event_count as usize > snap.events.len() {
+            print!(
+                "  ... +{} more\r\n",
+                snap.event_count as usize - snap.events.len()
+            );
+        }
+    }
+
+    print!("\r\n");
+    print!("Controls:\r\n");
+    print!("  1-7     chord pads I-VII (hold; release key or press 0)\r\n");
+    print!("  0       release held chord\r\n");
+    print!("  r       toggle record arm\r\n");
+    print!("  m       toggle punch-out / overdub\r\n");
+    print!("  c       clear clip\r\n");
+    print!("  space   play / stop\r\n");
+    print!("  [ ]     root down / up\r\n");
+    print!("  s       toggle major / minor\r\n");
+    print!("  q       quit\r\n");
+    print!("\r\n");
+    print!("Tip: arm punch-out, hold chords for one bar, auto-disarm, hear them loop.\r\n");
+    io::stdout().flush()?;
+    Ok(())
+}
+
+#[cfg(feature = "native")]
+fn trigger_degree(engine: *mut GooeyEngine, state: &AppState, degree: u32) {
+    unsafe {
+        gooey_engine_poly_trigger_chord(
+            engine,
+            state.root,
+            state.scale,
+            degree,
+            0, // root position
+            state.preset,
+            state.octave,
+            0.9,
+        );
+    }
+}
+
+#[cfg(feature = "native")]
+fn release_chord(engine: *mut GooeyEngine) {
+    unsafe {
+        gooey_engine_poly_release(engine);
+    }
+}
+
+#[cfg(feature = "native")]
+fn build_output_stream(
+    engine: Arc<Mutex<FfiEngine>>,
+    device: &cpal::Device,
+    config: &StreamConfig,
+    sample_format: cpal::SampleFormat,
+) -> anyhow::Result<Stream> {
+    match sample_format {
+        cpal::SampleFormat::I8 => make_stream::<i8>(engine, device, config),
+        cpal::SampleFormat::I16 => make_stream::<i16>(engine, device, config),
+        cpal::SampleFormat::I32 => make_stream::<i32>(engine, device, config),
+        cpal::SampleFormat::I64 => make_stream::<i64>(engine, device, config),
+        cpal::SampleFormat::U8 => make_stream::<u8>(engine, device, config),
+        cpal::SampleFormat::U16 => make_stream::<u16>(engine, device, config),
+        cpal::SampleFormat::U32 => make_stream::<u32>(engine, device, config),
+        cpal::SampleFormat::U64 => make_stream::<u64>(engine, device, config),
+        cpal::SampleFormat::F32 => make_stream::<f32>(engine, device, config),
+        cpal::SampleFormat::F64 => make_stream::<f64>(engine, device, config),
+        format => Err(anyhow::anyhow!("unsupported sample format {format}")),
+    }
+}
+
+#[cfg(feature = "native")]
+fn make_stream<T>(
+    engine: Arc<Mutex<FfiEngine>>,
+    device: &cpal::Device,
+    config: &StreamConfig,
+) -> anyhow::Result<Stream>
+where
+    T: SizedSample + FromSample<f32>,
+{
+    let channels = config.channels as usize;
+    let err_fn = |err| eprintln!("audio stream error: {err}");
+    let stream = device.build_output_stream(
+        config,
+        move |output: &mut [T], _| {
+            render_audio(output, channels, &engine);
+        },
+        err_fn,
+        None,
+    )?;
+    Ok(stream)
+}
+
+#[cfg(feature = "native")]
+thread_local! {
+    static RENDER_BUF: RefCell<Vec<f32>> = RefCell::new(Vec::new());
+}
+
+#[cfg(feature = "native")]
+fn render_audio<T>(output: &mut [T], channels: usize, engine: &Arc<Mutex<FfiEngine>>)
+where
+    T: Sample + FromSample<f32>,
+{
+    let frames = output.len() / channels;
+    let needed = frames * GOOEY_OUTPUT_CHANNELS as usize;
+
+    // Never allocate on the audio thread after warm-up: reuse a TLS buffer.
+    RENDER_BUF.with(|cell| {
+        let mut interleaved = cell.borrow_mut();
+        if interleaved.len() < needed {
+            interleaved.resize(needed, 0.0);
+        }
+
+        // Blocking lock is OK if the UI only holds the mutex for microsecond
+        // snapshots / key handlers. try_lock+silence was causing buffer-sized pops.
+        let engine = engine.lock().unwrap();
+        unsafe {
+            gooey_engine_render(engine.ptr(), interleaved.as_mut_ptr(), frames as u32);
+        }
+
+        for (frame_idx, frame) in output.chunks_mut(channels).enumerate() {
+            let l = interleaved[frame_idx * 2];
+            let r = interleaved[frame_idx * 2 + 1];
+            match frame.len() {
+                0 => {}
+                1 => frame[0] = T::from_sample(0.5 * (l + r)),
+                _ => {
+                    frame[0] = T::from_sample(l);
+                    frame[1] = T::from_sample(r);
+                    if frame.len() > 2 {
+                        let mono = T::from_sample(0.5 * (l + r));
+                        for sample in &mut frame[2..] {
+                            *sample = mono;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+#[cfg(feature = "native")]
+fn main() -> anyhow::Result<()> {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or_else(|| anyhow::anyhow!("no default output device"))?;
+    let supported_config = device.default_output_config()?;
+    let config: StreamConfig = supported_config.clone().into();
+    let sample_rate = config.sample_rate.0 as f32;
+
+    println!("Output device: {}", device.name()?);
+    println!("Sample rate: {sample_rate}");
+
+    let ffi_engine = FfiEngine::new(sample_rate);
+    configure_engine(ffi_engine.ptr());
+    let engine = Arc::new(Mutex::new(ffi_engine));
+
+    let stream = build_output_stream(
+        engine.clone(),
+        &device,
+        &config,
+        supported_config.sample_format(),
+    )?;
+    stream.play()?;
+
+    let mut state = AppState {
+        playing: true,
+        holding_degree: None,
+        root: 0,  // C
+        scale: 0, // major
+        octave: 4,
+        preset: POLY_PRESET_PAD,
+    };
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    // Request key-up events when the terminal supports them (for hold-to-sustain).
+    let _ = execute!(
+        stdout,
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::REPORT_EVENT_TYPES)
+    );
+    execute!(stdout, cursor::Hide)?;
+
+    let mut last_draw = Instant::now() - UI_REFRESH;
+    // Warm the audio render buffer so the first callback does not allocate.
+    RENDER_BUF.with(|cell| {
+        cell.borrow_mut().resize(4096 * 2, 0.0);
+    });
+
+    loop {
+        // Redraw at a modest rate. Snapshot under a short lock, then print
+        // without holding the engine (print was blocking audio → silence pops).
+        if last_draw.elapsed() >= UI_REFRESH {
+            let snap = {
+                let guard = engine.lock().unwrap();
+                snapshot_ui(guard.ptr())
+            };
+            draw_ui(&snap, &state)?;
+            last_draw = Instant::now();
+        }
+
+        if event::poll(Duration::from_millis(10))? {
+            if let Event::Key(KeyEvent { code, kind, .. }) = event::read()? {
+                // Ignore key-repeat presses; handle Press and Release.
+                let is_press = kind == KeyEventKind::Press;
+                let is_release = kind == KeyEventKind::Release;
+                if !is_press && !is_release {
+                    continue;
+                }
+
+                match code {
+                    KeyCode::Char('q') | KeyCode::Esc if is_press => break,
+
+                    KeyCode::Char(' ') if is_press => {
+                        let guard = engine.lock().unwrap();
+                        unsafe {
+                            if state.playing {
+                                gooey_engine_sequencer_stop(guard.ptr());
+                                if state.holding_degree.is_some() {
+                                    release_chord(guard.ptr());
+                                    state.holding_degree = None;
+                                }
+                                state.playing = false;
+                            } else {
+                                gooey_engine_sequencer_start(guard.ptr());
+                                state.playing = true;
+                            }
+                        }
+                    }
+
+                    KeyCode::Char('r') if is_press => {
+                        let guard = engine.lock().unwrap();
+                        unsafe {
+                            let armed = gooey_engine_perf_is_record_armed(guard.ptr());
+                            gooey_engine_perf_set_record_armed(guard.ptr(), !armed);
+                        }
+                    }
+
+                    KeyCode::Char('m') if is_press => {
+                        let guard = engine.lock().unwrap();
+                        unsafe {
+                            let mode = gooey_engine_perf_get_record_mode(guard.ptr());
+                            let next = if mode == PERF_RECORD_MODE_OVERDUB {
+                                PERF_RECORD_MODE_PUNCH_OUT
+                            } else {
+                                PERF_RECORD_MODE_OVERDUB
+                            };
+                            gooey_engine_perf_set_record_mode(guard.ptr(), next);
+                        }
+                    }
+
+                    KeyCode::Char('c') if is_press => {
+                        let guard = engine.lock().unwrap();
+                        unsafe {
+                            gooey_engine_perf_clear_clip(guard.ptr());
+                        }
+                    }
+
+                    KeyCode::Char('[') if is_press => {
+                        state.root = state.root.wrapping_sub(1) % 12;
+                    }
+                    KeyCode::Char(']') if is_press => {
+                        state.root = (state.root + 1) % 12;
+                    }
+                    KeyCode::Char('s') if is_press => {
+                        state.scale = 1 - state.scale;
+                    }
+
+                    KeyCode::Char(ch @ '1'..='7') if is_press => {
+                        let degree = (ch as u8 - b'1') as u32;
+                        if state.holding_degree != Some(degree) {
+                            let guard = engine.lock().unwrap();
+                            if state.holding_degree.is_some() {
+                                release_chord(guard.ptr());
+                            }
+                            trigger_degree(guard.ptr(), &state, degree);
+                            state.holding_degree = Some(degree);
+                        }
+                    }
+
+                    KeyCode::Char(ch @ '1'..='7') if is_release => {
+                        let degree = (ch as u8 - b'1') as u32;
+                        if state.holding_degree == Some(degree) {
+                            let guard = engine.lock().unwrap();
+                            release_chord(guard.ptr());
+                            state.holding_degree = None;
+                        }
+                    }
+
+                    // Fallback when the terminal does not report key-up.
+                    KeyCode::Char('0') | KeyCode::Enter if is_press => {
+                        if state.holding_degree.is_some() {
+                            let guard = engine.lock().unwrap();
+                            release_chord(guard.ptr());
+                            state.holding_degree = None;
+                        }
+                    }
+
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    // Release any held chord on exit.
+    {
+        let guard = engine.lock().unwrap();
+        if state.holding_degree.is_some() {
+            release_chord(guard.ptr());
+        }
+        unsafe {
+            gooey_engine_sequencer_stop(guard.ptr());
+        }
+    }
+
+    let _ = execute!(stdout, PopKeyboardEnhancementFlags);
+    execute!(stdout, cursor::Show)?;
+    disable_raw_mode()?;
+    println!("\nBye.");
+    Ok(())
+}
+
+#[cfg(not(feature = "native"))]
+fn main() {
+    eprintln!("This example requires --features native,crossterm");
+}

--- a/plans/performance-recording-plan.md
+++ b/plans/performance-recording-plan.md
@@ -1,0 +1,282 @@
+# Performance Recording for Live Instruments (Chords First)
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This repository contains `.agent/PLANS.md`, and this document must be maintained in accordance with that file. If this plan is revised, keep it self-contained: a future contributor should be able to read only this file and the current working tree, then continue safely.
+
+## Purpose / Big Picture
+
+Tide can already sequence drums and bass on a shared 16-step grid and play chords live on the poly synth. What is missing is the ability to capture a free-hand chord pad performance into a looping clip that stays locked to the same transport as the drums.
+
+After Stage 1 of this plan, a host can record-arm the performance clip, choose punch-out (auto-disarm after one loop) or continuous overdub, play chord pads while the transport runs, and hear those chords replay sample-accurately on subsequent loops through the same poly synth path used for live pads. Later stages add quantize-on-record, configurable loop length, parameter automation, and undo.
+
+## Progress
+
+- [x] (2026-07-09) Authored multi-stage plan from Tide/libgooey architecture review and product decisions.
+- [x] (2026-07-09) Created git worktree at `../libgooey-worktrees/performance-recording` on branch `bhurlow/performance-recording`.
+- [x] (2026-07-09) Implement Stage 1 core module `src/performance/` (clip, events, record modes, player).
+- [x] (2026-07-09) Wire Stage 1 into `GooeyEngine` render + poly chord FFI (record on live pad, playback on clock).
+- [x] (2026-07-09) Expose Stage 1 C FFI (`gooey_engine_perf_*`).
+- [x] (2026-07-09) Add unit tests for punch-out, overdub cut-gate, loop wrap, empty clip (11 lib tests).
+- [x] (2026-07-09) Add FFI integration tests (`tests/performance_recording.rs`, 5 tests).
+- [ ] Stage 2: quantize options + editable event query for UI grid.
+- [ ] Stage 3: configurable clip length (steps/bars).
+- [ ] Stage 4: parameter automation recording/replay.
+- [ ] Stage 5: undo / take stack.
+- [x] (2026-07-09) Basic CLI demo: `examples/performance_record.rs` (FFI + cpal + crossterm).
+- [ ] Tide host: transport record arm + mode toggle calling new FFI.
+
+## Surprises & Discoveries
+
+- Observation: Poly synth is not on a sequencer voice strip. Drums and bass use per-voice `Sequencer` inside `VoiceStrip`; poly is a free-standing `PolySynth` driven only by `gooey_engine_poly_trigger_chord` / `poly_release`. Chord recording cannot reuse monophonic `SequencerStep.note` without a new data model.
+  Evidence: `src/ffi.rs` `GooeyEngine` fields; poly FFI near `gooey_engine_poly_trigger_chord`.
+
+- Observation: Existing sequencer "arm" means scheduled transport start (Link/host time), not record-arm. Naming in FFI must use `perf` / `record` clearly to avoid confusion with `gooey_engine_sequencer_start_at_host_time`.
+  Evidence: `ArmedStart` in `src/engine/sequencer.rs` and host-time arm in `src/ffi.rs`.
+
+- Observation: `gooey_engine_sequencer_get_beat_position` already returns a fractional quarter-note position derived from the reference (kick) sequencer with swing-aware interpolation. That is the correct clock for stamping and replaying clip events.
+  Evidence: `gooey_engine_sequencer_get_beat_position` in `src/ffi.rs`.
+
+## Decision Log
+
+- Decision: Store performances as timed event clips (sub-step ticks), not only a 16-step chord grid.
+  Rationale: Free pad timing is the main value of live chord recording; quantize can be layered later without throwing away free-time data.
+  Date/Author: 2026-07-09 / plan author
+
+- Decision: Own record and sample-accurate replay in libgooey core, not only in Tide Swift.
+  Rationale: One engine clock keeps chords locked to drums/bass; Nebula and other hosts can share the same FFI.
+  Date/Author: 2026-07-09 / plan author
+
+- Decision: Stage 1 chord payload is pad parameters (root, scale, degree, voicing, preset, octave, velocity), not expanded MIDI note lists.
+  Rationale: Matches Tide/Nebula pad UX and existing `poly_trigger_chord` rebuild path; editing stays in musical terms.
+  Date/Author: 2026-07-09 / plan author
+
+- Decision: Stage 1 loop length is fixed at 16 sixteenth-note steps (one 4/4 bar on the current grid). Configurable length is Stage 3.
+  Rationale: Matches current Tide drum/bass grid and minimizes API surface for MVP.
+  Date/Author: 2026-07-09 / plan author
+
+- Decision: Tick resolution is 96 pulses per quarter note (24 ticks per 16th step, 384 ticks per 16-step loop).
+  Rationale: Fine enough for free pad timing, integer-friendly, common MIDI-style PPQN; avoids float event times in the clip.
+  Date/Author: 2026-07-09 / plan author
+
+- Decision: Record modes are Overdub (stay armed across loops) and PunchOut (auto-disarm after one full clip length of active recording).
+  Rationale: Product request for punch-out vs continuous overdub from day one.
+  Date/Author: 2026-07-09 / plan author
+
+- Decision: Overdub overlap policy cuts the previous event gate at the new event start (tape-style), matching live `release_all` monophonic chord policy.
+  Rationale: Stacked poly chords would require a different engine policy; cut-gate matches what the user hears live.
+  Date/Author: 2026-07-09 / plan author
+
+- Decision: Recording only stamps events from live poly FFI calls while armed and transport is running. Clip playback must not re-enter the recorder.
+  Rationale: Prevents feedback loops and keeps overdub intentional (only new pad presses).
+  Date/Author: 2026-07-09 / plan author
+
+- Decision: When arming while transport is already running, the punch-out window and event acceptance begin at the next loop boundary (tick 0). When arming while stopped, recording becomes active when transport starts.
+  Rationale: Clean one-bar takes without partial first loops; still simple to reason about.
+  Date/Author: 2026-07-09 / plan author
+
+## Outcomes & Retrospective
+
+### Stage 1 core (2026-07-09)
+
+Delivered a working chord performance clip in libgooey: timed pad-parameter events, punch-out and overdub modes, cut-gate overdub, loop-boundary arm quantize, sample-clocked playback in `gooey_engine_render`, and C FFI for hosts. Live pad monitoring still triggers immediately; newly stamped events are held out of playback until the next loop wrap (or punch-out complete) so they do not double-fire with the live press.
+
+Remaining for product completeness: Tide UI wiring, quantize, configurable length, automation, undo. Full `cargo test` should be green on the branch after this pass.
+
+## Context and Orientation
+
+libgooey is a Rust real-time audio engine. iOS hosts talk to it only through C FFI in `src/ffi.rs`, generated into headers via cbindgen. The FFI-facing engine type is `GooeyEngine`.
+
+Relevant layout:
+
+- `src/ffi.rs` — `GooeyEngine`, render loop, poly chord FFI, sequencer transport FFI.
+- `src/engine/sequencer.rs` — sample-accurate 16-step sequencer used by drum and bass voices.
+- `src/instruments/poly_synth.rs` — six-voice poly synth with `trigger_note`, `release_note`, `release_all`.
+- `src/music/` — key, scale, chord, voicing helpers used by `gooey_engine_poly_trigger_chord`.
+- `src/mixer/graph.rs` — routes `SOURCE_POLYSYNTH` into the Synth track.
+
+Plain-language terms used in this plan:
+
+A clip is a looping container of timed musical events with a fixed length in ticks. A tick is one pulse on a fixed musical grid (96 per quarter note). Record-arm means the engine will write new events when the user plays while transport runs. Punch-out means record-arm turns off automatically after one full loop of active recording. Overdub means record-arm stays on and new events are merged into the clip using cut-gate overlap. Transport is the shared play/stop/BPM clock that advances drum sequencers and, after this work, the performance clip player.
+
+Today chords are live only. Tide calls `gooey_engine_poly_trigger_chord` on pad down and `gooey_engine_poly_release` on pad up. Those calls do not store history. Drums and bass already store patterns as `SequencerStep` rows (enabled, velocity, optional blend, optional monophonic MIDI note).
+
+There is no existing performance recorder, automation lane, or chord step grid in libgooey. Offline `bounce.rs` only replays the native mono `Engine` sequencers and does not capture live poly performance.
+
+## Plan of Work
+
+### Stage 1 — Chord clip record and replay (MVP)
+
+Create module `src/performance/` with:
+
+- Constants: `TICKS_PER_QUARTER = 96`, `DEFAULT_LENGTH_STEPS = 16`, `TICKS_PER_STEP = 24`, `DEFAULT_LENGTH_TICKS = 384`.
+- `RecordMode::{Overdub, PunchOut}` mapped to C constants `PERF_RECORD_MODE_OVERDUB = 0`, `PERF_RECORD_MODE_PUNCH_OUT = 1`.
+- `ChordClipEvent` with start_tick, duration_ticks, root, scale_type, degree, voicing, preset, octave, velocity.
+- `PerformanceClip` owning length_ticks and a `Vec` of events (sorted by start_tick for stable queries).
+- `PerformanceRecorder` owning arm state, mode, pending loop-boundary start, punch remaining ticks, optional open (unreleased) event, and the clip.
+- `PerformancePlayer` tracking last loop tick and active event index for sample-accurate trigger/release while transport runs.
+
+Helpers:
+
+- `beat_to_tick(beat_position: f64, length_ticks: u32) -> u32` using floor of `beat_position * TICKS_PER_QUARTER` modulo length.
+- `tick_distance(start, end, length)` for gate lengths that may wrap.
+- `cut_gates_at(clip, tick)` truncates any event whose gate covers `tick` so its end becomes `tick` (for monophonic overdub).
+
+Wire into `GooeyEngine` in `src/ffi.rs`:
+
+1. Add field `performance: PerformanceRecorder` (player state can live inside the same struct).
+2. Each audio sample in `render`, after sequencers advance, if transport is running on the reference sequencer: compute beat position (same math as `gooey_engine_sequencer_get_beat_position`), advance the performance player, and apply Trigger/Release actions to `poly_synth` without recording.
+3. On `gooey_engine_poly_trigger_chord`, after live trigger, if recorder is actively recording, cut previous gates, open a new event at current tick, and store pad params. Keep a `last_beat_position` updated every render sample for stamping when UI calls arrive between buffers.
+4. On `gooey_engine_poly_release`, if an open recorded event exists, finalize duration from open start to current tick (minimum 1 tick).
+5. On transport stop, finalize any open event and leave arm state as configured (armed may stay true for next play; punch remaining only counts while actively recording).
+6. On transport reset / set_beat_position, reset player last-tick so replay does not miss or double-fire.
+
+FFI surface (Stage 1):
+
+- `gooey_engine_perf_set_record_armed(engine, bool)`
+- `gooey_engine_perf_is_record_armed(engine) -> bool`
+- `gooey_engine_perf_is_recording(engine) -> bool` (armed and actively capturing this loop window)
+- `gooey_engine_perf_set_record_mode(engine, mode)`
+- `gooey_engine_perf_get_record_mode(engine) -> u32`
+- `gooey_engine_perf_clear_clip(engine)`
+- `gooey_engine_perf_get_event_count(engine) -> u32`
+- `gooey_engine_perf_get_event(engine, index, out fields...) -> bool`
+- `gooey_engine_perf_get_length_ticks(engine) -> u32`
+- `gooey_engine_perf_get_length_steps(engine) -> u32` (always 16 in Stage 1)
+
+Register `pub mod performance` in `src/lib.rs`.
+
+Tests in `src/performance/mod.rs` (unit) and `tests/performance_recording.rs` (FFI):
+
+- Punch-out disarms after exactly one loop of active recording.
+- Overdub keeps arm and appends a second-pass event; cut-gate shortens the earlier event.
+- Empty clip produces no poly activity from the player.
+- Clear empties events and open state.
+- Replay at same BPM fires chord starts near recorded ticks (tolerance of a few samples via event query after simulated render, or pure unit player tests without audio).
+
+### Stage 2 — Quantize and UI-facing edit helpers
+
+Add record quantize modes Off / 16th / 8th / quarter that snap start_tick on note-on (and optionally duration on note-off). Add FFI to replace or delete an event by index for a simple chord strip UI. Tide can show recorded degrees on a 16-step strip even though storage remains free-time ticks.
+
+### Stage 3 — Configurable loop length
+
+Allow host to set length in steps (8/16/32) or bars. Punch-out length follows clip length. Document whether drum sequencers must match (default: independent clip length is allowed; hosts should set both when they want a single grid).
+
+### Stage 4 — Parameter performance
+
+Add a second event stream or unified timeline of `{tick, target_id, value}` for poly (then mixer/FX) parameters. Record while armed when host sets params; replay by setting smoothed targets. Requires stable param IDs already present for poly.
+
+### Stage 5 — Undo / take stack
+
+Keep a small ring of clip snapshots on punch-out complete, clear, or explicit commit. FFI undo/redo/can_undo.
+
+## Concrete Steps
+
+Work in the worktree:
+
+    cd /Users/pretzel/code/gooey/gooey/libgooey-worktrees/performance-recording
+
+Stage 1 implementation order:
+
+1. Add `src/performance/mod.rs` with types and pure unit tests; `cargo test performance --lib`.
+2. Export module from `src/lib.rs`.
+3. Embed recorder in `GooeyEngine::new`, hook render + poly + transport FFI.
+4. Add `tests/performance_recording.rs` using `gooey_engine_*` C API.
+5. Run full `cargo test` and fix regressions.
+6. Rebuild cbindgen headers if the project expects committed headers (this repo generates via `build.rs`; verify `include/` or build output as existing convention).
+
+Expected commands:
+
+    cargo test --lib performance
+    cargo test --test performance_recording
+    cargo test
+
+## Validation and Acceptance
+
+Stage 1 is done when all of the following hold:
+
+1. Unit tests prove punch-out disarms after one loop, overdub cut-gate works, and tick math wraps correctly.
+2. An FFI test starts transport, arms punch-out, injects `poly_trigger_chord` / `poly_release` at known times via render advancement, then on the next loop observes either recorded event fields matching the pad params or audible poly activity aligned with those ticks.
+3. Live pad calls still sound immediately while recording (monitor path unchanged).
+4. Clip playback uses the same chord-building path as live (pad params → diatonic seventh → voicing → notes).
+5. `cargo test` passes on the branch.
+
+Manual Tide acceptance (after a thin host wrap, can be a follow-up commit): play drums, arm punch-out, play four chords in one bar, auto-disarm, hear the chord loop locked to the bar.
+
+## Idempotence and Recovery
+
+All Stage 1 code is additive. `clear_clip` and disarm are safe to call repeatedly. Tests must not depend on global process state. If a mid-implementation build fails, the performance field can be left disarmed by default so existing hosts that never call `perf_*` behave as today.
+
+## Artifacts and Notes
+
+Branch: `bhurlow/performance-recording`
+
+Worktree path (from monorepo): `libgooey-worktrees/performance-recording` (sibling checkout of the libgooey submodule).
+
+Primary new files:
+
+- `plans/performance-recording-plan.md` (this file)
+- `src/performance/mod.rs`
+- `tests/performance_recording.rs`
+
+## Interfaces and Dependencies
+
+In `src/performance/mod.rs` define approximately:
+
+    pub const TICKS_PER_QUARTER: u32 = 96;
+    pub const DEFAULT_LENGTH_STEPS: u32 = 16;
+    pub const TICKS_PER_STEP: u32 = TICKS_PER_QUARTER / 4;
+    pub const DEFAULT_LENGTH_TICKS: u32 = DEFAULT_LENGTH_STEPS * TICKS_PER_STEP;
+
+    pub const PERF_RECORD_MODE_OVERDUB: u32 = 0;
+    pub const PERF_RECORD_MODE_PUNCH_OUT: u32 = 1;
+
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    pub enum RecordMode { Overdub, PunchOut }
+
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    pub struct ChordClipEvent {
+        pub start_tick: u32,
+        pub duration_ticks: u32,
+        pub root: u32,
+        pub scale_type: u32,
+        pub degree: u32,
+        pub voicing: u32,
+        pub preset: u32,
+        pub octave: i32,
+        pub velocity: f32,
+    }
+
+    pub struct PerformanceRecorder { /* arm, mode, clip, player, open event, punch state */ }
+
+    pub enum PlayerAction {
+        Trigger(ChordClipEvent),
+        Release,
+    }
+
+    impl PerformanceRecorder {
+        pub fn new() -> Self;
+        pub fn set_armed(&mut self, armed: bool);
+        pub fn is_armed(&self) -> bool;
+        pub fn is_recording(&self) -> bool;
+        pub fn set_mode(&mut self, mode: RecordMode);
+        pub fn clear_clip(&mut self);
+        pub fn on_transport_running(&mut self, running: bool, beat_position: f64);
+        pub fn tick_playback(&mut self, beat_position: f64) -> Option<PlayerAction>;
+        pub fn record_chord_on(&mut self, beat_position: f64, event_params: ...) -> bool;
+        pub fn record_chord_off(&mut self, beat_position: f64) -> bool;
+        pub fn event_count(&self) -> usize;
+        pub fn event(&self, index: usize) -> Option<ChordClipEvent>;
+        pub fn length_ticks(&self) -> u32;
+        pub fn update_clock(&mut self, beat_position: f64, transport_running: bool);
+    }
+
+No new crates. Uses only `std` plus existing music helpers at the FFI boundary when applying a `PlayerAction::Trigger` (reuse the same key/voicing code path as `gooey_engine_poly_trigger_chord`).
+
+## Stage narrative (user story)
+
+Milestone A (this implementation pass): pure clip math and recorder state machine with tests.
+
+Milestone B: engine integration so that arming and playing pads while the sequencer runs leaves a clip that replays on the next loop without Tide changes beyond optional UI (FFI-only proof is enough for libgooey acceptance).
+
+Milestone C (host, optional same PR or follow-up in Tide): transport bar record button and mode toggle calling the new FFI.

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -16,6 +16,9 @@ use crate::instruments::{
 };
 use crate::mixer::{Mixer, MixerGraph, PitchMode, StereoSampleBuffer};
 use crate::music::{apply_voicing, available_voicings, Key, NoteName, ScaleType, VoicingType};
+use crate::performance::{
+    ChordClipEvent, PerformanceRecorder, PlayerAction, RecordMode,
+};
 use crate::utils::{PresetBlender, SmoothedParam};
 use std::ffi::{c_char, c_void, CStr, CString};
 use std::slice;
@@ -755,6 +758,9 @@ pub struct GooeyEngine {
     // each render call against `host_clock_anchor`.
     host_clock_anchor: Option<HostClockAnchor>,
     pending_arm_host_time: Option<PendingArm>,
+
+    // Live performance clip recorder/player (Stage 1: chord pad events).
+    performance: PerformanceRecorder,
 }
 
 /// Host-clock reference for the next render buffer. The audio callback sets
@@ -934,6 +940,8 @@ impl GooeyEngine {
             // Scheduled-start state (used for Ableton Link Sync Start/Stop)
             host_clock_anchor: None,
             pending_arm_host_time: None,
+            // Chord performance clip (disarmed by default)
+            performance: PerformanceRecorder::new(),
         }
     }
 
@@ -1167,6 +1175,19 @@ impl GooeyEngine {
                         }
                         self.push_midi_event(ch as u32, velocity, sample_offset);
                     }
+                }
+            }
+
+            // Advance the performance clip clock and apply any chord trigger/release
+            // from recorded events. Playback must not re-enter the recorder.
+            {
+                let beat = self.compute_beat_position();
+                let running = self
+                    .reference_sequencer()
+                    .map(|s| s.is_running())
+                    .unwrap_or(false);
+                if let Some(action) = self.performance.update_clock(beat, running) {
+                    self.apply_performance_action(action);
                 }
             }
 
@@ -3693,6 +3714,62 @@ impl GooeyEngine {
     fn reference_sequencer(&self) -> Option<&Sequencer> {
         self.voice(0).map(|v| &v.sequencer)
     }
+
+    /// Fractional beat position (quarter notes) from the reference sequencer.
+    /// Same math as `gooey_engine_sequencer_get_beat_position`.
+    fn compute_beat_position(&self) -> f64 {
+        let Some(seq) = self.reference_sequencer() else {
+            return 0.0;
+        };
+        let step = seq.current_step() as f64;
+        let step_start = seq.step_start_sample();
+        let step_end = seq.next_trigger_sample();
+        let step_duration = step_end.saturating_sub(step_start);
+        let frac = if step_duration > 0 {
+            let elapsed = seq.sample_count().saturating_sub(step_start);
+            (elapsed as f64 / step_duration as f64).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        (step + frac) / 4.0
+    }
+
+    /// Apply a clip player action to the poly synth without recording.
+    fn apply_performance_action(&mut self, action: PlayerAction) {
+        self.performance.set_applying_playback(true);
+        match action {
+            PlayerAction::Trigger(event) => {
+                self.trigger_poly_chord_from_event(event);
+            }
+            PlayerAction::Release => {
+                self.poly_synth.release_all();
+            }
+        }
+        self.performance.set_applying_playback(false);
+    }
+
+    /// Build and trigger a chord from a recorded pad-parameter event.
+    fn trigger_poly_chord_from_event(&mut self, event: ChordClipEvent) {
+        let root_note = root_from_id(event.root);
+        let scale = scale_from_id(event.scale_type);
+        let key = Key::new(root_note, scale);
+        let voicing_type = voicing_from_id(event.voicing);
+        let octave = event.octave.clamp(0, 8) as i8;
+        let velocity = event.velocity.clamp(0.0, 1.0);
+
+        // Smoothed targets only — avoid snap_params on every clip replay hit.
+        self.poly_synth.set_config(preset_config(event.preset));
+
+        let chords = key.diatonic_sevenths();
+        let degree = event.degree as usize % chords.len().max(1);
+        let chord = &chords[degree];
+        let midi_notes = apply_voicing(chord, voicing_type, octave);
+
+        self.poly_synth.release_all();
+        for note in &midi_notes {
+            self.poly_synth.trigger_note(*note, velocity);
+        }
+    }
 }
 
 /// Set a sequencer step on or off for a specific instrument
@@ -5432,26 +5509,39 @@ pub unsafe extern "C" fn gooey_engine_poly_trigger_chord(
     let scale = scale_from_id(scale_type);
     let key = Key::new(root_note, scale);
     let voicing_type = voicing_from_id(voicing);
-    let octave = octave.clamp(0, 8) as i8;
+    let octave_clamped = octave.clamp(0, 8) as i8;
     let velocity = velocity.clamp(0.0, 1.0);
 
-    // Apply preset
+    // Apply preset only as smoothed targets — do not snap_params here.
+    // Snapping on every chord change forces discontinuous filter/volume jumps
+    // while voices may still be releasing, which clicks.
     engine.poly_synth.set_config(preset_config(preset));
-    engine.poly_synth.snap_params();
 
     // Get diatonic seventh chords and pick the requested degree
     let chords = key.diatonic_sevenths();
-    let degree = degree as usize % chords.len();
-    let chord = &chords[degree];
+    let degree_idx = degree as usize % chords.len();
+    let chord = &chords[degree_idx];
 
     // Apply voicing to get MIDI notes
-    let midi_notes = apply_voicing(chord, voicing_type, octave);
+    let midi_notes = apply_voicing(chord, voicing_type, octave_clamped);
 
     // Release any currently sounding notes, then trigger the new chord
     engine.poly_synth.release_all();
     for note in &midi_notes {
         engine.poly_synth.trigger_note(*note, velocity);
     }
+
+    // Stamp into the performance clip when record-armed and transport is running.
+    // Playback-driven triggers set applying_playback and are ignored.
+    let _ = engine.performance.record_chord_on(
+        root,
+        scale_type,
+        degree,
+        voicing,
+        preset,
+        octave,
+        velocity,
+    );
 }
 
 /// Release all sounding poly synth notes.
@@ -5465,6 +5555,7 @@ pub unsafe extern "C" fn gooey_engine_poly_release(engine: *mut GooeyEngine) {
     }
     let engine = &mut *engine;
     engine.poly_synth.release_all();
+    let _ = engine.performance.record_chord_off();
 }
 
 /// Set the poly synth preset.
@@ -5482,6 +5573,191 @@ pub unsafe extern "C" fn gooey_engine_poly_set_preset(engine: *mut GooeyEngine, 
     }
     let engine = &mut *engine;
     engine.poly_synth.set_config(preset_config(preset));
+}
+
+// =============================================================================
+// Performance recording (live chord clips)
+// =============================================================================
+
+/// Continuous overdub: stay armed across loop wraps.
+pub const PERF_RECORD_MODE_OVERDUB: u32 = crate::performance::PERF_RECORD_MODE_OVERDUB;
+/// Punch-out: auto-disarm after one full clip length of active recording.
+pub const PERF_RECORD_MODE_PUNCH_OUT: u32 = crate::performance::PERF_RECORD_MODE_PUNCH_OUT;
+
+/// Arm or disarm performance recording.
+///
+/// When armed while transport is running, capture begins at the next loop
+/// boundary (tick 0). When armed while stopped, capture begins when transport
+/// starts at tick 0 (or waits for the next loop start if transport starts mid-bar).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_perf_set_record_armed(engine: *mut GooeyEngine, armed: bool) {
+    if engine.is_null() {
+        return;
+    }
+    (*engine).performance.set_armed(armed);
+}
+
+/// Returns true if performance record-arm is on.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_perf_is_record_armed(engine: *const GooeyEngine) -> bool {
+    if engine.is_null() {
+        return false;
+    }
+    (*engine).performance.is_armed()
+}
+
+/// Returns true if the engine is currently capturing performance events
+/// (armed, transport running, and inside the active capture window).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_perf_is_recording(engine: *const GooeyEngine) -> bool {
+    if engine.is_null() {
+        return false;
+    }
+    (*engine).performance.is_recording()
+}
+
+/// Set the performance record mode.
+///
+/// `mode` is `PERF_RECORD_MODE_OVERDUB` (0) or `PERF_RECORD_MODE_PUNCH_OUT` (1).
+/// Invalid values are ignored.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_perf_set_record_mode(engine: *mut GooeyEngine, mode: u32) {
+    if engine.is_null() {
+        return;
+    }
+    if let Some(m) = RecordMode::from_u32(mode) {
+        (*engine).performance.set_mode(m);
+    }
+}
+
+/// Get the performance record mode (`PERF_RECORD_MODE_*`).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_perf_get_record_mode(engine: *const GooeyEngine) -> u32 {
+    if engine.is_null() {
+        return PERF_RECORD_MODE_PUNCH_OUT;
+    }
+    (*engine).performance.mode().as_u32()
+}
+
+/// Clear all events from the performance clip.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_perf_clear_clip(engine: *mut GooeyEngine) {
+    if engine.is_null() {
+        return;
+    }
+    (*engine).performance.clear_clip();
+}
+
+/// Number of events in the performance clip.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_perf_get_event_count(engine: *const GooeyEngine) -> u32 {
+    if engine.is_null() {
+        return 0;
+    }
+    (*engine).performance.event_count() as u32
+}
+
+/// Read one performance clip event by index.
+///
+/// Returns false if the engine pointer is null or `index` is out of range.
+/// Output pointers may be null to skip fields.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+/// Writable out-pointers must be valid for `T` or null.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_perf_get_event(
+    engine: *const GooeyEngine,
+    index: u32,
+    start_tick: *mut u32,
+    duration_ticks: *mut u32,
+    root: *mut u32,
+    scale_type: *mut u32,
+    degree: *mut u32,
+    voicing: *mut u32,
+    preset: *mut u32,
+    octave: *mut i32,
+    velocity: *mut f32,
+) -> bool {
+    if engine.is_null() {
+        return false;
+    }
+    let Some(event) = (*engine).performance.event(index as usize) else {
+        return false;
+    };
+    if !start_tick.is_null() {
+        *start_tick = event.start_tick;
+    }
+    if !duration_ticks.is_null() {
+        *duration_ticks = event.duration_ticks;
+    }
+    if !root.is_null() {
+        *root = event.root;
+    }
+    if !scale_type.is_null() {
+        *scale_type = event.scale_type;
+    }
+    if !degree.is_null() {
+        *degree = event.degree;
+    }
+    if !voicing.is_null() {
+        *voicing = event.voicing;
+    }
+    if !preset.is_null() {
+        *preset = event.preset;
+    }
+    if !octave.is_null() {
+        *octave = event.octave;
+    }
+    if !velocity.is_null() {
+        *velocity = event.velocity;
+    }
+    true
+}
+
+/// Clip length in ticks (Stage 1: always 384 = 16 steps × 24 ticks).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_perf_get_length_ticks(engine: *const GooeyEngine) -> u32 {
+    if engine.is_null() {
+        return 0;
+    }
+    (*engine).performance.length_ticks()
+}
+
+/// Clip length in sixteenth-note steps (Stage 1: always 16).
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_perf_get_length_steps(engine: *const GooeyEngine) -> u32 {
+    if engine.is_null() {
+        return 0;
+    }
+    (*engine).performance.length_steps()
 }
 
 /// Set a single poly synth parameter by index.

--- a/src/instruments/poly_synth.rs
+++ b/src/instruments/poly_synth.rs
@@ -518,9 +518,10 @@ impl Instrument for PolySynth {
             output += self.generate_voice(i, current_time);
         }
 
-        // Scale by inverse of voice count to prevent clipping with chords
-        let active = self.voices.iter().filter(|v| v.active).count().max(1) as f32;
-        output / active
+        // Fixed headroom for a typical 4-note chord. Do NOT divide by the
+        // instantaneous active-voice count — that jumps when notes start/end
+        // and produces zipper/pop artifacts on chord changes and releases.
+        output * (1.0 / 4.0)
     }
 
     fn is_active(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod gen;
 pub mod instruments;
 pub mod mixer;
 pub mod music;
+pub mod performance;
 pub mod sequencer;
 pub mod utils;
 

--- a/src/performance/mod.rs
+++ b/src/performance/mod.rs
@@ -1,0 +1,724 @@
+//! Performance clip recording and sample-accurate replay for live instruments.
+//!
+//! Stage 1 focuses on chord pad performances: timed pad-parameter events in a
+//! looping clip locked to the engine transport (same beat clock as drum sequencers).
+
+/// Pulses per quarter note. One sixteenth-note step is `TICKS_PER_QUARTER / 4`.
+pub const TICKS_PER_QUARTER: u32 = 96;
+
+/// Default clip length in sixteenth-note steps (one 4/4 bar on the current grid).
+pub const DEFAULT_LENGTH_STEPS: u32 = 16;
+
+/// Ticks per sixteenth-note step.
+pub const TICKS_PER_STEP: u32 = TICKS_PER_QUARTER / 4;
+
+/// Default clip length in ticks (`DEFAULT_LENGTH_STEPS * TICKS_PER_STEP`).
+pub const DEFAULT_LENGTH_TICKS: u32 = DEFAULT_LENGTH_STEPS * TICKS_PER_STEP;
+
+/// Continuous overdub: stay armed across loop wraps.
+pub const PERF_RECORD_MODE_OVERDUB: u32 = 0;
+/// Punch-out: auto-disarm after one full clip length of active recording.
+pub const PERF_RECORD_MODE_PUNCH_OUT: u32 = 1;
+
+/// How record-arm behaves across loop boundaries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecordMode {
+    Overdub,
+    PunchOut,
+}
+
+impl RecordMode {
+    pub fn from_u32(value: u32) -> Option<Self> {
+        match value {
+            PERF_RECORD_MODE_OVERDUB => Some(Self::Overdub),
+            PERF_RECORD_MODE_PUNCH_OUT => Some(Self::PunchOut),
+            _ => None,
+        }
+    }
+
+    pub fn as_u32(self) -> u32 {
+        match self {
+            Self::Overdub => PERF_RECORD_MODE_OVERDUB,
+            Self::PunchOut => PERF_RECORD_MODE_PUNCH_OUT,
+        }
+    }
+}
+
+/// One recorded chord pad press in the looping clip.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ChordClipEvent {
+    /// Start position within the loop, in ticks `[0, length_ticks)`.
+    pub start_tick: u32,
+    /// Gate length in ticks. At least 1 when finalized.
+    pub duration_ticks: u32,
+    pub root: u32,
+    pub scale_type: u32,
+    pub degree: u32,
+    pub voicing: u32,
+    pub preset: u32,
+    pub octave: i32,
+    pub velocity: f32,
+}
+
+impl ChordClipEvent {
+    pub fn end_tick(&self, length_ticks: u32) -> u32 {
+        if length_ticks == 0 {
+            return self.start_tick;
+        }
+        (self.start_tick + self.duration_ticks) % length_ticks
+    }
+
+    /// True if `tick` lies in `[start, start+duration)` on the looping timeline.
+    pub fn covers(&self, tick: u32, length_ticks: u32) -> bool {
+        if length_ticks == 0 || self.duration_ticks == 0 {
+            return false;
+        }
+        let tick = tick % length_ticks;
+        let start = self.start_tick % length_ticks;
+        let end = start + self.duration_ticks;
+        if end <= length_ticks {
+            tick >= start && tick < end
+        } else {
+            // Wraps past loop end.
+            tick >= start || tick < (end % length_ticks)
+        }
+    }
+}
+
+/// Action the player wants applied to the poly synth this sample.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PlayerAction {
+    Trigger(ChordClipEvent),
+    Release,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OpenEvent {
+    start_tick: u32,
+    root: u32,
+    scale_type: u32,
+    degree: u32,
+    voicing: u32,
+    preset: u32,
+    octave: i32,
+    velocity: f32,
+}
+
+/// Looping chord clip with record-arm and sample-accurate playback.
+pub struct PerformanceRecorder {
+    length_ticks: u32,
+    events: Vec<ChordClipEvent>,
+    mode: RecordMode,
+    /// Host wants to record when transport allows.
+    armed: bool,
+    /// Actively accepting record input (past loop-boundary wait if needed).
+    recording_active: bool,
+    /// When true, wait until tick 0 before starting active recording.
+    wait_for_loop_start: bool,
+    /// Samples-of-recording remaining for punch-out, counted in ticks while active.
+    punch_ticks_remaining: Option<u32>,
+    open: Option<OpenEvent>,
+    /// Last transport beat position observed (quarter notes).
+    last_beat: f64,
+    last_tick: u32,
+    transport_running: bool,
+    /// Event currently sounding from clip playback (index into `events`), if any.
+    playing_index: Option<usize>,
+    /// Suppress recording while applying player actions (must stay false for live path).
+    applying_playback: bool,
+    /// While recording, only events with index `< playback_limit` are played back.
+    /// This keeps live monitoring monophonic without immediately replaying the
+    /// event just stamped. On each loop wrap during overdub the limit advances
+    /// to the current event count so the previous pass becomes audible.
+    playback_limit: usize,
+}
+
+impl Default for PerformanceRecorder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PerformanceRecorder {
+    pub fn new() -> Self {
+        Self {
+            length_ticks: DEFAULT_LENGTH_TICKS,
+            events: Vec::new(),
+            mode: RecordMode::PunchOut,
+            armed: false,
+            recording_active: false,
+            wait_for_loop_start: false,
+            punch_ticks_remaining: None,
+            open: None,
+            last_beat: 0.0,
+            last_tick: 0,
+            transport_running: false,
+            playing_index: None,
+            applying_playback: false,
+            playback_limit: 0,
+        }
+    }
+
+    pub fn length_ticks(&self) -> u32 {
+        self.length_ticks
+    }
+
+    pub fn length_steps(&self) -> u32 {
+        if TICKS_PER_STEP == 0 {
+            0
+        } else {
+            self.length_ticks / TICKS_PER_STEP
+        }
+    }
+
+    pub fn set_armed(&mut self, armed: bool) {
+        if armed == self.armed {
+            return;
+        }
+        self.armed = armed;
+        if !armed {
+            self.finalize_open_at(self.last_tick);
+            self.recording_active = false;
+            self.wait_for_loop_start = false;
+            self.punch_ticks_remaining = None;
+            return;
+        }
+
+        // Arming on: prepare capture window.
+        if self.transport_running {
+            // Clean takes start at the next loop boundary.
+            self.wait_for_loop_start = true;
+            self.recording_active = false;
+            self.punch_ticks_remaining = None;
+        } else {
+            // Start active as soon as transport starts.
+            self.wait_for_loop_start = false;
+            self.recording_active = false;
+            self.punch_ticks_remaining = None;
+        }
+    }
+
+    pub fn is_armed(&self) -> bool {
+        self.armed
+    }
+
+    /// True when the recorder is actively capturing (armed and inside the capture window).
+    pub fn is_recording(&self) -> bool {
+        self.armed && self.recording_active && self.transport_running
+    }
+
+    pub fn set_mode(&mut self, mode: RecordMode) {
+        self.mode = mode;
+    }
+
+    pub fn mode(&self) -> RecordMode {
+        self.mode
+    }
+
+    pub fn clear_clip(&mut self) {
+        self.events.clear();
+        self.open = None;
+        self.playing_index = None;
+        self.playback_limit = 0;
+    }
+
+    pub fn event_count(&self) -> usize {
+        self.events.len()
+    }
+
+    pub fn event(&self, index: usize) -> Option<ChordClipEvent> {
+        self.events.get(index).copied()
+    }
+
+    pub fn events(&self) -> &[ChordClipEvent] {
+        &self.events
+    }
+
+    /// Advance clock from the engine transport. Call once per audio sample (or
+    /// whenever beat position is known). Returns at most one player action.
+    pub fn update_clock(&mut self, beat_position: f64, transport_running: bool) -> Option<PlayerAction> {
+        let was_running = self.transport_running;
+        self.transport_running = transport_running;
+        self.last_beat = beat_position;
+
+        if !transport_running {
+            if was_running {
+                self.finalize_open_at(self.last_tick);
+                // Punch remaining freezes while stopped; arm state is preserved.
+                self.recording_active = false;
+                // Next start: if still armed, wait for loop start again only if
+                // we had already been capturing mid-loop; simpler: re-enter via
+                // transport start path below.
+            }
+            self.playing_index = None;
+            return None;
+        }
+
+        let tick = beat_to_tick(beat_position, self.length_ticks);
+        let prev_tick = self.last_tick;
+
+        // Transport just started.
+        if !was_running {
+            self.last_tick = tick;
+            if self.armed {
+                if tick == 0 {
+                    self.begin_active_recording();
+                } else {
+                    self.wait_for_loop_start = true;
+                    self.recording_active = false;
+                }
+            }
+            return self.playback_action_at(tick, true);
+        }
+
+        // Detect loop wrap (tick went backwards within the loop).
+        let wrapped = tick < prev_tick;
+
+        if self.armed {
+            if self.wait_for_loop_start && (wrapped || tick == 0) {
+                self.begin_active_recording();
+            } else if self.recording_active {
+                if wrapped {
+                    // Previous-pass events become audible on the next overdub loop.
+                    self.playback_limit = self.events.len();
+                }
+                if let Some(remaining) = self.punch_ticks_remaining.as_mut() {
+                    let advanced = if wrapped {
+                        (self.length_ticks - prev_tick) + tick
+                    } else {
+                        tick.saturating_sub(prev_tick)
+                    };
+                    if advanced >= *remaining {
+                        *remaining = 0;
+                        self.finalize_open_at(tick);
+                        self.armed = false;
+                        self.recording_active = false;
+                        self.punch_ticks_remaining = None;
+                        self.wait_for_loop_start = false;
+                        // Full clip is playable after punch-out completes.
+                        self.playback_limit = self.events.len();
+                    } else {
+                        *remaining -= advanced;
+                    }
+                }
+            }
+        } else if wrapped {
+            // Keep limit in sync when not recording so all events play.
+            self.playback_limit = self.events.len();
+        }
+
+        self.last_tick = tick;
+        self.playback_action_at(tick, wrapped)
+    }
+
+    /// Record a chord pad press at the current clock. Returns true if stamped.
+    pub fn record_chord_on(
+        &mut self,
+        root: u32,
+        scale_type: u32,
+        degree: u32,
+        voicing: u32,
+        preset: u32,
+        octave: i32,
+        velocity: f32,
+    ) -> bool {
+        if self.applying_playback || !self.is_recording() {
+            return false;
+        }
+        let tick = beat_to_tick(self.last_beat, self.length_ticks);
+        self.finalize_open_at(tick);
+        cut_gates_at(&mut self.events, tick, self.length_ticks);
+        self.open = Some(OpenEvent {
+            start_tick: tick,
+            root,
+            scale_type,
+            degree,
+            voicing,
+            preset,
+            octave,
+            velocity: velocity.clamp(0.0, 1.0),
+        });
+        true
+    }
+
+    /// Record a chord pad release. Returns true if an open event was closed.
+    pub fn record_chord_off(&mut self) -> bool {
+        if self.applying_playback || !self.is_recording() {
+            // Still finalize if we somehow have an open event while disarming.
+            if self.open.is_some() {
+                let tick = beat_to_tick(self.last_beat, self.length_ticks);
+                return self.finalize_open_at(tick);
+            }
+            return false;
+        }
+        let tick = beat_to_tick(self.last_beat, self.length_ticks);
+        self.finalize_open_at(tick)
+    }
+
+    /// Mark that subsequent poly actions come from the player (do not record).
+    pub fn set_applying_playback(&mut self, applying: bool) {
+        self.applying_playback = applying;
+    }
+
+    pub fn is_applying_playback(&self) -> bool {
+        self.applying_playback
+    }
+
+    fn begin_active_recording(&mut self) {
+        self.wait_for_loop_start = false;
+        self.recording_active = true;
+        // Existing events remain playable; newly finalized ones wait for the next wrap.
+        self.playback_limit = self.events.len();
+        if self.mode == RecordMode::PunchOut {
+            self.punch_ticks_remaining = Some(self.length_ticks);
+        } else {
+            self.punch_ticks_remaining = None;
+        }
+    }
+
+    fn finalize_open_at(&mut self, end_tick: u32) -> bool {
+        let Some(open) = self.open.take() else {
+            return false;
+        };
+        let mut duration = tick_distance(open.start_tick, end_tick, self.length_ticks);
+        if duration == 0 {
+            duration = 1;
+        }
+        // Do not allow events longer than one full loop.
+        duration = duration.min(self.length_ticks);
+        let event = ChordClipEvent {
+            start_tick: open.start_tick % self.length_ticks,
+            duration_ticks: duration,
+            root: open.root,
+            scale_type: open.scale_type,
+            degree: open.degree,
+            voicing: open.voicing,
+            preset: open.preset,
+            octave: open.octave,
+            velocity: open.velocity,
+        };
+        // Keep insertion order so `playback_limit` (index of first "this pass" event)
+        // stays valid during overdub. Hosts that want timeline order can sort on read.
+        self.events.push(event);
+        true
+    }
+
+    fn playback_action_at(&mut self, tick: u32, force_rescan: bool) -> Option<PlayerAction> {
+        let playable_end = if self.recording_active {
+            self.playback_limit.min(self.events.len())
+        } else {
+            self.events.len()
+        };
+
+        if playable_end == 0 {
+            if self.playing_index.take().is_some() {
+                return Some(PlayerAction::Release);
+            }
+            return None;
+        }
+
+        // Find the event that should be sounding at `tick`, if any.
+        // Prefer the latest-started event that covers this tick (monophonic).
+        let mut best: Option<usize> = None;
+        for (i, ev) in self.events.iter().enumerate().take(playable_end) {
+            if ev.covers(tick, self.length_ticks) {
+                match best {
+                    None => best = Some(i),
+                    Some(bi) => {
+                        // Prefer higher start_tick (later in loop), with wrap-aware
+                        // comparison relative to tick.
+                        if event_start_rank(ev.start_tick, tick, self.length_ticks)
+                            >= event_start_rank(self.events[bi].start_tick, tick, self.length_ticks)
+                        {
+                            best = Some(i);
+                        }
+                    }
+                }
+            }
+        }
+
+        if best == self.playing_index && !force_rescan {
+            return None;
+        }
+
+        // On wrap, force re-trigger if the same event still covers (sustains
+        // across loop) — monophonic pad policy retriggers only when index changes
+        // or we cross a start boundary.
+        if best == self.playing_index {
+            // Check if we just landed on a start boundary of that event.
+            if let Some(i) = best {
+                if self.events[i].start_tick == tick {
+                    self.playing_index = best;
+                    return Some(PlayerAction::Trigger(self.events[i]));
+                }
+            }
+            return None;
+        }
+
+        match (self.playing_index, best) {
+            (None, Some(i)) => {
+                self.playing_index = Some(i);
+                Some(PlayerAction::Trigger(self.events[i]))
+            }
+            (Some(_), None) => {
+                self.playing_index = None;
+                Some(PlayerAction::Release)
+            }
+            (Some(_), Some(i)) => {
+                self.playing_index = Some(i);
+                Some(PlayerAction::Trigger(self.events[i]))
+            }
+            (None, None) => None,
+        }
+    }
+}
+
+/// Convert a beat position (quarter notes) into a tick within `[0, length_ticks)`.
+pub fn beat_to_tick(beat_position: f64, length_ticks: u32) -> u32 {
+    if length_ticks == 0 {
+        return 0;
+    }
+    let raw = beat_position * f64::from(TICKS_PER_QUARTER);
+    // Floor toward -inf then wrap into the loop.
+    let floored = raw.floor();
+    let mut tick = floored as i64 % i64::from(length_ticks);
+    if tick < 0 {
+        tick += i64::from(length_ticks);
+    }
+    tick as u32
+}
+
+/// Forward distance from `start` to `end` on a looping timeline of `length` ticks.
+pub fn tick_distance(start: u32, end: u32, length: u32) -> u32 {
+    if length == 0 {
+        return 0;
+    }
+    let start = start % length;
+    let end = end % length;
+    if end >= start {
+        end - start
+    } else {
+        length - start + end
+    }
+}
+
+/// Truncate any event whose gate covers `tick` so it ends at `tick` (cut-gate).
+pub fn cut_gates_at(events: &mut Vec<ChordClipEvent>, tick: u32, length_ticks: u32) {
+    if length_ticks == 0 {
+        return;
+    }
+    let tick = tick % length_ticks;
+    events.retain_mut(|ev| {
+        if !ev.covers(tick, length_ticks) {
+            return true;
+        }
+        // If the event starts at tick, remove it entirely (replaced by new note-on).
+        if ev.start_tick % length_ticks == tick {
+            return false;
+        }
+        let new_duration = tick_distance(ev.start_tick, tick, length_ticks);
+        if new_duration == 0 {
+            return false;
+        }
+        ev.duration_ticks = new_duration;
+        true
+    });
+}
+
+fn event_start_rank(start: u32, tick: u32, length: u32) -> u32 {
+    // Distance backward from tick to start (how long ago it started).
+    // Smaller distance = more recent = higher priority → invert.
+    let dist = tick_distance(start, tick, length);
+    length.saturating_sub(dist)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn beat_to_tick_basic() {
+        assert_eq!(beat_to_tick(0.0, DEFAULT_LENGTH_TICKS), 0);
+        // One quarter note = 96 ticks.
+        assert_eq!(beat_to_tick(1.0, DEFAULT_LENGTH_TICKS), 96);
+        // One 16th = 0.25 beats = 24 ticks.
+        assert_eq!(beat_to_tick(0.25, DEFAULT_LENGTH_TICKS), 24);
+        // Full bar (4 beats) wraps to 0.
+        assert_eq!(beat_to_tick(4.0, DEFAULT_LENGTH_TICKS), 0);
+        // 4.5 beats → half bar into next loop = 48 ticks? 0.5 * 96 = 48.
+        assert_eq!(beat_to_tick(4.5, DEFAULT_LENGTH_TICKS), 48);
+    }
+
+    #[test]
+    fn tick_distance_wraps() {
+        assert_eq!(tick_distance(10, 20, 100), 10);
+        assert_eq!(tick_distance(90, 10, 100), 20);
+        assert_eq!(tick_distance(0, 0, 100), 0);
+    }
+
+    #[test]
+    fn cut_gates_shortens_overlapping() {
+        let mut events = vec![ChordClipEvent {
+            start_tick: 0,
+            duration_ticks: 100,
+            root: 0,
+            scale_type: 0,
+            degree: 0,
+            voicing: 0,
+            preset: 0,
+            octave: 4,
+            velocity: 0.9,
+        }];
+        cut_gates_at(&mut events, 40, DEFAULT_LENGTH_TICKS);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].duration_ticks, 40);
+    }
+
+    #[test]
+    fn record_chord_on_off_stores_event() {
+        let mut rec = PerformanceRecorder::new();
+        rec.set_mode(RecordMode::Overdub);
+        rec.set_armed(true);
+        // Simulate transport running at beat 0.
+        let _ = rec.update_clock(0.0, true);
+        assert!(rec.is_recording());
+
+        assert!(rec.record_chord_on(0, 0, 0, 0, 1, 4, 0.9));
+        // Advance to beat 1 (96 ticks).
+        let _ = rec.update_clock(1.0, true);
+        assert!(rec.record_chord_off());
+        assert_eq!(rec.event_count(), 1);
+        let e = rec.event(0).unwrap();
+        assert_eq!(e.start_tick, 0);
+        assert_eq!(e.duration_ticks, 96);
+        assert_eq!(e.degree, 0);
+    }
+
+    #[test]
+    fn punch_out_disarms_after_one_loop() {
+        let mut rec = PerformanceRecorder::new();
+        rec.set_mode(RecordMode::PunchOut);
+        rec.set_armed(true);
+        let _ = rec.update_clock(0.0, true);
+        assert!(rec.is_armed());
+        assert!(rec.is_recording());
+
+        // Advance almost one full loop (383 ticks ≈ 3.9896 beats).
+        let almost = (DEFAULT_LENGTH_TICKS - 1) as f64 / f64::from(TICKS_PER_QUARTER);
+        let _ = rec.update_clock(almost, true);
+        assert!(rec.is_armed());
+
+        // Cross the loop boundary — punch should complete.
+        let _ = rec.update_clock(4.0, true);
+        assert!(!rec.is_armed());
+        assert!(!rec.is_recording());
+    }
+
+    #[test]
+    fn overdub_stays_armed_across_loop() {
+        let mut rec = PerformanceRecorder::new();
+        rec.set_mode(RecordMode::Overdub);
+        rec.set_armed(true);
+        let _ = rec.update_clock(0.0, true);
+        let _ = rec.update_clock(4.0, true);
+        let _ = rec.update_clock(4.5, true);
+        assert!(rec.is_armed());
+        assert!(rec.is_recording());
+    }
+
+    #[test]
+    fn overdub_cut_gate_on_second_pass() {
+        let mut rec = PerformanceRecorder::new();
+        rec.set_mode(RecordMode::Overdub);
+        rec.set_armed(true);
+        let _ = rec.update_clock(0.0, true);
+
+        // First pass: chord from 0 for a long gate.
+        assert!(rec.record_chord_on(0, 0, 0, 0, 1, 4, 0.9));
+        let _ = rec.update_clock(2.0, true); // 192 ticks
+        assert!(rec.record_chord_off());
+        assert_eq!(rec.event_count(), 1);
+        assert_eq!(rec.event(0).unwrap().duration_ticks, 192);
+
+        // Second pass at beat 0.5 (48 ticks): new chord cuts previous.
+        let _ = rec.update_clock(4.5, true);
+        assert!(rec.record_chord_on(0, 0, 4, 0, 1, 4, 0.8));
+        let _ = rec.update_clock(5.0, true);
+        assert!(rec.record_chord_off());
+
+        assert_eq!(rec.event_count(), 2);
+        let first = rec.events().iter().find(|e| e.degree == 0).unwrap();
+        assert_eq!(first.duration_ticks, 48);
+        let second = rec.events().iter().find(|e| e.degree == 4).unwrap();
+        assert_eq!(second.start_tick, 48);
+    }
+
+    #[test]
+    fn arm_while_running_waits_for_loop_start() {
+        let mut rec = PerformanceRecorder::new();
+        rec.set_mode(RecordMode::PunchOut);
+        // Transport already mid-bar.
+        let _ = rec.update_clock(1.0, true);
+        rec.set_armed(true);
+        assert!(!rec.is_recording());
+        // Still mid-bar.
+        let _ = rec.update_clock(2.0, true);
+        assert!(!rec.is_recording());
+        // Loop wrap.
+        let _ = rec.update_clock(4.0, true);
+        assert!(rec.is_recording());
+    }
+
+    #[test]
+    fn playback_triggers_and_releases() {
+        let mut rec = PerformanceRecorder::new();
+        rec.events.push(ChordClipEvent {
+            start_tick: 0,
+            duration_ticks: 48,
+            root: 0,
+            scale_type: 0,
+            degree: 0,
+            voicing: 0,
+            preset: 1,
+            octave: 4,
+            velocity: 0.9,
+        });
+
+        let a = rec.update_clock(0.0, true);
+        assert!(matches!(a, Some(PlayerAction::Trigger(_))));
+
+        // Still inside gate (beat 0.25 = 24 ticks).
+        let a = rec.update_clock(0.25, true);
+        assert!(a.is_none());
+
+        // Past gate (beat 0.6 = 57.6 → 57 ticks).
+        let a = rec.update_clock(0.6, true);
+        assert!(matches!(a, Some(PlayerAction::Release)));
+    }
+
+    #[test]
+    fn clear_clip_empties_events() {
+        let mut rec = PerformanceRecorder::new();
+        rec.events.push(ChordClipEvent {
+            start_tick: 0,
+            duration_ticks: 10,
+            root: 0,
+            scale_type: 0,
+            degree: 0,
+            voicing: 0,
+            preset: 0,
+            octave: 4,
+            velocity: 1.0,
+        });
+        rec.clear_clip();
+        assert_eq!(rec.event_count(), 0);
+    }
+
+    #[test]
+    fn does_not_record_when_disarmed() {
+        let mut rec = PerformanceRecorder::new();
+        let _ = rec.update_clock(0.0, true);
+        assert!(!rec.record_chord_on(0, 0, 0, 0, 0, 4, 1.0));
+        assert_eq!(rec.event_count(), 0);
+    }
+}

--- a/tests/performance_recording.rs
+++ b/tests/performance_recording.rs
@@ -1,0 +1,171 @@
+//! FFI integration tests for Stage 1 performance (chord clip) recording.
+
+use gooey::ffi::*;
+use std::ptr;
+
+fn render_frames(engine: *mut GooeyEngine, frames: usize) {
+    let mut buf = vec![0.0_f32; frames * 2];
+    unsafe {
+        gooey_engine_render(engine, buf.as_mut_ptr(), frames as u32);
+    }
+}
+
+/// Samples per 16th-note step at the given BPM and sample rate.
+fn samples_per_step(bpm: f32, sample_rate: f32) -> f32 {
+    (60.0 / bpm) / 4.0 * sample_rate
+}
+
+#[test]
+fn perf_defaults_disarmed_empty_clip() {
+    let engine = unsafe { gooey_engine_new(44_100.0) };
+    assert!(!engine.is_null());
+
+    unsafe {
+        assert!(!gooey_engine_perf_is_record_armed(engine));
+        assert!(!gooey_engine_perf_is_recording(engine));
+        assert_eq!(
+            gooey_engine_perf_get_record_mode(engine),
+            PERF_RECORD_MODE_PUNCH_OUT
+        );
+        assert_eq!(gooey_engine_perf_get_event_count(engine), 0);
+        assert_eq!(gooey_engine_perf_get_length_steps(engine), 16);
+        assert_eq!(gooey_engine_perf_get_length_ticks(engine), 384);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn perf_record_punch_out_one_chord() {
+    let sample_rate = 44_100.0;
+    let bpm = 120.0;
+    let engine = unsafe { gooey_engine_new(sample_rate) };
+    assert!(!engine.is_null());
+
+    unsafe {
+        gooey_engine_set_bpm(engine, bpm);
+        gooey_engine_perf_set_record_mode(engine, PERF_RECORD_MODE_PUNCH_OUT);
+        gooey_engine_perf_set_record_armed(engine, true);
+        gooey_engine_sequencer_start(engine);
+
+        // One buffer advances the clock so recording becomes active at tick 0.
+        render_frames(engine, 64);
+        assert!(gooey_engine_perf_is_recording(engine));
+
+        // Chord on: degree I
+        gooey_engine_poly_trigger_chord(engine, 0, 0, 0, 0, 1, 4, 0.9);
+
+        // Hold for roughly a quarter note (~ samples for 1 beat).
+        let hold = samples_per_step(bpm, sample_rate) as usize * 4;
+        render_frames(engine, hold);
+
+        gooey_engine_poly_release(engine);
+        assert_eq!(gooey_engine_perf_get_event_count(engine), 1);
+
+        // Run the rest of the bar so punch-out completes (16 steps total).
+        let rest = samples_per_step(bpm, sample_rate) as usize * 12;
+        render_frames(engine, rest + 512);
+
+        assert!(
+            !gooey_engine_perf_is_record_armed(engine),
+            "punch-out should disarm after one loop"
+        );
+        assert_eq!(gooey_engine_perf_get_event_count(engine), 1);
+
+        let mut start = 0u32;
+        let mut dur = 0u32;
+        let mut degree = 0u32;
+        let mut velocity = 0.0f32;
+        assert!(gooey_engine_perf_get_event(
+            engine,
+            0,
+            &mut start,
+            &mut dur,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut degree,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut velocity,
+        ));
+        assert_eq!(degree, 0);
+        assert!(dur > 0);
+        assert!((velocity - 0.9).abs() < 0.001);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn perf_overdub_keeps_arm_and_appends() {
+    let sample_rate = 44_100.0;
+    let bpm = 120.0;
+    let engine = unsafe { gooey_engine_new(sample_rate) };
+    assert!(!engine.is_null());
+
+    unsafe {
+        gooey_engine_set_bpm(engine, bpm);
+        gooey_engine_perf_set_record_mode(engine, PERF_RECORD_MODE_OVERDUB);
+        gooey_engine_perf_set_record_armed(engine, true);
+        gooey_engine_sequencer_start(engine);
+        render_frames(engine, 64);
+
+        gooey_engine_poly_trigger_chord(engine, 0, 0, 0, 0, 1, 4, 0.9);
+        let q = samples_per_step(bpm, sample_rate) as usize * 4;
+        render_frames(engine, q);
+        gooey_engine_poly_release(engine);
+        assert_eq!(gooey_engine_perf_get_event_count(engine), 1);
+
+        // Finish the bar and enter second loop.
+        render_frames(engine, samples_per_step(bpm, sample_rate) as usize * 12 + 256);
+        assert!(gooey_engine_perf_is_record_armed(engine));
+
+        // Second pass: different degree
+        gooey_engine_poly_trigger_chord(engine, 0, 0, 4, 0, 1, 4, 0.8);
+        render_frames(engine, q);
+        gooey_engine_poly_release(engine);
+
+        assert!(gooey_engine_perf_get_event_count(engine) >= 2);
+        assert!(gooey_engine_perf_is_record_armed(engine));
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn perf_clear_clip() {
+    let engine = unsafe { gooey_engine_new(44_100.0) };
+    unsafe {
+        gooey_engine_set_bpm(engine, 120.0);
+        gooey_engine_perf_set_record_mode(engine, PERF_RECORD_MODE_OVERDUB);
+        gooey_engine_perf_set_record_armed(engine, true);
+        gooey_engine_sequencer_start(engine);
+        render_frames(engine, 128);
+        gooey_engine_poly_trigger_chord(engine, 0, 0, 1, 0, 1, 4, 1.0);
+        render_frames(engine, 1024);
+        gooey_engine_poly_release(engine);
+        assert!(gooey_engine_perf_get_event_count(engine) >= 1);
+
+        gooey_engine_perf_clear_clip(engine);
+        assert_eq!(gooey_engine_perf_get_event_count(engine), 0);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn live_chord_still_works_without_arm() {
+    let engine = unsafe { gooey_engine_new(44_100.0) };
+    unsafe {
+        gooey_engine_poly_trigger_chord(engine, 0, 0, 0, 0, 1, 4, 0.9);
+        let mut buf = vec![0.0_f32; 2048];
+        gooey_engine_render(engine, buf.as_mut_ptr(), 1024);
+        let peak = buf.iter().map(|s| s.abs()).fold(0.0_f32, f32::max);
+        assert!(
+            peak > 0.001,
+            "live chord should produce audio without recording"
+        );
+        assert_eq!(gooey_engine_perf_get_event_count(engine), 0);
+        gooey_engine_free(engine);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a timed chord performance clip in libgooey (`src/performance/`) with punch-out and continuous overdub modes, sample-accurate replay locked to the drum transport, and `gooey_engine_perf_*` FFI for hosts.
- Live pad presses still monitor immediately; when record-armed they stamp pad-parameter events (root/scale/degree/voicing/preset/octave/velocity) into a 16-step loop (384 ticks @ 96 PPQN).
- Includes unit + FFI tests, an interactive CLI demo (`cargo run --example performance_record --features native,crossterm`), and the multi-stage plan in `plans/performance-recording-plan.md`.
- Fixes poly synth zipper/pop artifacts found while demos: fixed chord headroom instead of dividing by live voice count, and stop `snap_params` on every chord trigger.

## Test plan
- [x] `cargo test --lib performance`
- [x] `cargo test --test performance_recording`
- [x] `cargo test` (full suite)
- [x] `cargo run --example performance_record --features native,crossterm`
  - Arm punch-out (`r`), hold chords `1`–`7` for one bar, hear auto-disarm + looped replay
  - Switch to overdub (`m`) and layer a second pass
  - Clear clip (`c`); confirm drums stay clean without UI-induced pops