### PR TITLE
Add transport-synchronized clip-grid scheduling

### DIFF
--- a/plans/clip-scheduling-plan.md
+++ b/plans/clip-scheduling-plan.md
@@ -1,0 +1,131 @@
+# Add transport-synchronized clip-grid scheduling
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds. Maintain this document in accordance with `.agent/PLANS.md` from the repository root.
+
+## Purpose / Big Picture
+
+After this work, an iOS or native host can preload a 4-column by 8-row grid of stereo audio clips and launch one clip, a whole scene row, or a column stop on a future musical boundary. Each column is mutually exclusive, so only one of its eight clips can play at a time. Clip playback follows the engine transport and BPM, including host-time armed starts and explicit transport seeks, while the host can query loaded, queued, and playing state to render an Ableton-style session grid.
+
+The behavior is demonstrated through the public C FFI: tests load distinct buffers into slots, start transport, schedule transitions, render across the target beat, and observe that state and audio change on the intended sample. Existing `gooey_engine_loop_*` users continue working when they do not use the grid.
+
+## Progress
+
+- [x] (2026-07-10 19:07Z) Inspected the loop mixer, queued-buffer swap, sequencer transport, host-time arm, generated-header convention, and baseline tests.
+- [x] (2026-07-10 19:07Z) Recorded product decisions for grid dimensions, quantization, scene behavior, transport stop, pitch preservation, relaunch, and active-slot replacement.
+- [x] (2026-07-10 19:12Z) Implemented the clip-grid scheduler, monotonic transport, state queries, scene actions, hot replacement, seek alignment, and legacy detachment in the mixer; 40 mixer unit tests pass.
+- [x] (2026-07-10 19:22Z) Wired BPM/start/stop/reset/seek/host-time arm and the full clip-grid control/state surface through C FFI.
+- [x] (2026-07-10 19:22Z) Added 7 focused mixer unit tests and 10 end-to-end FFI integration tests; all new tests pass.
+- [x] (2026-07-10 19:22Z) Completed validation: focused and full tests pass, changed Rust files are formatted, library/test clippy completes with the existing warning backlog, the iOS-feature build passes, and the generated header exposes the complete API. Repository-wide fmt and all-target clippy remain blocked by pre-existing unrelated files/examples documented below.
+
+## Surprises & Discoveries
+
+- Observation: `LoopChannel::queue_swap` is not a general clip-launch clock. It only fires when an already-playing channel cursor crosses a division, so it cannot launch an empty or stopped column or coordinate scenes against global transport.
+  Evidence: `src/mixer/loop_channel.rs::maybe_swap_pending` derives its boundary from the active buffer cursor.
+
+- Observation: `gooey_engine_sequencer_get_beat_position` reports the reference sequencer's position inside its 16-step pattern and therefore wraps every four quarter notes.
+  Evidence: `src/ffi.rs::compute_beat_position` returns `(step + frac) / 4.0` using a wrapping `current_step`.
+
+- Observation: generated `include/gooey.h` is intentionally untracked; `build.rs` regenerates it during Cargo builds.
+  Evidence: only `include/module.modulemap` is tracked by Git.
+
+- Observation: WSOLA correlation on constant audio has many equally valid offsets and can make its reported analysis cursor lag even when channels remain aligned.
+  Evidence: the first tempo-alignment test used DC buffers and reported equal phases near 0.13 instead of the nominal 0.25; non-periodic buffers produce the expected transport phase and preserve equality across different source BPMs.
+
+- Observation: Repository-wide formatting and all-target clippy were already not clean outside this feature.
+  Evidence: `cargo fmt --check` requests formatting in the existing performance-recording example/module/test, while `cargo clippy --all-targets --all-features` fails because `examples/lfo_test.rs` imports the obsolete `libgooey` crate name and `examples/hihat.rs` references removed HiHat2 fields. `cargo clippy --lib --tests --all-features` completes, and none of its warnings point to the new clip-grid code.
+
+## Decision Log
+
+- Decision: The engine owns a fixed 4-column by 8-row grid.
+  Rationale: Four columns map directly to the existing loop mixer and a fixed eight rows gives hosts a stable FFI contract.
+  Date/Author: 2026-07-10 / user and Codex
+
+- Decision: Individual clip launch, whole-row scene launch, and quantized column stop are all in the first implementation.
+  Rationale: These operations form the minimum useful Ableton-style session workflow.
+  Date/Author: 2026-07-10 / user and Codex
+
+- Decision: Launch timing supports straight sixteenth, quarter, and four-beat bar quantization plus an exact absolute future beat; default quantization is one bar.
+  Rationale: Common clicks stay simple while hosts and Link integrations can name an exact musical time.
+  Date/Author: 2026-07-10 / user and Codex
+
+- Decision: Every slot requires a source BPM and always launches in pitch-preserving mode.
+  Rationale: Remaining synchronized is mandatory and pitch-preserving WSOLA already exists in the loop channel.
+  Date/Author: 2026-07-10 / user and Codex
+
+- Decision: Empty cells in a launched scene stop their columns. Transport stop freezes active clips and cancels pending actions; resume continues frozen phase unless a seek/reset realigns it.
+  Rationale: A scene fully describes the resulting mix, and transport behavior is predictable without discarding active clip selection.
+  Date/Author: 2026-07-10 / user and Codex
+
+- Decision: Relaunch restarts a clip. Replacing an active slot schedules its new buffer with default quantization; unloading it schedules stop-and-remove.
+  Rationale: Slot edits must not tear the sounding buffer in the middle of a frame.
+  Date/Author: 2026-07-10 / user and Codex
+
+## Outcomes & Retrospective
+
+The requested 4×8 engine-owned clip grid is implemented in Rust and C FFI. It supports preloading, individual and atomic scene launch, quantized and exact beats, column stops, cancellation, state inspection, monotonic transport, host-time start, freeze/resume/seek, pitch-preserving source-tempo alignment, active replacement/unload, and coherent legacy-loop detachment.
+
+All 274 library tests and the complete integration/doc test suite pass, including 10 new clip-grid FFI tests plus the existing 17 loop-mixer and 9 host-time-start regressions. The iOS-feature build succeeds, `include/gooey.h` contains every new constant and function, and `git diff --check` is clean. Repository-wide fmt/all-target clippy gaps are unrelated pre-existing maintenance issues and were intentionally not folded into this feature.
+
+## Context and Orientation
+
+`src/mixer/mod.rs` defines `Mixer`, which owns four `LoopChannel` values. Each `LoopChannel` in `src/mixer/loop_channel.rs` owns one active stereo sample buffer, playback cursor, tempo-warp mode, fader state, and effects. `StereoSampleBuffer` in `src/mixer/stereo_buffer.rs` uses reference-counted channel data, so cloning a clip for activation is cheap.
+
+`src/ffi.rs` defines `GooeyEngine`, the public C-facing engine used by iOS. Its render loop advances drum sequencers once per sample and then calls `Mixer::tick`. Existing sequencer start, stop, reset, seek, BPM, and host-time-arm functions are the authoritative transport controls and must drive the new mixer transport too.
+
+A clip slot is one grid coordinate holding a full-buffer stereo loop and its required source BPM. A scene is one row across all four columns. Quantization means rounding a request to a future straight musical boundary. The monotonic transport is an absolute quarter-note position that does not wrap every bar.
+
+## Plan of Work
+
+Add `src/mixer/clip_grid.rs` containing the fixed grid, launch quantization enum, slot-state bit constants, per-column active and pending state, and a monotonic transport clock. The clock advances by `bpm / (60 * sample_rate)` beats after each rendered frame while running. Scheduled actions become due before the frame at their target beat is rendered. Use a half-sample beat tolerance so floating-point accumulation cannot skip a boundary.
+
+Embed the grid and clock in `Mixer`. Before summing channels, apply all due actions against the same current transport beat. Launch clones the selected slot buffer into its `LoopChannel`, sets full loop bounds, speed one, `PitchMode::PreservePitch`, starts playback, and records the launch beat. Stop clears the active row and stops playback. Scene launch computes one target and installs four pending actions at that target, using stop actions for empty cells. A later request replaces that column's pending action.
+
+Transport stop sets grid-owned channels non-playing without clearing active rows and cancels pending actions. Start re-enables active channels. Seek sets the absolute beat and computes active phase as `(beat - launch_beat).rem_euclid(clip_length_beats) / clip_length_beats`, where clip length in beats is `(frames / sample_rate) * source_bpm / 60`. Reset seeks to zero and cancels pending actions.
+
+Quantized requests made while running use the next strictly future boundary. While stopped, an exactly aligned current boundary is allowed and executes on the first frame after start. Exact targets must be finite, nonnegative, and not earlier than the current transport position; invalid requests leave existing pending state unchanged.
+
+Make legacy buffer/playhead mutations detach clip-grid ownership for that column before applying. This includes direct load, playing, loop bounds, speed, restart, position, source BPM, pitch mode, and queued swap controls. Gain, mute/solo, and effect APIs remain shared column-strip controls and do not detach.
+
+In `src/ffi.rs`, wire the mixer transport into BPM/start/stop/reset/seek/host-time-arm. Add constants and functions for slot load/unload/clear, clip and scene launch by quantization or exact beat, column stop, cancellation, default quantization, state queries, and absolute transport beat queries. FFI slot loading validates coordinates, audio input, sample rate, and source BPM before mutating the grid.
+
+Add pure unit tests beside the clip-grid implementation and end-to-end tests in `tests/clip_grid.rs`. Keep old queued-swap APIs and tests unchanged.
+
+## Concrete Steps
+
+Work from `/Users/pretzel/conductor/workspaces/libgooey/rio-de-janeiro-v1`.
+
+Implement and validate incrementally with:
+
+    cargo test --lib mixer
+    cargo test --test clip_grid
+    cargo test --test loop_mixer --test sequencer_armed_start
+    cargo test
+    cargo fmt --check
+    cargo clippy --all-targets --all-features
+    cargo build --no-default-features --features ios
+
+After the build, confirm the generated header contains `gooey_engine_clip_` and `gooey_engine_transport_get_beat_position` declarations. Do not commit `include/gooey.h` because it is generated and ignored.
+
+## Validation and Acceptance
+
+The feature is accepted when a clip in an empty column starts at the requested sample, a second row replaces it without overlapping the same column, and a scene changes all four columns on one sample while empty cells stop. State queries must distinguish loaded, playing, and queued, including the playing-and-queued combination used for active replacement.
+
+Tests must prove sixteenth, quarter, bar, and exact-beat launches across render-buffer boundaries; last-request-wins cancellation; stopped transport freeze/resume; seek phase realignment; active replacement, relaunch, and unload; invalid-input rejection; pitch-preserving BPM adaptation; and legacy loop detachment. The full existing test suite, formatting, clippy, and iOS-feature build must remain green.
+
+## Idempotence and Recovery
+
+All changes are additive except small transport hooks and legacy-control detachment. Loading the same inactive slot replaces it safely. Cancel, clear, stop, and detach operations are idempotent. If an implementation step fails, unit tests can be run independently before FFI wiring; no migrations or external state changes are required.
+
+The associated Nexus task is still `backlog`, so do not claim or update it during this implementation unless its status becomes `ready`.
+
+## Artifacts and Notes
+
+The primary implementation files are `src/mixer/clip_grid.rs`, `src/mixer/mod.rs`, `src/ffi.rs`, and `tests/clip_grid.rs`. This plan itself is committed at `plans/clip-scheduling-plan.md` and must be revised after each milestone and at completion.
+
+## Interfaces and Dependencies
+
+Expose Rust constants `CLIP_COLUMN_COUNT = 4`, `CLIP_ROW_COUNT = 8`, quantization IDs for sixteenth/quarter/bar, and bit flags for loaded/playing/queued. Expose an internal `LaunchQuantization` enum and `ClipGrid` methods mirrored by `Mixer`.
+
+The C API uses `u32` column, row, quantization, and state values; `i32` row queries return `-1` for no row; scheduled-beat queries return `-1.0` when absent. Functions that schedule or mutate slots return `bool` for validation failure. No new crate dependency is needed.
+
+Revision note (2026-07-10): Initial self-contained execution plan created from repository inspection and the user's approved implementation specification. Updated after implementation with delivered behavior, test evidence, the WSOLA test-material discovery, and pre-existing repository validation blockers.

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -469,6 +469,8 @@ impl Engine {
         for lfo in &mut self.lfos {
             lfo.reset();
         }
+        self.mixer.transport_reset();
+        self.mixer.transport_start();
         self.master_gain.snap();
         self.trigger_queue.clear();
         self.saved_global_freq.clear();
@@ -479,5 +481,6 @@ impl Engine {
         for seq in &mut self.sequencers {
             seq.stop();
         }
+        self.mixer.transport_stop();
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -15,7 +15,7 @@ use crate::instruments::{
     PolySynthConfig, SampleBuffer, SamplerBuffer, SamplerRack, SnareConfig, SnareDrum, Tom2,
     Tom2Config,
 };
-use crate::mixer::{Mixer, MixerGraph, PitchMode, StereoSampleBuffer};
+use crate::mixer::{LaunchQuantization, Mixer, MixerGraph, PitchMode, StereoSampleBuffer};
 use crate::music::{apply_voicing, available_voicings, Key, NoteName, ScaleType, VoicingType};
 use crate::performance::{ChordClipEvent, PerformanceRecorder, PlayerAction, RecordMode};
 use crate::utils::{PresetBlender, SmoothedParam};
@@ -1128,6 +1128,8 @@ impl GooeyEngine {
                         sequencer.set_beat_position(pending.beat_position);
                         sequencer.start();
                     }
+                    self.mixer.transport_seek(pending.beat_position);
+                    self.mixer.transport_start();
                 }
                 arm_fires_at = None;
             }
@@ -3497,6 +3499,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_start(engine: *mut GooeyEngine) 
     for seq in engine.sequencers_iter_mut() {
         seq.start();
     }
+    engine.mixer.transport_start();
 }
 
 /// Stop all sequencers.
@@ -3516,6 +3519,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_stop(engine: *mut GooeyEngine) {
     for seq in engine.sequencers_iter_mut() {
         seq.stop();
     }
+    engine.mixer.transport_stop();
 }
 
 /// Reset all sequencers to step 0.
@@ -3535,6 +3539,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_reset(engine: *mut GooeyEngine) 
     for seq in engine.sequencers_iter_mut() {
         seq.reset();
     }
+    engine.mixer.transport_reset();
 }
 
 /// Set all sequencers to a specific beat position in quarter notes.
@@ -3570,6 +3575,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_set_beat_position(
     for seq in engine.sequencers_iter_mut() {
         seq.set_beat_position(beat_position);
     }
+    engine.mixer.transport_seek(beat_position);
 }
 
 /// Tell the engine the host time corresponding to sample 0 of the next
@@ -3648,6 +3654,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_start_at_host_time(
         start_host_time,
         beat_position,
     });
+    engine.mixer.transport_stop();
     for seq in engine.sequencers_iter_mut() {
         seq.cancel_arm();
         seq.stop();
@@ -6590,6 +6597,353 @@ pub unsafe extern "C" fn gooey_engine_track_effect_type_at(
         .as_ref()
         .and_then(|engine| engine.graph.effect_type_at(track as usize, slot as usize))
         .map_or(-1, |id| id as i32)
+}
+
+// =============================================================================
+// Transport-synchronized clip grid: 4 columns x 8 rows
+// =============================================================================
+
+/// Number of clip-grid columns (one per loop mixer channel).
+pub const CLIP_COLUMN_COUNT: u32 = crate::mixer::CLIP_COLUMN_COUNT as u32;
+/// Number of rows in each clip-grid column.
+pub const CLIP_ROW_COUNT: u32 = crate::mixer::CLIP_ROW_COUNT as u32;
+
+/// Launch on the next straight sixteenth-note boundary.
+pub const CLIP_QUANTIZE_SIXTEENTH: u32 = crate::mixer::CLIP_QUANTIZE_SIXTEENTH;
+/// Launch on the next quarter-note boundary.
+pub const CLIP_QUANTIZE_QUARTER: u32 = crate::mixer::CLIP_QUANTIZE_QUARTER;
+/// Launch on the next 4/4 bar boundary (the default).
+pub const CLIP_QUANTIZE_BAR: u32 = crate::mixer::CLIP_QUANTIZE_BAR;
+
+/// Slot contains a preloaded clip buffer.
+pub const CLIP_STATE_LOADED: u32 = crate::mixer::CLIP_STATE_LOADED;
+/// Slot is the active clip for its column (also true while transport is stopped).
+pub const CLIP_STATE_PLAYING: u32 = crate::mixer::CLIP_STATE_PLAYING;
+/// Slot has a pending launch/relaunch/unload action.
+pub const CLIP_STATE_QUEUED: u32 = crate::mixer::CLIP_STATE_QUEUED;
+
+/// Load or replace one clip-grid slot from interleaved audio.
+///
+/// `source_bpm` is required and must be finite and positive. Grid clips always
+/// launch as full-buffer loops using pitch-preserving tempo adaptation.
+/// Replacing the active slot keeps its old buffer sounding and schedules the
+/// replacement using the default launch quantization.
+///
+/// # Safety
+/// `engine` must be valid and `samples` must reference at least
+/// `frames * channels` readable `f32` values.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_load(
+    engine: *mut GooeyEngine,
+    column: u32,
+    row: u32,
+    samples: *const f32,
+    frames: u32,
+    channels: u32,
+    sample_rate: f32,
+    source_bpm: f32,
+) -> bool {
+    if engine.is_null()
+        || samples.is_null()
+        || frames == 0
+        || channels == 0
+        || !source_bpm.is_finite()
+        || source_bpm <= 0.0
+        || column >= CLIP_COLUMN_COUNT
+        || row >= CLIP_ROW_COUNT
+    {
+        return false;
+    }
+    let Some(total) = (frames as usize).checked_mul(channels as usize) else {
+        return false;
+    };
+    let samples = slice::from_raw_parts(samples, total);
+    match StereoSampleBuffer::from_interleaved(samples, channels as usize, sample_rate) {
+        Ok(buffer) => (*engine)
+            .mixer
+            .clip_load(column as usize, row as usize, buffer, source_bpm),
+        Err(_) => false,
+    }
+}
+
+/// Unload a slot. An active slot stops and disappears at the default boundary;
+/// an inactive slot is removed immediately.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_unload(
+    engine: *mut GooeyEngine,
+    column: u32,
+    row: u32,
+) -> bool {
+    engine
+        .as_mut()
+        .is_some_and(|engine| engine.mixer.clip_unload(column as usize, row as usize))
+}
+
+/// Stop all grid-owned columns and unload every slot.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_clear(engine: *mut GooeyEngine) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.clip_clear();
+    }
+}
+
+/// Queue one clip for a musical boundary. Returns false for an invalid slot,
+/// empty slot, or unknown `CLIP_QUANTIZE_*` value.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_launch(
+    engine: *mut GooeyEngine,
+    column: u32,
+    row: u32,
+    quantization: u32,
+) -> bool {
+    let Some(engine) = engine.as_mut() else {
+        return false;
+    };
+    let Some(quantization) = LaunchQuantization::from_id(quantization) else {
+        return false;
+    };
+    engine
+        .mixer
+        .clip_launch(column as usize, row as usize, quantization)
+}
+
+/// Queue one clip at an absolute future quarter-note position.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_launch_at_beat(
+    engine: *mut GooeyEngine,
+    column: u32,
+    row: u32,
+    beat: f64,
+) -> bool {
+    engine.as_mut().is_some_and(|engine| {
+        engine
+            .mixer
+            .clip_launch_at(column as usize, row as usize, beat)
+    })
+}
+
+/// Queue an entire scene row. Populated cells launch and empty cells stop
+/// their columns on the same sample.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_launch_scene(
+    engine: *mut GooeyEngine,
+    row: u32,
+    quantization: u32,
+) -> bool {
+    let Some(engine) = engine.as_mut() else {
+        return false;
+    };
+    let Some(quantization) = LaunchQuantization::from_id(quantization) else {
+        return false;
+    };
+    engine.mixer.clip_launch_scene(row as usize, quantization)
+}
+
+/// Queue an entire scene row at an absolute future beat.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_launch_scene_at_beat(
+    engine: *mut GooeyEngine,
+    row: u32,
+    beat: f64,
+) -> bool {
+    engine
+        .as_mut()
+        .is_some_and(|engine| engine.mixer.clip_launch_scene_at(row as usize, beat))
+}
+
+/// Queue a column stop at a musical boundary.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_stop(
+    engine: *mut GooeyEngine,
+    column: u32,
+    quantization: u32,
+) -> bool {
+    let Some(engine) = engine.as_mut() else {
+        return false;
+    };
+    let Some(quantization) = LaunchQuantization::from_id(quantization) else {
+        return false;
+    };
+    engine.mixer.clip_stop(column as usize, quantization)
+}
+
+/// Queue a column stop at an absolute future beat.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_stop_at_beat(
+    engine: *mut GooeyEngine,
+    column: u32,
+    beat: f64,
+) -> bool {
+    engine
+        .as_mut()
+        .is_some_and(|engine| engine.mixer.clip_stop_at(column as usize, beat))
+}
+
+/// Cancel one column's pending clip action without changing its active clip.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_cancel(engine: *mut GooeyEngine, column: u32) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.clip_cancel(column as usize);
+    }
+}
+
+/// Cancel every pending clip action.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_cancel_all(engine: *mut GooeyEngine) {
+    if let Some(engine) = engine.as_mut() {
+        engine.mixer.clip_cancel_all();
+    }
+}
+
+/// Set the quantization used by active-slot replacement and unload.
+///
+/// # Safety
+/// `engine` must be a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_set_default_quantization(
+    engine: *mut GooeyEngine,
+    quantization: u32,
+) -> bool {
+    let Some(engine) = engine.as_mut() else {
+        return false;
+    };
+    let Some(quantization) = LaunchQuantization::from_id(quantization) else {
+        return false;
+    };
+    engine.mixer.clip_set_default_quantization(quantization);
+    true
+}
+
+/// Return the current default `CLIP_QUANTIZE_*` value (bar for a null engine).
+///
+/// # Safety
+/// `engine` must be null or a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_get_default_quantization(
+    engine: *const GooeyEngine,
+) -> u32 {
+    engine.as_ref().map_or(CLIP_QUANTIZE_BAR, |engine| {
+        engine.mixer.clip_default_quantization().id()
+    })
+}
+
+/// Return a bitwise combination of `CLIP_STATE_*` for one slot.
+///
+/// # Safety
+/// `engine` must be null or a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_get_state(
+    engine: *const GooeyEngine,
+    column: u32,
+    row: u32,
+) -> u32 {
+    engine.as_ref().map_or(0, |engine| {
+        engine.mixer.clip_slot_state(column as usize, row as usize)
+    })
+}
+
+/// Return the active row in a column, or `-1` if none/out of range.
+///
+/// # Safety
+/// `engine` must be null or a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_get_active_row(
+    engine: *const GooeyEngine,
+    column: u32,
+) -> i32 {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.mixer.clip_active_row(column as usize))
+        .map_or(-1, |row| row as i32)
+}
+
+/// Return the row targeted by a pending launch/unload, or `-1` for none/stop.
+///
+/// # Safety
+/// `engine` must be null or a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_get_queued_row(
+    engine: *const GooeyEngine,
+    column: u32,
+) -> i32 {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.mixer.clip_queued_row(column as usize))
+        .map_or(-1, |row| row as i32)
+}
+
+/// Return true when the pending action will stop the column (including unload).
+///
+/// # Safety
+/// `engine` must be null or a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_is_stop_queued(
+    engine: *const GooeyEngine,
+    column: u32,
+) -> bool {
+    engine
+        .as_ref()
+        .is_some_and(|engine| engine.mixer.clip_is_stop_queued(column as usize))
+}
+
+/// Return a column's scheduled absolute beat, or `-1.0` if no action is queued.
+///
+/// # Safety
+/// `engine` must be null or a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_get_scheduled_beat(
+    engine: *const GooeyEngine,
+    column: u32,
+) -> f64 {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.mixer.clip_scheduled_beat(column as usize))
+        .unwrap_or(-1.0)
+}
+
+/// Return the monotonic absolute transport position in quarter notes.
+/// Unlike `gooey_engine_sequencer_get_beat_position`, this value does not wrap
+/// at the end of the 16-step sequencer pattern.
+///
+/// # Safety
+/// `engine` must be null or a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_transport_get_beat_position(
+    engine: *const GooeyEngine,
+) -> f64 {
+    engine
+        .as_ref()
+        .map_or(0.0, |engine| engine.mixer.transport_beat())
 }
 
 // =============================================================================

--- a/src/mixer/clip_grid.rs
+++ b/src/mixer/clip_grid.rs
@@ -1,0 +1,623 @@
+//! Transport-synchronized session clip grid layered over the loop mixer.
+
+use super::{LoopChannel, PitchMode, StereoSampleBuffer, LOOP_CHANNEL_COUNT};
+
+pub const CLIP_COLUMN_COUNT: usize = LOOP_CHANNEL_COUNT;
+pub const CLIP_ROW_COUNT: usize = 8;
+
+pub const CLIP_QUANTIZE_SIXTEENTH: u32 = 0;
+pub const CLIP_QUANTIZE_QUARTER: u32 = 1;
+pub const CLIP_QUANTIZE_BAR: u32 = 2;
+
+pub const CLIP_STATE_LOADED: u32 = 1 << 0;
+pub const CLIP_STATE_PLAYING: u32 = 1 << 1;
+pub const CLIP_STATE_QUEUED: u32 = 1 << 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LaunchQuantization {
+    Sixteenth,
+    Quarter,
+    Bar,
+}
+
+impl LaunchQuantization {
+    pub fn from_id(value: u32) -> Option<Self> {
+        match value {
+            CLIP_QUANTIZE_SIXTEENTH => Some(Self::Sixteenth),
+            CLIP_QUANTIZE_QUARTER => Some(Self::Quarter),
+            CLIP_QUANTIZE_BAR => Some(Self::Bar),
+            _ => None,
+        }
+    }
+
+    pub fn id(self) -> u32 {
+        match self {
+            Self::Sixteenth => CLIP_QUANTIZE_SIXTEENTH,
+            Self::Quarter => CLIP_QUANTIZE_QUARTER,
+            Self::Bar => CLIP_QUANTIZE_BAR,
+        }
+    }
+
+    fn beats(self) -> f64 {
+        match self {
+            Self::Sixteenth => 0.25,
+            Self::Quarter => 1.0,
+            Self::Bar => 4.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Clip {
+    buffer: StereoSampleBuffer,
+    length_beats: f64,
+}
+
+impl Clip {
+    fn new(mut buffer: StereoSampleBuffer, source_bpm: f32) -> Option<Self> {
+        if !source_bpm.is_finite() || source_bpm <= 0.0 || buffer.is_empty() {
+            return None;
+        }
+        let length_beats =
+            buffer.len() as f64 / buffer.sample_rate() as f64 * source_bpm as f64 / 60.0;
+        if !length_beats.is_finite() || length_beats <= 0.0 {
+            return None;
+        }
+        buffer.set_source_bpm(Some(source_bpm));
+        Some(Self {
+            buffer,
+            length_beats,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PendingKind {
+    Launch { row: usize },
+    Stop,
+    StopAndUnload { row: usize },
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ScheduledAction {
+    kind: PendingKind,
+    beat: f64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ColumnState {
+    active_row: Option<usize>,
+    active_clip: Option<Clip>,
+    launch_beat: f64,
+    pending: Option<ScheduledAction>,
+}
+
+/// Engine-owned 4×8 clip grid plus its monotonic musical transport.
+pub struct ClipGrid {
+    slots: [[Option<Clip>; CLIP_ROW_COUNT]; CLIP_COLUMN_COUNT],
+    columns: [ColumnState; CLIP_COLUMN_COUNT],
+    default_quantization: LaunchQuantization,
+    transport_beat: f64,
+    transport_running: bool,
+    bpm: f32,
+    sample_rate: f32,
+}
+
+impl ClipGrid {
+    pub fn new(sample_rate: f32, bpm: f32) -> Self {
+        Self {
+            slots: std::array::from_fn(|_| std::array::from_fn(|_| None)),
+            columns: std::array::from_fn(|_| ColumnState::default()),
+            default_quantization: LaunchQuantization::Bar,
+            transport_beat: 0.0,
+            transport_running: false,
+            bpm,
+            sample_rate,
+        }
+    }
+
+    fn valid_slot(column: usize, row: usize) -> bool {
+        column < CLIP_COLUMN_COUNT && row < CLIP_ROW_COUNT
+    }
+
+    fn beats_per_sample(&self) -> f64 {
+        self.bpm.max(0.0) as f64 / (60.0 * self.sample_rate.max(1.0) as f64)
+    }
+
+    fn quantized_target(&self, quantization: LaunchQuantization) -> f64 {
+        let interval = quantization.beats();
+        let scaled = self.transport_beat / interval;
+        let nearest = scaled.round();
+        let aligned = (scaled - nearest).abs() <= 1.0e-9;
+        if !self.transport_running && aligned {
+            nearest * interval
+        } else {
+            (scaled.floor() + 1.0) * interval
+        }
+    }
+
+    fn valid_exact_target(&self, beat: f64) -> bool {
+        beat.is_finite() && beat >= 0.0 && beat + 1.0e-9 >= self.transport_beat
+    }
+
+    fn schedule(&mut self, column: usize, kind: PendingKind, beat: f64) -> bool {
+        let Some(state) = self.columns.get_mut(column) else {
+            return false;
+        };
+        state.pending = Some(ScheduledAction { kind, beat });
+        true
+    }
+
+    pub fn load(
+        &mut self,
+        column: usize,
+        row: usize,
+        buffer: StereoSampleBuffer,
+        source_bpm: f32,
+    ) -> bool {
+        if !Self::valid_slot(column, row) {
+            return false;
+        }
+        let Some(clip) = Clip::new(buffer, source_bpm) else {
+            return false;
+        };
+        self.slots[column][row] = Some(clip);
+
+        if self.columns[column].active_row == Some(row) {
+            let target = self.quantized_target(self.default_quantization);
+            self.columns[column].pending = Some(ScheduledAction {
+                kind: PendingKind::Launch { row },
+                beat: target,
+            });
+        }
+        true
+    }
+
+    pub fn unload(&mut self, column: usize, row: usize) -> bool {
+        if !Self::valid_slot(column, row) || self.slots[column][row].is_none() {
+            return false;
+        }
+        if self.columns[column].active_row == Some(row) {
+            let target = self.quantized_target(self.default_quantization);
+            self.columns[column].pending = Some(ScheduledAction {
+                kind: PendingKind::StopAndUnload { row },
+                beat: target,
+            });
+        } else {
+            self.slots[column][row] = None;
+            if matches!(
+                self.columns[column].pending,
+                Some(ScheduledAction {
+                    kind: PendingKind::Launch { row: pending_row },
+                    ..
+                }) if pending_row == row
+            ) {
+                self.columns[column].pending = None;
+            }
+        }
+        true
+    }
+
+    pub fn clear(&mut self, channels: &mut [LoopChannel]) {
+        for column in 0..CLIP_COLUMN_COUNT {
+            if self.columns[column].active_row.is_some() {
+                if let Some(channel) = channels.get_mut(column) {
+                    channel.clear_buffer();
+                }
+            }
+            self.columns[column] = ColumnState::default();
+            for slot in &mut self.slots[column] {
+                *slot = None;
+            }
+        }
+    }
+
+    pub fn launch_quantized(
+        &mut self,
+        column: usize,
+        row: usize,
+        quantization: LaunchQuantization,
+    ) -> bool {
+        if !Self::valid_slot(column, row) || self.slots[column][row].is_none() {
+            return false;
+        }
+        let target = self.quantized_target(quantization);
+        self.schedule(column, PendingKind::Launch { row }, target)
+    }
+
+    pub fn launch_at(&mut self, column: usize, row: usize, beat: f64) -> bool {
+        if !Self::valid_slot(column, row)
+            || self.slots[column][row].is_none()
+            || !self.valid_exact_target(beat)
+        {
+            return false;
+        }
+        self.schedule(column, PendingKind::Launch { row }, beat)
+    }
+
+    pub fn launch_scene_quantized(&mut self, row: usize, quantization: LaunchQuantization) -> bool {
+        if row >= CLIP_ROW_COUNT {
+            return false;
+        }
+        let target = self.quantized_target(quantization);
+        for column in 0..CLIP_COLUMN_COUNT {
+            let kind = if self.slots[column][row].is_some() {
+                PendingKind::Launch { row }
+            } else {
+                PendingKind::Stop
+            };
+            self.columns[column].pending = Some(ScheduledAction { kind, beat: target });
+        }
+        true
+    }
+
+    pub fn launch_scene_at(&mut self, row: usize, beat: f64) -> bool {
+        if row >= CLIP_ROW_COUNT || !self.valid_exact_target(beat) {
+            return false;
+        }
+        for column in 0..CLIP_COLUMN_COUNT {
+            let kind = if self.slots[column][row].is_some() {
+                PendingKind::Launch { row }
+            } else {
+                PendingKind::Stop
+            };
+            self.columns[column].pending = Some(ScheduledAction { kind, beat });
+        }
+        true
+    }
+
+    pub fn stop_quantized(&mut self, column: usize, quantization: LaunchQuantization) -> bool {
+        let target = self.quantized_target(quantization);
+        self.schedule(column, PendingKind::Stop, target)
+    }
+
+    pub fn stop_at(&mut self, column: usize, beat: f64) -> bool {
+        if !self.valid_exact_target(beat) {
+            return false;
+        }
+        self.schedule(column, PendingKind::Stop, beat)
+    }
+
+    pub fn cancel(&mut self, column: usize) {
+        if let Some(state) = self.columns.get_mut(column) {
+            state.pending = None;
+        }
+    }
+
+    pub fn cancel_all(&mut self) {
+        for state in &mut self.columns {
+            state.pending = None;
+        }
+    }
+
+    pub fn detach_column(&mut self, column: usize) {
+        if let Some(state) = self.columns.get_mut(column) {
+            *state = ColumnState::default();
+        }
+    }
+
+    pub fn set_default_quantization(&mut self, quantization: LaunchQuantization) {
+        self.default_quantization = quantization;
+    }
+
+    pub fn default_quantization(&self) -> LaunchQuantization {
+        self.default_quantization
+    }
+
+    pub fn slot_state(&self, column: usize, row: usize) -> u32 {
+        if !Self::valid_slot(column, row) {
+            return 0;
+        }
+        let mut state = 0;
+        if self.slots[column][row].is_some() {
+            state |= CLIP_STATE_LOADED;
+        }
+        if self.columns[column].active_row == Some(row) {
+            state |= CLIP_STATE_PLAYING;
+        }
+        if matches!(
+            self.columns[column].pending,
+            Some(ScheduledAction {
+                kind: PendingKind::Launch { row: pending_row }
+                    | PendingKind::StopAndUnload { row: pending_row },
+                ..
+            }) if pending_row == row
+        ) {
+            state |= CLIP_STATE_QUEUED;
+        }
+        state
+    }
+
+    pub fn active_row(&self, column: usize) -> Option<usize> {
+        self.columns.get(column).and_then(|state| state.active_row)
+    }
+
+    pub fn queued_row(&self, column: usize) -> Option<usize> {
+        match self.columns.get(column)?.pending?.kind {
+            PendingKind::Launch { row } | PendingKind::StopAndUnload { row } => Some(row),
+            PendingKind::Stop => None,
+        }
+    }
+
+    pub fn is_stop_queued(&self, column: usize) -> bool {
+        matches!(
+            self.columns.get(column).and_then(|state| state.pending),
+            Some(ScheduledAction {
+                kind: PendingKind::Stop | PendingKind::StopAndUnload { .. },
+                ..
+            })
+        )
+    }
+
+    pub fn scheduled_beat(&self, column: usize) -> Option<f64> {
+        self.columns
+            .get(column)
+            .and_then(|state| state.pending.map(|pending| pending.beat))
+    }
+
+    pub fn set_bpm(&mut self, bpm: f32) {
+        if bpm.is_finite() && bpm > 0.0 {
+            self.bpm = bpm;
+        }
+    }
+
+    pub fn transport_start(&mut self, channels: &mut [LoopChannel]) {
+        self.transport_running = true;
+        for (column, state) in self.columns.iter().enumerate() {
+            if state.active_row.is_some() {
+                if let Some(channel) = channels.get_mut(column) {
+                    channel.set_playing(true);
+                }
+            }
+        }
+    }
+
+    pub fn transport_stop(&mut self, channels: &mut [LoopChannel]) {
+        self.transport_running = false;
+        self.cancel_all();
+        for (column, state) in self.columns.iter().enumerate() {
+            if state.active_row.is_some() {
+                if let Some(channel) = channels.get_mut(column) {
+                    channel.set_playing(false);
+                }
+            }
+        }
+    }
+
+    pub fn transport_seek(&mut self, beat: f64, channels: &mut [LoopChannel]) -> bool {
+        if !beat.is_finite() || beat < 0.0 {
+            return false;
+        }
+        self.transport_beat = beat;
+        for (column, state) in self.columns.iter().enumerate() {
+            let Some(clip) = state.active_clip.as_ref() else {
+                continue;
+            };
+            let phase =
+                (beat - state.launch_beat).rem_euclid(clip.length_beats) / clip.length_beats;
+            if let Some(channel) = channels.get_mut(column) {
+                channel.set_position(phase as f32);
+            }
+        }
+        true
+    }
+
+    pub fn transport_reset(&mut self, channels: &mut [LoopChannel]) {
+        self.cancel_all();
+        self.transport_seek(0.0, channels);
+    }
+
+    pub fn transport_beat(&self) -> f64 {
+        self.transport_beat
+    }
+
+    pub fn transport_running(&self) -> bool {
+        self.transport_running
+    }
+
+    fn activate(&mut self, column: usize, row: usize, channels: &mut [LoopChannel]) {
+        let Some(clip) = self.slots[column][row].clone() else {
+            self.stop_now(column, channels);
+            return;
+        };
+        let Some(channel) = channels.get_mut(column) else {
+            return;
+        };
+        channel.set_loop_start(0.0);
+        channel.set_loop_end(1.0);
+        channel.set_speed(1.0);
+        channel.set_pitch_mode(PitchMode::PreservePitch);
+        channel.cancel_queued_swap();
+        channel.set_buffer(clip.buffer.clone());
+        channel.set_playing(self.transport_running);
+        self.columns[column].active_row = Some(row);
+        self.columns[column].active_clip = Some(clip);
+        self.columns[column].launch_beat = self.transport_beat;
+    }
+
+    fn stop_now(&mut self, column: usize, channels: &mut [LoopChannel]) {
+        if let Some(channel) = channels.get_mut(column) {
+            channel.set_playing(false);
+        }
+        self.columns[column].active_row = None;
+        self.columns[column].active_clip = None;
+        self.columns[column].launch_beat = 0.0;
+    }
+
+    /// Apply due actions before this sample is rendered, then advance the
+    /// monotonic beat clock after the sample has been produced.
+    pub fn before_tick(&mut self, channels: &mut [LoopChannel]) {
+        if !self.transport_running {
+            return;
+        }
+        let tolerance = self.beats_per_sample() * 0.5 + 1.0e-12;
+        for column in 0..CLIP_COLUMN_COUNT {
+            let Some(pending) = self.columns[column].pending else {
+                continue;
+            };
+            if self.transport_beat + tolerance < pending.beat {
+                continue;
+            }
+            self.columns[column].pending = None;
+            match pending.kind {
+                PendingKind::Launch { row } => self.activate(column, row, channels),
+                PendingKind::Stop => self.stop_now(column, channels),
+                PendingKind::StopAndUnload { row } => {
+                    self.stop_now(column, channels);
+                    if let Some(channel) = channels.get_mut(column) {
+                        channel.clear_buffer();
+                    }
+                    self.slots[column][row] = None;
+                }
+            }
+        }
+    }
+
+    pub fn after_tick(&mut self) {
+        if self.transport_running {
+            self.transport_beat += self.beats_per_sample();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SR: f32 = 100.0;
+
+    fn clip(value: f32, frames: usize, source_bpm: f32) -> (StereoSampleBuffer, f32) {
+        (
+            StereoSampleBuffer::from_channels(vec![value; frames], vec![value; frames], SR)
+                .unwrap(),
+            source_bpm,
+        )
+    }
+
+    fn channels() -> Vec<LoopChannel> {
+        (0..CLIP_COLUMN_COUNT)
+            .map(|_| LoopChannel::new(SR))
+            .collect()
+    }
+
+    #[test]
+    fn quantized_running_targets_strictly_future_boundary() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        grid.transport_start(&mut channels);
+        assert_eq!(grid.quantized_target(LaunchQuantization::Bar), 4.0);
+        grid.transport_beat = 4.0;
+        assert_eq!(grid.quantized_target(LaunchQuantization::Bar), 8.0);
+    }
+
+    #[test]
+    fn stopped_aligned_launch_fires_on_first_started_tick() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        let (buffer, bpm) = clip(0.5, 100, 60.0);
+        assert!(grid.load(0, 0, buffer, bpm));
+        assert!(grid.launch_quantized(0, 0, LaunchQuantization::Bar));
+        assert_eq!(grid.scheduled_beat(0), Some(0.0));
+        grid.before_tick(&mut channels);
+        assert_eq!(grid.active_row(0), None);
+        grid.transport_start(&mut channels);
+        grid.before_tick(&mut channels);
+        assert_eq!(grid.active_row(0), Some(0));
+    }
+
+    #[test]
+    fn exact_past_target_is_rejected_without_replacing_queue() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        for row in 0..2 {
+            let (buffer, bpm) = clip(row as f32 + 1.0, 100, 60.0);
+            assert!(grid.load(0, row, buffer, bpm));
+        }
+        grid.transport_beat = 3.0;
+        grid.transport_start(&mut channels);
+        assert!(grid.launch_at(0, 0, 4.0));
+        assert!(!grid.launch_at(0, 1, 2.0));
+        assert_eq!(grid.queued_row(0), Some(0));
+        assert_eq!(grid.scheduled_beat(0), Some(4.0));
+    }
+
+    #[test]
+    fn scene_launch_starts_loaded_cells_and_stops_empty_cells() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        for column in 0..CLIP_COLUMN_COUNT {
+            let (buffer, bpm) = clip(column as f32 + 1.0, 100, 60.0);
+            grid.load(column, 0, buffer, bpm);
+        }
+        grid.launch_scene_at(0, 0.0);
+        grid.transport_start(&mut channels);
+        grid.before_tick(&mut channels);
+        assert_eq!(
+            grid.columns
+                .iter()
+                .map(|c| c.active_row)
+                .collect::<Vec<_>>(),
+            vec![Some(0); 4]
+        );
+
+        let (buffer, bpm) = clip(9.0, 100, 60.0);
+        grid.load(0, 1, buffer, bpm);
+        grid.launch_scene_at(1, 0.0);
+        grid.before_tick(&mut channels);
+        assert_eq!(grid.active_row(0), Some(1));
+        for column in 1..CLIP_COLUMN_COUNT {
+            assert_eq!(grid.active_row(column), None);
+        }
+    }
+
+    #[test]
+    fn state_bits_support_playing_and_queued_replacement() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        let (buffer, bpm) = clip(1.0, 100, 60.0);
+        grid.load(0, 0, buffer, bpm);
+        grid.launch_at(0, 0, 0.0);
+        grid.transport_start(&mut channels);
+        grid.before_tick(&mut channels);
+
+        let (replacement, bpm) = clip(2.0, 100, 60.0);
+        grid.load(0, 0, replacement, bpm);
+        assert_eq!(
+            grid.slot_state(0, 0),
+            CLIP_STATE_LOADED | CLIP_STATE_PLAYING | CLIP_STATE_QUEUED
+        );
+    }
+
+    #[test]
+    fn transport_stop_freezes_and_cancels_queue() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        let (buffer, bpm) = clip(1.0, 100, 60.0);
+        grid.load(0, 0, buffer, bpm);
+        grid.launch_at(0, 0, 0.0);
+        grid.transport_start(&mut channels);
+        grid.before_tick(&mut channels);
+        grid.after_tick();
+        let beat = grid.transport_beat();
+        grid.stop_quantized(0, LaunchQuantization::Quarter);
+        grid.transport_stop(&mut channels);
+        assert!(grid.scheduled_beat(0).is_none());
+        grid.after_tick();
+        assert_eq!(grid.transport_beat(), beat);
+        assert_eq!(grid.active_row(0), Some(0));
+        assert!(!channels[0].is_playing());
+    }
+
+    #[test]
+    fn seek_realigns_active_clip_phase() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        let (buffer, bpm) = clip(1.0, 400, 60.0); // four beats
+        grid.load(0, 0, buffer, bpm);
+        grid.launch_at(0, 0, 0.0);
+        grid.transport_start(&mut channels);
+        grid.before_tick(&mut channels);
+        assert!(grid.transport_seek(2.0, &mut channels));
+        assert!((channels[0].position_normalized() - 0.5).abs() < 0.01);
+    }
+}

--- a/src/mixer/clip_grid.rs
+++ b/src/mixer/clip_grid.rs
@@ -437,7 +437,12 @@ impl ClipGrid {
 
     fn stop_now(&mut self, column: usize, channels: &mut [LoopChannel]) {
         if let Some(channel) = channels.get_mut(column) {
-            channel.set_playing(false);
+            // Drop the grid buffer, not just playback: a stopped column keeps no
+            // sounding material, so a later `clear` or legacy detach cannot
+            // replay a slot the grid already reported as inactive. Transport
+            // freeze keeps its buffer via `transport_stop`, which never routes
+            // through here.
+            channel.clear_buffer();
         }
         self.columns[column].active_row = None;
         self.columns[column].active_clip = None;
@@ -463,10 +468,8 @@ impl ClipGrid {
                 PendingKind::Launch { row } => self.activate(column, row, channels),
                 PendingKind::Stop => self.stop_now(column, channels),
                 PendingKind::StopAndUnload { row } => {
+                    // `stop_now` already drops the channel buffer.
                     self.stop_now(column, channels);
-                    if let Some(channel) = channels.get_mut(column) {
-                        channel.clear_buffer();
-                    }
                     self.slots[column][row] = None;
                 }
             }
@@ -619,5 +622,29 @@ mod tests {
         grid.before_tick(&mut channels);
         assert!(grid.transport_seek(2.0, &mut channels));
         assert!((channels[0].position_normalized() - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn stopped_column_drops_channel_buffer_so_clear_leaves_nothing() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        let (buffer, bpm) = clip(0.5, 100, 60.0);
+        grid.load(0, 0, buffer, bpm);
+        grid.launch_at(0, 0, 0.0);
+        grid.transport_start(&mut channels);
+        grid.before_tick(&mut channels);
+        assert!(channels[0].has_buffer());
+
+        // A plain column stop must leave no sounding material behind.
+        grid.stop_at(0, grid.transport_beat());
+        grid.before_tick(&mut channels);
+        assert_eq!(grid.active_row(0), None);
+        assert!(!channels[0].has_buffer());
+
+        // `clear` after the stop cannot resurrect the buffer via a later
+        // legacy detach + set_playing.
+        grid.clear(&mut channels);
+        assert_eq!(grid.slot_state(0, 0), 0);
+        assert!(!channels[0].has_buffer());
     }
 }

--- a/src/mixer/loop_channel.rs
+++ b/src/mixer/loop_channel.rs
@@ -273,6 +273,15 @@ impl LoopChannel {
         self.stretcher = None;
     }
 
+    /// Drop the active sample buffer and reset playback state while preserving
+    /// the channel strip (gain, mute/solo, and effects).
+    pub fn clear_buffer(&mut self) {
+        self.buffer = None;
+        self.cursor = 0.0;
+        self.playing = false;
+        self.stretcher = None;
+    }
+
     pub fn set_playing(&mut self, playing: bool) {
         self.playing = playing;
     }

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -8,12 +8,18 @@
 //! it. The mixer sums its channels into a single stereo frame that the host
 //! engine adds to its master bus before the global effects + limiter.
 
+pub mod clip_grid;
 pub mod effect_chain;
 pub mod graph;
 pub mod loop_channel;
 pub mod stereo_buffer;
 mod wsola;
 
+pub use clip_grid::{
+    ClipGrid, LaunchQuantization, CLIP_COLUMN_COUNT, CLIP_QUANTIZE_BAR, CLIP_QUANTIZE_QUARTER,
+    CLIP_QUANTIZE_SIXTEENTH, CLIP_ROW_COUNT, CLIP_STATE_LOADED, CLIP_STATE_PLAYING,
+    CLIP_STATE_QUEUED,
+};
 pub use effect_chain::{ChannelEffect, EffectChain};
 pub use graph::MixerGraph;
 pub use loop_channel::{LoopChannel, PitchMode};
@@ -30,6 +36,7 @@ const DEFAULT_BPM: f32 = 120.0;
 
 pub struct Mixer {
     channels: Vec<LoopChannel>,
+    clip_grid: ClipGrid,
     sample_rate: f32,
     bpm: f32,
 }
@@ -42,6 +49,7 @@ impl Mixer {
             .collect();
         Self {
             channels,
+            clip_grid: ClipGrid::new(sample_rate, DEFAULT_BPM),
             sample_rate,
             bpm: DEFAULT_BPM,
         }
@@ -50,6 +58,7 @@ impl Mixer {
     /// Sum all channels into one stereo frame, honoring mute/solo: if any channel
     /// is soloed, only soloed channels sound; otherwise all un-muted channels do.
     pub fn tick(&mut self, engine_sample_rate: f32) -> StereoFrame {
+        self.clip_grid.before_tick(&mut self.channels);
         let any_solo = self.channels.iter().any(LoopChannel::is_soloed);
         let mut out = StereoFrame::default();
         for channel in &mut self.channels {
@@ -61,6 +70,7 @@ impl Mixer {
             channel.set_active(audible);
             out += channel.tick(engine_sample_rate);
         }
+        self.clip_grid.after_tick();
         out
     }
 
@@ -69,6 +79,7 @@ impl Mixer {
     /// the value used when creating new ones.
     pub fn set_bpm(&mut self, bpm: f32) {
         self.bpm = bpm;
+        self.clip_grid.set_bpm(bpm);
         for channel in &mut self.channels {
             channel.effects().set_bpm(bpm);
             channel.set_engine_bpm(bpm);
@@ -90,6 +101,7 @@ impl Mixer {
     // --- Channel control (bounds-checked, FFI-friendly) -------------------
 
     pub fn load(&mut self, channel: usize, buffer: StereoSampleBuffer) -> bool {
+        self.clip_grid.detach_column(channel);
         match self.channels.get_mut(channel) {
             Some(ch) => {
                 ch.set_buffer(buffer);
@@ -100,6 +112,7 @@ impl Mixer {
     }
 
     pub fn set_playing(&mut self, channel: usize, playing: bool) {
+        self.clip_grid.detach_column(channel);
         if let Some(ch) = self.channels.get_mut(channel) {
             ch.set_playing(playing);
         }
@@ -124,30 +137,35 @@ impl Mixer {
     }
 
     pub fn set_loop_start(&mut self, channel: usize, normalized: f32) {
+        self.clip_grid.detach_column(channel);
         if let Some(ch) = self.channels.get_mut(channel) {
             ch.set_loop_start(normalized);
         }
     }
 
     pub fn set_loop_end(&mut self, channel: usize, normalized: f32) {
+        self.clip_grid.detach_column(channel);
         if let Some(ch) = self.channels.get_mut(channel) {
             ch.set_loop_end(normalized);
         }
     }
 
     pub fn set_speed(&mut self, channel: usize, speed: f32) {
+        self.clip_grid.detach_column(channel);
         if let Some(ch) = self.channels.get_mut(channel) {
             ch.set_speed(speed);
         }
     }
 
     pub fn restart(&mut self, channel: usize) {
+        self.clip_grid.detach_column(channel);
         if let Some(ch) = self.channels.get_mut(channel) {
             ch.restart();
         }
     }
 
     pub fn set_position(&mut self, channel: usize, normalized: f32) {
+        self.clip_grid.detach_column(channel);
         if let Some(ch) = self.channels.get_mut(channel) {
             ch.set_position(normalized);
         }
@@ -156,6 +174,7 @@ impl Mixer {
     /// Tag a channel's loaded buffer with its source BPM (`None` clears the
     /// tag). No-op for a bad channel index or if no buffer is loaded.
     pub fn set_source_bpm(&mut self, channel: usize, bpm: Option<f32>) {
+        self.clip_grid.detach_column(channel);
         if let Some(ch) = self.channels.get_mut(channel) {
             ch.set_source_bpm(bpm);
         }
@@ -168,6 +187,7 @@ impl Mixer {
     }
 
     pub fn set_pitch_mode(&mut self, channel: usize, mode: PitchMode) {
+        self.clip_grid.detach_column(channel);
         if let Some(ch) = self.channels.get_mut(channel) {
             ch.set_pitch_mode(mode);
         }
@@ -189,6 +209,7 @@ impl Mixer {
         buffer: StereoSampleBuffer,
         divisions: u32,
     ) -> bool {
+        self.clip_grid.detach_column(channel);
         if buffer.is_empty() {
             return false;
         }
@@ -202,6 +223,7 @@ impl Mixer {
     }
 
     pub fn cancel_queued_swap(&mut self, channel: usize) {
+        self.clip_grid.detach_column(channel);
         if let Some(ch) = self.channels.get_mut(channel) {
             ch.cancel_queued_swap();
         }
@@ -211,6 +233,115 @@ impl Mixer {
         self.channels
             .get(channel)
             .map_or(0, |ch| ch.swaps_completed())
+    }
+
+    // --- Transport-synchronized clip grid -------------------------------
+
+    pub fn clip_load(
+        &mut self,
+        column: usize,
+        row: usize,
+        buffer: StereoSampleBuffer,
+        source_bpm: f32,
+    ) -> bool {
+        self.clip_grid.load(column, row, buffer, source_bpm)
+    }
+
+    pub fn clip_unload(&mut self, column: usize, row: usize) -> bool {
+        self.clip_grid.unload(column, row)
+    }
+
+    pub fn clip_clear(&mut self) {
+        self.clip_grid.clear(&mut self.channels);
+    }
+
+    pub fn clip_launch(
+        &mut self,
+        column: usize,
+        row: usize,
+        quantization: LaunchQuantization,
+    ) -> bool {
+        self.clip_grid.launch_quantized(column, row, quantization)
+    }
+
+    pub fn clip_launch_at(&mut self, column: usize, row: usize, beat: f64) -> bool {
+        self.clip_grid.launch_at(column, row, beat)
+    }
+
+    pub fn clip_launch_scene(&mut self, row: usize, quantization: LaunchQuantization) -> bool {
+        self.clip_grid.launch_scene_quantized(row, quantization)
+    }
+
+    pub fn clip_launch_scene_at(&mut self, row: usize, beat: f64) -> bool {
+        self.clip_grid.launch_scene_at(row, beat)
+    }
+
+    pub fn clip_stop(&mut self, column: usize, quantization: LaunchQuantization) -> bool {
+        self.clip_grid.stop_quantized(column, quantization)
+    }
+
+    pub fn clip_stop_at(&mut self, column: usize, beat: f64) -> bool {
+        self.clip_grid.stop_at(column, beat)
+    }
+
+    pub fn clip_cancel(&mut self, column: usize) {
+        self.clip_grid.cancel(column);
+    }
+
+    pub fn clip_cancel_all(&mut self) {
+        self.clip_grid.cancel_all();
+    }
+
+    pub fn clip_set_default_quantization(&mut self, quantization: LaunchQuantization) {
+        self.clip_grid.set_default_quantization(quantization);
+    }
+
+    pub fn clip_default_quantization(&self) -> LaunchQuantization {
+        self.clip_grid.default_quantization()
+    }
+
+    pub fn clip_slot_state(&self, column: usize, row: usize) -> u32 {
+        self.clip_grid.slot_state(column, row)
+    }
+
+    pub fn clip_active_row(&self, column: usize) -> Option<usize> {
+        self.clip_grid.active_row(column)
+    }
+
+    pub fn clip_queued_row(&self, column: usize) -> Option<usize> {
+        self.clip_grid.queued_row(column)
+    }
+
+    pub fn clip_is_stop_queued(&self, column: usize) -> bool {
+        self.clip_grid.is_stop_queued(column)
+    }
+
+    pub fn clip_scheduled_beat(&self, column: usize) -> Option<f64> {
+        self.clip_grid.scheduled_beat(column)
+    }
+
+    pub fn transport_start(&mut self) {
+        self.clip_grid.transport_start(&mut self.channels);
+    }
+
+    pub fn transport_stop(&mut self) {
+        self.clip_grid.transport_stop(&mut self.channels);
+    }
+
+    pub fn transport_seek(&mut self, beat: f64) -> bool {
+        self.clip_grid.transport_seek(beat, &mut self.channels)
+    }
+
+    pub fn transport_reset(&mut self) {
+        self.clip_grid.transport_reset(&mut self.channels);
+    }
+
+    pub fn transport_beat(&self) -> f64 {
+        self.clip_grid.transport_beat()
+    }
+
+    pub fn transport_running(&self) -> bool {
+        self.clip_grid.transport_running()
     }
 
     // --- Per-channel effects ----------------------------------------------

--- a/tests/clip_grid.rs
+++ b/tests/clip_grid.rs
@@ -1,0 +1,410 @@
+//! End-to-end tests for the transport-synchronized clip-grid C FFI.
+
+use gooey::ffi::*;
+
+const SR: f32 = 1_000.0;
+
+fn mono_clip(value: f32, frames: usize) -> Vec<f32> {
+    vec![value; frames]
+}
+
+fn noise_clip(frames: usize, mut state: u32) -> Vec<f32> {
+    (0..frames)
+        .map(|_| {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            (state as f32 / u32::MAX as f32) * 2.0 - 1.0
+        })
+        .collect()
+}
+
+unsafe fn load(
+    engine: *mut GooeyEngine,
+    column: u32,
+    row: u32,
+    value: f32,
+    frames: usize,
+    source_bpm: f32,
+) -> Vec<f32> {
+    let samples = mono_clip(value, frames);
+    assert!(gooey_engine_clip_load(
+        engine,
+        column,
+        row,
+        samples.as_ptr(),
+        frames as u32,
+        1,
+        SR,
+        source_bpm,
+    ));
+    samples
+}
+
+unsafe fn render(engine: *mut GooeyEngine, frames: usize) -> Vec<f32> {
+    let mut out = vec![0.0; frames * 2];
+    gooey_engine_render(engine, out.as_mut_ptr(), frames as u32);
+    out
+}
+
+#[test]
+fn constants_and_load_validation_are_stable() {
+    unsafe {
+        assert_eq!(CLIP_COLUMN_COUNT, 4);
+        assert_eq!(CLIP_ROW_COUNT, 8);
+        let engine = gooey_engine_new(SR);
+        let samples = mono_clip(0.5, 1000);
+
+        assert!(!gooey_engine_clip_load(
+            engine,
+            CLIP_COLUMN_COUNT,
+            0,
+            samples.as_ptr(),
+            1000,
+            1,
+            SR,
+            60.0,
+        ));
+        assert!(!gooey_engine_clip_load(
+            engine,
+            0,
+            CLIP_ROW_COUNT,
+            samples.as_ptr(),
+            1000,
+            1,
+            SR,
+            60.0,
+        ));
+        assert!(!gooey_engine_clip_load(
+            engine,
+            0,
+            0,
+            samples.as_ptr(),
+            1000,
+            1,
+            SR,
+            0.0,
+        ));
+        assert!(!gooey_engine_clip_load(
+            engine,
+            0,
+            0,
+            samples.as_ptr(),
+            1000,
+            1,
+            f32::NAN,
+            60.0,
+        ));
+        assert_eq!(gooey_engine_clip_get_state(engine, 0, 0), 0);
+
+        let _samples = load(engine, 0, 0, 0.5, 1000, 60.0);
+        assert_eq!(gooey_engine_clip_get_state(engine, 0, 0), CLIP_STATE_LOADED);
+        assert_eq!(
+            gooey_engine_clip_get_default_quantization(engine),
+            CLIP_QUANTIZE_BAR
+        );
+        assert!(!gooey_engine_clip_set_default_quantization(engine, 99));
+        gooey_engine_clip_clear(engine);
+        assert_eq!(gooey_engine_clip_get_state(engine, 0, 0), 0);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn stopped_launch_starts_empty_column_on_first_transport_sample() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        let _samples = load(engine, 0, 0, 0.5, 4000, 60.0);
+        assert!(gooey_engine_clip_launch(engine, 0, 0, CLIP_QUANTIZE_BAR));
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), -1);
+        assert_eq!(gooey_engine_clip_get_queued_row(engine, 0), 0);
+        assert_eq!(gooey_engine_clip_get_scheduled_beat(engine, 0), 0.0);
+
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 1);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
+        assert_eq!(
+            gooey_engine_clip_get_state(engine, 0, 0),
+            CLIP_STATE_LOADED | CLIP_STATE_PLAYING
+        );
+        assert!((gooey_engine_transport_get_beat_position(engine) - 0.002).abs() < 1e-9);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn quantized_and_exact_launches_cross_render_boundaries() {
+    unsafe fn assert_launch(quantization: u32, expected_beat: f64) {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let _samples = load(engine, 0, 0, 0.5, 8000, 60.0);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 100); // beat 0.1
+        assert!(gooey_engine_clip_launch(engine, 0, 0, quantization));
+        assert!((gooey_engine_clip_get_scheduled_beat(engine, 0) - expected_beat).abs() < 1e-9);
+
+        let frames_to_boundary = ((expected_beat - 0.1) * SR as f64) as usize;
+        let _ = render(engine, frames_to_boundary);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), -1);
+        let _ = render(engine, 1);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
+        gooey_engine_free(engine);
+    }
+
+    unsafe {
+        assert_launch(CLIP_QUANTIZE_SIXTEENTH, 0.25);
+        assert_launch(CLIP_QUANTIZE_QUARTER, 1.0);
+        assert_launch(CLIP_QUANTIZE_BAR, 4.0);
+
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let _samples = load(engine, 0, 0, 0.5, 8000, 60.0);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 100);
+        assert!(gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.333));
+        assert!(!gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.05));
+        assert!((gooey_engine_clip_get_scheduled_beat(engine, 0) - 0.333).abs() < 1e-9);
+        let _ = render(engine, 233);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), -1);
+        let _ = render(engine, 1);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn column_is_mutually_exclusive_and_latest_request_wins() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let _a = load(engine, 0, 0, 0.25, 4000, 60.0);
+        let _b = load(engine, 0, 1, 0.75, 4000, 60.0);
+        assert!(gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.0));
+        assert!(gooey_engine_clip_launch_at_beat(engine, 0, 1, 0.0));
+        assert_eq!(gooey_engine_clip_get_queued_row(engine, 0), 1);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 1);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 1);
+        assert_eq!(gooey_engine_clip_get_state(engine, 0, 0), CLIP_STATE_LOADED);
+        assert_eq!(
+            gooey_engine_clip_get_state(engine, 0, 1),
+            CLIP_STATE_LOADED | CLIP_STATE_PLAYING
+        );
+
+        assert!(gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.25));
+        gooey_engine_clip_cancel(engine, 0);
+        let _ = render(engine, 250);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 1);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn scene_launch_is_atomic_and_empty_cells_stop_columns() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let mut buffers = Vec::new();
+        for column in 0..CLIP_COLUMN_COUNT {
+            buffers.push(load(
+                engine,
+                column,
+                0,
+                0.1 + column as f32 * 0.1,
+                4000,
+                60.0,
+            ));
+        }
+        assert!(gooey_engine_clip_launch_scene_at_beat(engine, 0, 0.0));
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 1);
+        for column in 0..CLIP_COLUMN_COUNT {
+            assert_eq!(gooey_engine_clip_get_active_row(engine, column), 0);
+        }
+
+        buffers.push(load(engine, 0, 1, 0.9, 4000, 60.0));
+        assert!(gooey_engine_clip_launch_scene_at_beat(engine, 1, 0.25));
+        for column in 1..CLIP_COLUMN_COUNT {
+            assert!(gooey_engine_clip_is_stop_queued(engine, column));
+        }
+        let _ = render(engine, 249);
+        for column in 0..CLIP_COLUMN_COUNT {
+            assert_eq!(gooey_engine_clip_get_active_row(engine, column), 0);
+        }
+        let _ = render(engine, 1);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 1);
+        for column in 1..CLIP_COLUMN_COUNT {
+            assert_eq!(gooey_engine_clip_get_active_row(engine, column), -1);
+        }
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn transport_stop_freezes_active_phase_and_cancels_queue() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let _a = load(engine, 0, 0, 0.4, 4000, 60.0);
+        let _b = load(engine, 0, 1, 0.8, 4000, 60.0);
+        gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.0);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 300);
+        let beat = gooey_engine_transport_get_beat_position(engine);
+        let position = gooey_engine_loop_get_position(engine, 0);
+        gooey_engine_clip_launch_at_beat(engine, 0, 1, 1.0);
+
+        gooey_engine_sequencer_stop(engine);
+        assert_eq!(gooey_engine_clip_get_queued_row(engine, 0), -1);
+        let _ = render(engine, 500);
+        assert_eq!(gooey_engine_transport_get_beat_position(engine), beat);
+        assert_eq!(gooey_engine_loop_get_position(engine, 0), position);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
+
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 10);
+        assert!(gooey_engine_transport_get_beat_position(engine) > beat);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn active_replace_relaunch_and_unload_are_quantized() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        assert!(gooey_engine_clip_set_default_quantization(
+            engine,
+            CLIP_QUANTIZE_SIXTEENTH
+        ));
+        let _a = load(engine, 0, 0, 0.25, 4000, 60.0);
+        gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.0);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 100);
+
+        let _replacement = load(engine, 0, 0, 0.75, 4000, 60.0);
+        assert_eq!(
+            gooey_engine_clip_get_state(engine, 0, 0),
+            CLIP_STATE_LOADED | CLIP_STATE_PLAYING | CLIP_STATE_QUEUED
+        );
+        assert!((gooey_engine_clip_get_scheduled_beat(engine, 0) - 0.25).abs() < 1e-9);
+        let _ = render(engine, 150);
+        assert_ne!(
+            gooey_engine_clip_get_state(engine, 0, 0) & CLIP_STATE_QUEUED,
+            0
+        );
+        let _ = render(engine, 1);
+        assert_eq!(
+            gooey_engine_clip_get_state(engine, 0, 0),
+            CLIP_STATE_LOADED | CLIP_STATE_PLAYING
+        );
+
+        assert!(gooey_engine_clip_launch(
+            engine,
+            0,
+            0,
+            CLIP_QUANTIZE_SIXTEENTH
+        ));
+        assert_ne!(
+            gooey_engine_clip_get_state(engine, 0, 0) & CLIP_STATE_QUEUED,
+            0
+        );
+        gooey_engine_clip_cancel(engine, 0);
+
+        assert!(gooey_engine_clip_unload(engine, 0, 0));
+        assert!(gooey_engine_clip_is_stop_queued(engine, 0));
+        let target = gooey_engine_clip_get_scheduled_beat(engine, 0);
+        let current = gooey_engine_transport_get_beat_position(engine);
+        let frames = ((target - current) * SR as f64).ceil() as usize + 1;
+        let _ = render(engine, frames);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), -1);
+        assert_eq!(gooey_engine_clip_get_state(engine, 0, 0), 0);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn legacy_playhead_mutation_detaches_grid_state_but_keeps_slots() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        let _samples = load(engine, 0, 0, 0.5, 4000, 60.0);
+        gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.0);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 1);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
+
+        gooey_engine_loop_set_position(engine, 0, 0.5);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), -1);
+        assert_eq!(gooey_engine_clip_get_state(engine, 0, 0), CLIP_STATE_LOADED);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn different_source_tempos_hold_the_same_musical_phase() {
+    unsafe {
+        const AUDIO_SR: f32 = 44_100.0;
+        let engine = gooey_engine_new(AUDIO_SR);
+        gooey_engine_set_bpm(engine, 120.0);
+
+        // Both clips contain four beats: 2 s at 120 BPM and 4 s at 60 BPM.
+        // Non-periodic material gives WSOLA one unambiguous correlation peak;
+        // constant/sine buffers intentionally permit many equally good offsets.
+        let fast = noise_clip((AUDIO_SR * 2.0) as usize, 1);
+        let slow = noise_clip((AUDIO_SR * 4.0) as usize, 2);
+        assert!(gooey_engine_clip_load(
+            engine,
+            0,
+            0,
+            fast.as_ptr(),
+            fast.len() as u32,
+            1,
+            AUDIO_SR,
+            120.0,
+        ));
+        assert!(gooey_engine_clip_load(
+            engine,
+            1,
+            0,
+            slow.as_ptr(),
+            slow.len() as u32,
+            1,
+            AUDIO_SR,
+            60.0,
+        ));
+        gooey_engine_clip_launch_scene_at_beat(engine, 0, 0.0);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, (AUDIO_SR * 0.5) as usize); // one beat at 120 BPM
+
+        let fast_phase = gooey_engine_loop_get_position(engine, 0);
+        let slow_phase = gooey_engine_loop_get_position(engine, 1);
+        assert!(
+            (fast_phase - slow_phase).abs() < 0.08,
+            "musical phases diverged: fast={fast_phase}, slow={slow_phase}"
+        );
+        assert!(
+            (fast_phase - 0.25).abs() < 0.10,
+            "unexpected phase {fast_phase}"
+        );
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn host_time_arm_starts_transport_and_due_clip_on_same_sample() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let _samples = load(engine, 0, 0, 0.5, 4000, 60.0);
+        gooey_engine_set_render_host_time(engine, 1_000, 1.0);
+        gooey_engine_sequencer_start_at_host_time(engine, 1_050, 1.0);
+        assert!(gooey_engine_clip_launch_at_beat(engine, 0, 0, 1.0));
+
+        let _ = render(engine, 50);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), -1);
+        assert_eq!(gooey_engine_transport_get_beat_position(engine), 0.0);
+        gooey_engine_set_render_host_time(engine, 1_050, 1.0);
+        let _ = render(engine, 1);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
+        assert!(gooey_engine_transport_get_beat_position(engine) > 1.0);
+        gooey_engine_free(engine);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an Ableton-style **session clip grid** layered over the loop mixer: a fixed **4-column × 8-row** grid of stereo clips that launch, stop, and swap on future musical boundaries under the engine transport. Each column is mutually exclusive — only one of its eight clips plays at a time.

## What's included

- **`ClipGrid`** (`src/mixer/clip_grid.rs`): monotonic beat clock, per-column active/pending state, `sixteenth`/`quarter`/`bar` quantization plus exact-beat targets, applied via `before_tick`/`after_tick` around each rendered sample (half-sample tolerance so FP accumulation can't skip a boundary).
- **Mixer integration** (`src/mixer/mod.rs`): grid embedded in `Mixer`; legacy per-channel playhead mutations `detach` grid ownership for that column, while gain/mute/solo/effects remain shared column-strip controls.
- **C FFI** (`src/ffi.rs`): full `gooey_engine_clip_*` surface — load/unload/clear, individual + scene launch by quantization or exact beat, column stop, cancellation, default quantization, and state queries (loaded/playing/queued) — plus `gooey_engine_transport_get_beat_position` (an absolute, non-wrapping quarter-note position). Transport start/stop/reset/seek/BPM/host-time-arm all drive the grid.

## Behavior

- Individual clip launch, atomic whole-row scene launch (empty cells stop their columns), and quantized column stop.
- Last-request-wins per column; transport stop freezes active clips and cancels pending actions; seek realigns active-clip phase.
- Every slot carries a required source BPM and launches pitch-preserving (WSOLA), so different source tempos hold the same musical phase.

## Testing

- 40 mixer unit tests + **10 end-to-end FFI tests** (`tests/clip_grid.rs`) covering quantized/exact launches across render-buffer boundaries, atomic scenes, cancellation, freeze/resume/seek, active replace/relaunch/unload, invalid-input rejection, pitch-preserving tempo sync, and legacy detachment.
- Full suite green (276 lib + all integration), `cargo clippy --lib --tests` clean for the new code, and `cargo build --no-default-features --features ios` passes.
- Rebased onto and validated against `main` (#220 routable sampler rack).

Existing `gooey_engine_loop_*` users are unaffected when they don't use the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)