### PR TITLE
Add engine-managed clip trim with wrap-around loop region

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -15,7 +15,9 @@ use crate::instruments::{
     PolySynthConfig, SampleBuffer, SamplerBuffer, SamplerRack, SnareConfig, SnareDrum, Tom2,
     Tom2Config,
 };
-use crate::mixer::{LaunchQuantization, Mixer, MixerGraph, PitchMode, StereoSampleBuffer};
+use crate::mixer::{
+    LaunchQuantization, Mixer, MixerGraph, PitchMode, RetrimTiming, StereoSampleBuffer,
+};
 use crate::music::{apply_voicing, available_voicings, Key, NoteName, ScaleType, VoicingType};
 use crate::performance::{ChordClipEvent, PerformanceRecorder, PlayerAction, RecordMode};
 use crate::utils::{PresetBlender, SmoothedParam};
@@ -6614,6 +6616,10 @@ pub const CLIP_QUANTIZE_SIXTEENTH: u32 = crate::mixer::CLIP_QUANTIZE_SIXTEENTH;
 pub const CLIP_QUANTIZE_QUARTER: u32 = crate::mixer::CLIP_QUANTIZE_QUARTER;
 /// Launch on the next 4/4 bar boundary (the default).
 pub const CLIP_QUANTIZE_BAR: u32 = crate::mixer::CLIP_QUANTIZE_BAR;
+/// Trim-only timing: re-window the active loop immediately, ignoring the
+/// transport grid. Accepted by `gooey_engine_clip_set_trim`; the launch/stop
+/// functions still reject it as an unknown quantization.
+pub const CLIP_QUANTIZE_IMMEDIATE: u32 = crate::mixer::CLIP_QUANTIZE_IMMEDIATE;
 
 /// Slot contains a preloaded clip buffer.
 pub const CLIP_STATE_LOADED: u32 = crate::mixer::CLIP_STATE_LOADED;
@@ -6931,6 +6937,94 @@ pub unsafe extern "C" fn gooey_engine_clip_get_scheduled_beat(
         .unwrap_or(-1.0)
 }
 
+/// Set a slot's loop trim as normalized `[0, 1]` start/end markers.
+///
+/// The trim is always stored on the slot, so the next launch of that slot loops
+/// only `[start, end)` and `gooey_engine_clip_get_trim_start/_end` round-trip.
+/// When the slot is its column's active clip, the change also lands on the
+/// sounding loop: `quantization == CLIP_QUANTIZE_IMMEDIATE` re-windows it now
+/// (live marker scrubbing; also works while the transport is stopped), while a
+/// `CLIP_QUANTIZE_*` boundary schedules it for that grid point so the loop never
+/// jumps mid-bar. A queued retrim is independent of a queued launch/stop —
+/// neither cancels the other — and `gooey_engine_clip_cancel` drops both.
+///
+/// `end < start` is intentional: it selects a wrap-around loop region that plays
+/// `[start, 1) ∪ [0, end)`, rotating the phrase downbeat (the same reusable
+/// primitive the legacy `gooey_engine_loop_set_start/end` now exposes).
+///
+/// Reloading a slot with `gooey_engine_clip_load` installs a fresh clip and thus
+/// resets its trim to the full `[0, 1)` buffer.
+///
+/// Returns `false` for a null engine, out-of-range slot, non-finite markers,
+/// markers outside `[0, 1]`, `start == end`, an unknown quantization, or an
+/// empty slot.
+///
+/// # Safety
+/// `engine` must be null or a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_set_trim(
+    engine: *mut GooeyEngine,
+    column: u32,
+    row: u32,
+    start: f64,
+    end: f64,
+    quantization: u32,
+) -> bool {
+    let Some(engine) = engine.as_mut() else {
+        return false;
+    };
+    if column >= CLIP_COLUMN_COUNT
+        || row >= CLIP_ROW_COUNT
+        || !start.is_finite()
+        || !end.is_finite()
+        || !(0.0..=1.0).contains(&start)
+        || !(0.0..=1.0).contains(&end)
+        || start == end
+    {
+        return false;
+    }
+    let Some(timing) = RetrimTiming::from_id(quantization) else {
+        return false;
+    };
+    engine
+        .mixer
+        .clip_set_trim(column as usize, row as usize, start, end, timing)
+}
+
+/// Return a slot's normalized loop-start marker, or `-1.0` for a null engine or
+/// empty/out-of-range slot.
+///
+/// # Safety
+/// `engine` must be null or a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_get_trim_start(
+    engine: *const GooeyEngine,
+    column: u32,
+    row: u32,
+) -> f64 {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.mixer.clip_trim_start(column as usize, row as usize))
+        .unwrap_or(-1.0)
+}
+
+/// Return a slot's normalized loop-end marker, or `-1.0` for a null engine or
+/// empty/out-of-range slot.
+///
+/// # Safety
+/// `engine` must be null or a valid pointer returned by `gooey_engine_new`.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_get_trim_end(
+    engine: *const GooeyEngine,
+    column: u32,
+    row: u32,
+) -> f64 {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.mixer.clip_trim_end(column as usize, row as usize))
+        .unwrap_or(-1.0)
+}
+
 /// Return the monotonic absolute transport position in quarter notes.
 /// Unlike `gooey_engine_sequencer_get_beat_position`, this value does not wrap
 /// at the end of the 16-step sequencer pattern.
@@ -7062,6 +7156,10 @@ pub unsafe extern "C" fn gooey_engine_loop_set_solo(
 /// Set a loop channel's loop start point as a normalized `[0, 1]` position in
 /// the buffer.
 ///
+/// Note: when the resulting `end < start`, the loop now plays the wrap-around
+/// region `[start, 1) ∪ [0, end)` instead of silently swapping the two markers
+/// as it did previously — the same reusable primitive used by clip trim.
+///
 /// # Safety
 /// `engine` must be a valid pointer returned by `gooey_engine_new`.
 #[no_mangle]
@@ -7077,6 +7175,10 @@ pub unsafe extern "C" fn gooey_engine_loop_set_start(
 
 /// Set a loop channel's loop end point as a normalized `[0, 1]` position in
 /// the buffer.
+///
+/// Note: when the resulting `end < start`, the loop now plays the wrap-around
+/// region `[start, 1) ∪ [0, end)` instead of silently swapping the two markers
+/// as it did previously — the same reusable primitive used by clip trim.
 ///
 /// # Safety
 /// `engine` must be a valid pointer returned by `gooey_engine_new`.

--- a/src/mixer/clip_grid.rs
+++ b/src/mixer/clip_grid.rs
@@ -8,6 +8,9 @@ pub const CLIP_ROW_COUNT: usize = 8;
 pub const CLIP_QUANTIZE_SIXTEENTH: u32 = 0;
 pub const CLIP_QUANTIZE_QUARTER: u32 = 1;
 pub const CLIP_QUANTIZE_BAR: u32 = 2;
+/// Retrim timing sentinel: apply immediately, ignoring the transport grid.
+/// Valid only for trim edits — launches still reject it.
+pub const CLIP_QUANTIZE_IMMEDIATE: u32 = 3;
 
 pub const CLIP_STATE_LOADED: u32 = 1 << 0;
 pub const CLIP_STATE_PLAYING: u32 = 1 << 1;
@@ -47,10 +50,38 @@ impl LaunchQuantization {
     }
 }
 
+/// When a trim edit to the *active* clip takes effect.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RetrimTiming {
+    /// Re-window the loop right now (live marker scrubbing); works with the
+    /// transport stopped too.
+    Immediate,
+    /// Land the new window on the transport grid, like a launch, so the loop
+    /// never jumps mid-bar to a dissonant position.
+    Quantized(LaunchQuantization),
+}
+
+impl RetrimTiming {
+    /// Decode a `CLIP_QUANTIZE_*` id, where `CLIP_QUANTIZE_IMMEDIATE` selects
+    /// [`RetrimTiming::Immediate`] and the rest reuse [`LaunchQuantization`].
+    pub fn from_id(value: u32) -> Option<Self> {
+        if value == CLIP_QUANTIZE_IMMEDIATE {
+            Some(Self::Immediate)
+        } else {
+            LaunchQuantization::from_id(value).map(Self::Quantized)
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 struct Clip {
     buffer: StereoSampleBuffer,
     length_beats: f64,
+    /// Normalized loop trim markers in `[0, 1]`. `trim_end < trim_start` selects
+    /// a wrap-around loop region (see [`LoopChannel::set_loop_window`]). Applied
+    /// by [`ClipGrid::activate`] and round-tripped by the trim getters.
+    trim_start: f64,
+    trim_end: f64,
 }
 
 impl Clip {
@@ -67,6 +98,8 @@ impl Clip {
         Some(Self {
             buffer,
             length_beats,
+            trim_start: 0.0,
+            trim_end: 1.0,
         })
     }
 }
@@ -84,12 +117,23 @@ struct ScheduledAction {
     beat: f64,
 }
 
+/// A trim edit queued to land on the transport grid. Kept separate from
+/// `pending` (single latest-wins launch/stop slot) so a queued retrim never
+/// cancels a queued launch and vice versa.
+#[derive(Clone, Copy, Debug)]
+struct PendingRetrim {
+    beat: f64,
+    start: f64,
+    end: f64,
+}
+
 #[derive(Clone, Debug, Default)]
 struct ColumnState {
     active_row: Option<usize>,
     active_clip: Option<Clip>,
     launch_beat: f64,
     pending: Option<ScheduledAction>,
+    pending_retrim: Option<PendingRetrim>,
 }
 
 /// Engine-owned 4×8 clip grid plus its monotonic musical transport.
@@ -281,12 +325,14 @@ impl ClipGrid {
     pub fn cancel(&mut self, column: usize) {
         if let Some(state) = self.columns.get_mut(column) {
             state.pending = None;
+            state.pending_retrim = None;
         }
     }
 
     pub fn cancel_all(&mut self) {
         for state in &mut self.columns {
             state.pending = None;
+            state.pending_retrim = None;
         }
     }
 
@@ -355,6 +401,96 @@ impl ClipGrid {
             .and_then(|state| state.pending.map(|pending| pending.beat))
     }
 
+    /// Set a slot's loop trim as normalized `[0, 1]` start/end markers. The
+    /// value is always stored into the slot `Clip` (so the next launch applies
+    /// it, and the getters round-trip). When the slot is the currently active
+    /// one, the active clone is updated too and the change is applied to the
+    /// sounding channel per `timing`: [`RetrimTiming::Immediate`] re-windows the
+    /// loop now (also works with the transport stopped); a quantized timing
+    /// schedules the retrim for the next matching grid boundary, fired
+    /// sample-accurately in [`Self::before_tick`].
+    ///
+    /// `end < start` selects a wrap-around loop region. Rejects non-finite
+    /// markers, markers outside `[0, 1]`, `start == end`, invalid slots, and
+    /// sub-sample windows (`span * buffer_len < 1`).
+    pub fn set_trim(
+        &mut self,
+        column: usize,
+        row: usize,
+        start: f64,
+        end: f64,
+        timing: RetrimTiming,
+        channels: &mut [LoopChannel],
+    ) -> bool {
+        if !Self::valid_slot(column, row)
+            || !start.is_finite()
+            || !end.is_finite()
+            || !(0.0..=1.0).contains(&start)
+            || !(0.0..=1.0).contains(&end)
+            || start == end
+        {
+            return false;
+        }
+        let Some(clip) = self.slots[column][row].as_mut() else {
+            return false;
+        };
+        // Reject a window smaller than one frame (the grid owns the buffer, so
+        // it can check the physical span the channel can't).
+        let buffer_len = clip.buffer.len() as f64;
+        let span_frac = if end < start {
+            1.0 - start + end
+        } else {
+            end - start
+        };
+        if span_frac * buffer_len < 1.0 {
+            return false;
+        }
+        clip.trim_start = start;
+        clip.trim_end = end;
+
+        if self.columns[column].active_row != Some(row) {
+            return true;
+        }
+        // Keep the active clone in sync so a transport seek / relaunch uses the
+        // new trim, then apply to the sounding channel.
+        if let Some(active) = self.columns[column].active_clip.as_mut() {
+            active.trim_start = start;
+            active.trim_end = end;
+        }
+        match timing {
+            RetrimTiming::Immediate => {
+                if let Some(channel) = channels.get_mut(column) {
+                    channel.set_loop_window(start as f32, end as f32);
+                }
+                // An immediate retrim supersedes any queued one.
+                self.columns[column].pending_retrim = None;
+            }
+            RetrimTiming::Quantized(quantization) => {
+                let beat = self.quantized_target(quantization);
+                self.columns[column].pending_retrim = Some(PendingRetrim { beat, start, end });
+            }
+        }
+        true
+    }
+
+    /// The stored normalized loop-start marker for a slot, or `None` for an
+    /// invalid or empty slot.
+    pub fn trim_start(&self, column: usize, row: usize) -> Option<f64> {
+        if !Self::valid_slot(column, row) {
+            return None;
+        }
+        self.slots[column][row].as_ref().map(|clip| clip.trim_start)
+    }
+
+    /// The stored normalized loop-end marker for a slot, or `None` for an
+    /// invalid or empty slot.
+    pub fn trim_end(&self, column: usize, row: usize) -> Option<f64> {
+        if !Self::valid_slot(column, row) {
+            return None;
+        }
+        self.slots[column][row].as_ref().map(|clip| clip.trim_end)
+    }
+
     pub fn set_bpm(&mut self, bpm: f32) {
         if bpm.is_finite() && bpm > 0.0 {
             self.bpm = bpm;
@@ -396,7 +532,9 @@ impl ClipGrid {
             let phase =
                 (beat - state.launch_beat).rem_euclid(clip.length_beats) / clip.length_beats;
             if let Some(channel) = channels.get_mut(column) {
-                channel.set_position(phase as f32);
+                // Map the musical phrase phase through the loop window so it
+                // lands correctly inside a trimmed (or wrapped) region.
+                channel.set_window_phase(phase as f32);
             }
         }
         true
@@ -423,8 +561,9 @@ impl ClipGrid {
         let Some(channel) = channels.get_mut(column) else {
             return;
         };
-        channel.set_loop_start(0.0);
-        channel.set_loop_end(1.0);
+        // Apply the slot's stored trim before `set_buffer` so the cursor lands
+        // at the trimmed loop start.
+        channel.set_loop_window(clip.trim_start as f32, clip.trim_end as f32);
         channel.set_speed(1.0);
         channel.set_pitch_mode(PitchMode::PreservePitch);
         channel.cancel_queued_swap();
@@ -457,20 +596,32 @@ impl ClipGrid {
         }
         let tolerance = self.beats_per_sample() * 0.5 + 1.0e-12;
         for column in 0..CLIP_COLUMN_COUNT {
-            let Some(pending) = self.columns[column].pending else {
-                continue;
-            };
-            if self.transport_beat + tolerance < pending.beat {
-                continue;
+            if let Some(pending) = self.columns[column].pending {
+                if self.transport_beat + tolerance >= pending.beat {
+                    self.columns[column].pending = None;
+                    // A launch/stop re-applies the slot's stored trim on
+                    // activate, so any queued retrim is now stale.
+                    self.columns[column].pending_retrim = None;
+                    match pending.kind {
+                        PendingKind::Launch { row } => self.activate(column, row, channels),
+                        PendingKind::Stop => self.stop_now(column, channels),
+                        PendingKind::StopAndUnload { row } => {
+                            // `stop_now` already drops the channel buffer.
+                            self.stop_now(column, channels);
+                            self.slots[column][row] = None;
+                        }
+                    }
+                }
             }
-            self.columns[column].pending = None;
-            match pending.kind {
-                PendingKind::Launch { row } => self.activate(column, row, channels),
-                PendingKind::Stop => self.stop_now(column, channels),
-                PendingKind::StopAndUnload { row } => {
-                    // `stop_now` already drops the channel buffer.
-                    self.stop_now(column, channels);
-                    self.slots[column][row] = None;
+
+            // Fire a due retrim on the active clip. Independent of `pending`
+            // so a scheduled trim and a scheduled launch coexist.
+            if let Some(retrim) = self.columns[column].pending_retrim {
+                if self.transport_beat + tolerance >= retrim.beat {
+                    self.columns[column].pending_retrim = None;
+                    if let Some(channel) = channels.get_mut(column) {
+                        channel.set_loop_window(retrim.start as f32, retrim.end as f32);
+                    }
                 }
             }
         }
@@ -646,5 +797,160 @@ mod tests {
         grid.clear(&mut channels);
         assert_eq!(grid.slot_state(0, 0), 0);
         assert!(!channels[0].has_buffer());
+    }
+
+    /// Drive the grid + channels sample-by-sample, like the real render loop.
+    fn step(grid: &mut ClipGrid, channels: &mut [LoopChannel], samples: usize) {
+        for _ in 0..samples {
+            grid.before_tick(channels);
+            for ch in channels.iter_mut() {
+                ch.tick(SR);
+            }
+            grid.after_tick();
+        }
+    }
+
+    #[test]
+    fn set_trim_stores_and_activate_applies() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        let (buffer, bpm) = clip(0.5, 100, 60.0);
+        grid.load(0, 0, buffer, bpm);
+        // Store trim on an inactive slot (timing is irrelevant here).
+        assert!(grid.set_trim(0, 0, 0.25, 0.75, RetrimTiming::Immediate, &mut channels));
+        assert_eq!(grid.trim_start(0, 0), Some(0.25));
+        assert_eq!(grid.trim_end(0, 0), Some(0.75));
+        // Launch -> activate applies the stored trim to the channel window.
+        grid.launch_at(0, 0, 0.0);
+        grid.transport_start(&mut channels);
+        grid.before_tick(&mut channels);
+        assert_eq!(grid.active_row(0), Some(0));
+        assert!((channels[0].loop_start() - 0.25).abs() < 1e-6);
+        assert!((channels[0].loop_end() - 0.75).abs() < 1e-6);
+        // Cursor landed at the trimmed loop start.
+        assert!((channels[0].position_normalized() - 0.25).abs() < 1e-3);
+    }
+
+    #[test]
+    fn immediate_retrim_rewrites_active_window_without_restart() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        let (buffer, bpm) = clip(0.5, 400, 60.0);
+        grid.load(0, 0, buffer, bpm);
+        grid.launch_at(0, 0, 0.0);
+        grid.transport_start(&mut channels);
+        grid.before_tick(&mut channels);
+        // Advance the playhead into the middle of the full loop (~0.2).
+        step(&mut grid, &mut channels, 80);
+        let before = channels[0].position_normalized();
+        assert!(before > 0.1, "cursor did not advance: {before}");
+        // Retrim to a window that still contains the cursor -> no jump/restart.
+        assert!(grid.set_trim(0, 0, 0.1, 0.9, RetrimTiming::Immediate, &mut channels));
+        let after = channels[0].position_normalized();
+        assert!(
+            (after - before).abs() < 1e-6,
+            "cursor moved: {before} -> {after}"
+        );
+        assert!((channels[0].loop_start() - 0.1).abs() < 1e-6);
+        assert!((channels[0].loop_end() - 0.9).abs() < 1e-6);
+    }
+
+    #[test]
+    fn quantized_retrim_fires_at_boundary_and_coexists_with_pending_launch() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        let (a, bpm) = clip(0.3, 400, 60.0);
+        let (b, _) = clip(0.9, 400, 60.0);
+        grid.load(0, 0, a, bpm);
+        grid.load(0, 1, b, bpm);
+        grid.launch_at(0, 0, 0.0);
+        grid.transport_start(&mut channels);
+        grid.before_tick(&mut channels); // activate row 0 at beat 0
+
+        // Queue a retrim (sixteenth = 0.25 beat) AND a launch of row 1 (beat 1).
+        assert!(grid.set_trim(
+            0,
+            0,
+            0.8,
+            0.95,
+            RetrimTiming::Quantized(LaunchQuantization::Sixteenth),
+            &mut channels,
+        ));
+        assert!(grid.launch_at(0, 1, 1.0));
+        // Both coexist: launch pending on row 1, retrim not yet applied.
+        assert_eq!(grid.queued_row(0), Some(1));
+        assert!((channels[0].loop_start() - 0.0).abs() < 1e-6);
+
+        // Cross the sixteenth boundary (0.25 beat = 25 samples) but not beat 1.
+        step(&mut grid, &mut channels, 30);
+        assert!(
+            (channels[0].loop_start() - 0.8).abs() < 1e-6,
+            "retrim not applied: {}",
+            channels[0].loop_start()
+        );
+        assert_eq!(grid.active_row(0), Some(0)); // no detach
+        assert_eq!(grid.queued_row(0), Some(1)); // launch survived
+
+        // Reach the launch boundary (beat 1 = 100 samples from start).
+        step(&mut grid, &mut channels, 100);
+        assert_eq!(grid.active_row(0), Some(1));
+    }
+
+    #[test]
+    fn set_trim_rejects_degenerate() {
+        let mut grid = ClipGrid::new(SR, 60.0);
+        let mut channels = channels();
+        let (buffer, bpm) = clip(0.5, 100, 60.0);
+        grid.load(0, 0, buffer, bpm);
+        // start == end
+        assert!(!grid.set_trim(0, 0, 0.5, 0.5, RetrimTiming::Immediate, &mut channels));
+        // out of range
+        assert!(!grid.set_trim(0, 0, -0.1, 0.5, RetrimTiming::Immediate, &mut channels));
+        assert!(!grid.set_trim(0, 0, 0.5, 1.5, RetrimTiming::Immediate, &mut channels));
+        // non-finite
+        assert!(!grid.set_trim(0, 0, f64::NAN, 0.5, RetrimTiming::Immediate, &mut channels));
+        // sub-sample window: 0.005 * 100 frames = 0.5 frame < 1
+        assert!(!grid.set_trim(0, 0, 0.0, 0.005, RetrimTiming::Immediate, &mut channels));
+        // invalid slot
+        assert!(!grid.set_trim(
+            CLIP_COLUMN_COUNT,
+            0,
+            0.2,
+            0.8,
+            RetrimTiming::Immediate,
+            &mut channels
+        ));
+        // valid
+        assert!(grid.set_trim(0, 0, 0.2, 0.8, RetrimTiming::Immediate, &mut channels));
+    }
+
+    #[test]
+    fn transport_seek_maps_phase_into_trimmed_window() {
+        // Cropped (non-wrap) window: middle phase lands in the crop's middle.
+        {
+            let mut grid = ClipGrid::new(SR, 60.0);
+            let mut channels = channels();
+            let (buffer, bpm) = clip(0.5, 400, 60.0); // 4 beats
+            grid.load(0, 0, buffer, bpm);
+            grid.set_trim(0, 0, 0.25, 0.75, RetrimTiming::Immediate, &mut channels);
+            grid.launch_at(0, 0, 0.0);
+            grid.transport_start(&mut channels);
+            grid.before_tick(&mut channels);
+            assert!(grid.transport_seek(2.0, &mut channels)); // phase 0.5 of 4 beats
+            assert!((channels[0].position_normalized() - 0.5).abs() < 0.01);
+        }
+        // Wrapped window: half the span crosses the seam to frame 0.
+        {
+            let mut grid = ClipGrid::new(SR, 60.0);
+            let mut channels = channels();
+            let (buffer, bpm) = clip(0.5, 400, 60.0);
+            grid.load(0, 0, buffer, bpm);
+            grid.set_trim(0, 0, 0.75, 0.25, RetrimTiming::Immediate, &mut channels);
+            grid.launch_at(0, 0, 0.0);
+            grid.transport_start(&mut channels);
+            grid.before_tick(&mut channels);
+            assert!(grid.transport_seek(2.0, &mut channels)); // phase 0.5 -> seam
+            assert!(channels[0].position_normalized() < 0.01);
+        }
     }
 }

--- a/src/mixer/loop_channel.rs
+++ b/src/mixer/loop_channel.rs
@@ -44,6 +44,76 @@ pub enum PitchMode {
     PreservePitch,
 }
 
+/// A resolved loop window in physical frame coordinates.
+///
+/// Normally `[lo, hi)`. When the start marker is pushed past the end marker
+/// (`loop_end < loop_start`), the window wraps the buffer end and plays the
+/// union `[lo, len) ∪ [0, hi)` — rotating the phrase downbeat. `span` is the
+/// total playable length (`hi - lo`, or `len - lo + hi` when wrapped).
+///
+/// Playback math on the wrap branch runs in *virtual* coordinates `[0, span)`
+/// via [`LoopWindow::to_virtual`]/[`LoopWindow::to_physical`]; the non-wrap
+/// branch stays in physical frames so its float expressions are byte-identical
+/// to the pre-wrap engine.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct LoopWindow {
+    /// Loop start in physical frames.
+    pub(crate) lo: f64,
+    /// Loop end in physical frames.
+    pub(crate) hi: f64,
+    /// Playable span in frames: `hi - lo`, or `len - lo + hi` when wrapped.
+    pub(crate) span: f64,
+    /// Whether the window wraps the buffer end (`hi < lo`).
+    pub(crate) wraps: bool,
+    /// Buffer length in frames.
+    pub(crate) len: f64,
+}
+
+impl LoopWindow {
+    /// Map a physical frame position to its virtual offset in `[0, span)`.
+    #[inline]
+    pub(crate) fn to_virtual(self, p: f64) -> f64 {
+        (p - self.lo).rem_euclid(self.len)
+    }
+
+    /// Map a virtual offset back to a physical frame position in `[0, len)`.
+    #[inline]
+    pub(crate) fn to_physical(self, v: f64) -> f64 {
+        (self.lo + v).rem_euclid(self.len)
+    }
+
+    /// Whether a physical position lies inside the playable region.
+    #[inline]
+    fn contains(&self, p: f64) -> bool {
+        if self.wraps {
+            p >= self.lo || p < self.hi
+        } else {
+            p >= self.lo && p < self.hi
+        }
+    }
+
+    /// Fold a physical position into the window: returned unchanged when it is
+    /// already inside, otherwise snapped to the nearer edge of the playable
+    /// region (the loop start `lo` or end `hi`). On the wrap branch the gap is
+    /// the contiguous physical range `[hi, lo)`, so plain distance picks the
+    /// nearer edge.
+    #[inline]
+    fn fold(&self, p: f64) -> f64 {
+        if self.contains(p) {
+            return p;
+        }
+        if self.wraps {
+            if (p - self.hi) <= (self.lo - p) {
+                self.hi
+            } else {
+                self.lo
+            }
+        } else {
+            p.clamp(self.lo, self.hi)
+        }
+    }
+}
+
 pub struct LoopChannel {
     buffer: Option<StereoSampleBuffer>,
     /// Playback position in source frames (fractional).
@@ -113,7 +183,16 @@ impl LoopChannel {
             if self.pitch_mode == PitchMode::PreservePitch && self.speed >= 0.0 {
                 self.tick_preserve_pitch(engine_sample_rate)
             } else {
-                let frame = self.buffer.as_ref().unwrap().read_interpolated(self.cursor);
+                let buffer = self.buffer.as_ref().unwrap();
+                let window = self.window(buffer.len() as f64);
+                // Read through the wrapping cubic taps only when the window
+                // wraps the buffer end, so the seam stays continuous; the
+                // common non-wrap read is unchanged.
+                let frame = if window.wraps {
+                    buffer.read_wrapped(self.cursor)
+                } else {
+                    buffer.read_interpolated(self.cursor)
+                };
                 self.advance(engine_sample_rate);
                 frame
             }
@@ -136,7 +215,7 @@ impl LoopChannel {
     fn tick_preserve_pitch(&mut self, engine_sample_rate: f32) -> StereoFrame {
         let buffer = self.buffer.as_ref().unwrap().clone(); // cheap: two Arc bumps
         let len = buffer.len() as f64;
-        let (lo, hi) = self.loop_bounds(len);
+        let window = self.window(len);
         let sr_ratio = buffer.sample_rate() as f64 / engine_sample_rate.max(1.0) as f64;
         let warp = self.warp_ratio();
         let speed = self.speed as f64;
@@ -148,10 +227,16 @@ impl LoopChannel {
         let mut wrapped = false;
         let stretcher = self.stretcher.as_mut().unwrap();
         if stretcher.needs_refill() {
-            self.cursor = stretcher.synthesize_next_hop(&buffer, lo, hi, sr_ratio, speed, warp);
+            self.cursor = stretcher.synthesize_next_hop(&buffer, &window, sr_ratio, speed, warp);
             // Forward-only path (speed >= 0), so a cursor that moved backward can
-            // only mean the hop wrapped the loop window.
-            wrapped = self.cursor < prev;
+            // only mean the hop wrapped the loop window. Under a wrap window the
+            // physical cursor isn't monotonic across the buffer seam, so compare
+            // virtual offsets there.
+            wrapped = if window.wraps {
+                window.to_virtual(self.cursor) < window.to_virtual(prev)
+            } else {
+                self.cursor < prev
+            };
         }
         let out = self.stretcher.as_mut().unwrap().drain();
         // Land any queued audition swap at its bar-grid boundary. `advance` handles
@@ -166,8 +251,16 @@ impl LoopChannel {
         // are sample-accurate. This is accepted: the swap restarts the phrase from the
         // loop start (already a deliberate discontinuity), and sub-hop precision would
         // require splitting an overlap-add hop for no meaningful audible gain.
-        let span = (hi - lo).max(1.0);
-        self.maybe_swap_pending(prev, lo, span, wrapped);
+        let span = window.span.max(1.0);
+        // Feed `maybe_swap_pending` virtual offsets. The non-wrap branch passes
+        // `prev - lo` / `cursor - lo`, byte-identical to the previous internal
+        // math so the swap grid lands on exactly the same samples.
+        let (prev_v, cur_v) = if window.wraps {
+            (window.to_virtual(prev), window.to_virtual(self.cursor))
+        } else {
+            (prev - window.lo, self.cursor - window.lo)
+        };
+        self.maybe_swap_pending(prev_v, cur_v, span, wrapped);
         out
     }
 
@@ -178,8 +271,8 @@ impl LoopChannel {
             Some(buffer) => (buffer.len() as f64, buffer.sample_rate() as f64),
             None => return,
         };
-        let (lo, hi) = self.loop_bounds(len);
-        let span = (hi - lo).max(1.0);
+        let window = self.window(len);
+        let span = window.span.max(1.0);
 
         let ratio = source_sr / engine_sample_rate.max(1.0) as f64;
         let warp = if self.pitch_mode == PitchMode::Resample {
@@ -188,32 +281,48 @@ impl LoopChannel {
             1.0
         };
         let prev = self.cursor;
-        self.cursor += self.speed as f64 * ratio * warp;
+        let delta = self.speed as f64 * ratio * warp;
 
-        let mut wrapped = false;
-        if self.cursor >= hi {
-            self.cursor = lo + (self.cursor - lo).rem_euclid(span);
-            wrapped = true;
-        } else if self.cursor < lo {
-            // rem_euclid keeps the offset in [0, span); mirror it back from hi.
-            self.cursor = hi - (lo - self.cursor).rem_euclid(span);
-            wrapped = true;
-        }
+        let (prev_v, cur_v, wrapped) = if window.wraps {
+            // Wrap branch: advance in virtual coordinates [0, span). rem_euclid
+            // handles reverse (negative delta) for free.
+            let prev_v = window.to_virtual(prev);
+            let raw = prev_v + delta;
+            let wrapped = !(0.0..span).contains(&raw);
+            let cur_v = raw.rem_euclid(span);
+            self.cursor = window.to_physical(cur_v);
+            (prev_v, cur_v, wrapped)
+        } else {
+            // Non-wrap branch: physical-frame math, byte-identical to the
+            // pre-wrap engine.
+            let (lo, hi) = (window.lo, window.hi);
+            self.cursor += delta;
+            let mut wrapped = false;
+            if self.cursor >= hi {
+                self.cursor = lo + (self.cursor - lo).rem_euclid(span);
+                wrapped = true;
+            } else if self.cursor < lo {
+                // rem_euclid keeps the offset in [0, span); mirror it back from hi.
+                self.cursor = hi - (lo - self.cursor).rem_euclid(span);
+                wrapped = true;
+            }
+            (prev - lo, self.cursor - lo, wrapped)
+        };
 
-        self.maybe_swap_pending(prev, lo, span, wrapped);
+        self.maybe_swap_pending(prev_v, cur_v, span, wrapped);
     }
 
     /// If a queued buffer is waiting and this sample crossed a bar-grid boundary
     /// (or wrapped the loop), swap it in and restart the phrase from the loop
     /// start — the sample-accurate, click-free downbeat swap. Gated by an atomic
     /// flag so the nothing-queued path never locks.
-    fn maybe_swap_pending(&mut self, prev: f64, lo: f64, span: f64, wrapped: bool) {
+    fn maybe_swap_pending(&mut self, prev_v: f64, cur_v: f64, span: f64, wrapped: bool) {
         if !self.has_pending.load(Ordering::Acquire) {
             return;
         }
         let grid = self.pending_divisions.load(Ordering::Relaxed).max(1) as f64;
-        let prev_idx = (((prev - lo) / span) * grid).floor();
-        let new_idx = (((self.cursor - lo) / span) * grid).floor();
+        let prev_idx = ((prev_v / span) * grid).floor();
+        let new_idx = ((cur_v / span) * grid).floor();
         if !(wrapped || new_idx != prev_idx) {
             return;
         }
@@ -222,7 +331,7 @@ impl LoopChannel {
         // boundary; a missed lock just defers the swap to the next boundary.
         if let Ok(mut pending) = self.pending.try_lock() {
             if let Some(buffer) = pending.take() {
-                let (new_lo, _) = self.loop_bounds(buffer.len() as f64);
+                let new_lo = self.window(buffer.len() as f64).lo;
                 self.buffer = Some(buffer);
                 self.cursor = new_lo;
                 // The buffer/cursor moved externally; drop any WSOLA stretcher so
@@ -255,11 +364,21 @@ impl LoopChannel {
         }
     }
 
-    /// Resolve the normalized loop window to `[lo, hi)` frame positions.
-    fn loop_bounds(&self, len: f64) -> (f64, f64) {
-        let a = (self.loop_start as f64 * len).clamp(0.0, len);
-        let b = (self.loop_end as f64 * len).clamp(0.0, len);
-        (a.min(b), a.max(b))
+    /// Resolve the normalized loop markers to a physical [`LoopWindow`]. When
+    /// `loop_end < loop_start` the window wraps the buffer end into the union
+    /// region `[lo, len) ∪ [0, hi)`.
+    fn window(&self, len: f64) -> LoopWindow {
+        let lo = (self.loop_start as f64 * len).clamp(0.0, len);
+        let hi = (self.loop_end as f64 * len).clamp(0.0, len);
+        let wraps = hi < lo;
+        let span = if wraps { len - lo + hi } else { hi - lo };
+        LoopWindow {
+            lo,
+            hi,
+            span,
+            wraps,
+            len,
+        }
     }
 
     // --- Setters ----------------------------------------------------------
@@ -268,8 +387,7 @@ impl LoopChannel {
     pub fn set_buffer(&mut self, buffer: StereoSampleBuffer) {
         let len = buffer.len() as f64;
         self.buffer = Some(buffer);
-        let (lo, _) = self.loop_bounds(len);
-        self.cursor = lo;
+        self.cursor = self.window(len).lo;
         self.stretcher = None;
     }
 
@@ -339,24 +457,64 @@ impl LoopChannel {
 
     /// Restart playback from the loop start.
     pub fn restart(&mut self) {
-        if let Some(buffer) = &self.buffer {
-            let (lo, _) = self.loop_bounds(buffer.len() as f64);
-            self.cursor = lo;
+        let Some(buffer) = &self.buffer else {
+            return;
+        };
+        let len = buffer.len() as f64;
+        self.cursor = self.window(len).lo;
+        self.stretcher = None;
+    }
+
+    /// Set the playhead to a normalized [0, 1] position of the full buffer,
+    /// folded into the active loop window. Inverse of `position_normalized()`.
+    /// On a wrapped window a position that lands in the gap snaps to the nearer
+    /// edge. No-op if no buffer is loaded.
+    pub fn set_position(&mut self, normalized: f32) {
+        let Some(buffer) = &self.buffer else {
+            return;
+        };
+        let len = buffer.len() as f64;
+        let window = self.window(len);
+        let target = normalized.clamp(0.0, 1.0) as f64 * len;
+        self.cursor = window.fold(target);
+        self.stretcher = None;
+    }
+
+    /// Live-resize the loop window without a click or phrase restart. Sets the
+    /// normalized markers, then folds the cursor into the new window: if the
+    /// cursor is still inside the playable region it is kept and the WSOLA
+    /// stretcher is preserved (continuous scrubbing); if it fell into the gap
+    /// it snaps to the nearer edge and the stretcher resets (its ~20 ms
+    /// fade-in keeps the jump click-free). Works with transport stopped too.
+    pub fn set_loop_window(&mut self, start: f32, end: f32) {
+        self.loop_start = start.clamp(0.0, 1.0);
+        self.loop_end = end.clamp(0.0, 1.0);
+        let Some(buffer) = &self.buffer else {
+            return;
+        };
+        let len = buffer.len() as f64;
+        let window = self.window(len);
+        let folded = window.fold(self.cursor);
+        if folded != self.cursor {
+            self.cursor = folded;
             self.stretcher = None;
         }
     }
 
-    /// Set the playhead to a normalized [0, 1] position of the full buffer,
-    /// clamped into the active loop window. Inverse of `position_normalized()`.
-    /// No-op if no buffer is loaded.
-    pub fn set_position(&mut self, normalized: f32) {
-        if let Some(buffer) = &self.buffer {
-            let len = buffer.len() as f64;
-            let (lo, hi) = self.loop_bounds(len);
-            let target = normalized.clamp(0.0, 1.0) as f64 * len;
-            self.cursor = target.clamp(lo, hi);
-            self.stretcher = None;
-        }
+    /// Set the playhead to a musical phrase phase in `[0, 1)` of the loop
+    /// *window* (phase 0 is the loop start), mapping through virtual/window
+    /// coordinates so it lands correctly inside a wrapped region. Unlike
+    /// [`Self::set_position`] (full-buffer coords), this is how the transport
+    /// realigns an active clip's phase. No-op if no buffer is loaded.
+    pub fn set_window_phase(&mut self, phase: f32) {
+        let Some(buffer) = &self.buffer else {
+            return;
+        };
+        let len = buffer.len() as f64;
+        let window = self.window(len);
+        let v = (phase as f64).rem_euclid(1.0) * window.span;
+        self.cursor = window.to_physical(v);
+        self.stretcher = None;
     }
 
     /// Stage a buffer to atomically replace `buffer` at the next bar-grid
@@ -605,5 +763,152 @@ mod tests {
         // Now audible from C (~2000), never B (~-1000).
         let f = ch.tick(SR);
         assert!(f.l > 1500.0, "expected C after swap, got {}", f.l);
+    }
+
+    fn sine_buffer(frames: usize) -> StereoSampleBuffer {
+        let left: Vec<f32> = (0..frames)
+            .map(|i| (i as f32 / frames as f32 * std::f32::consts::TAU).sin())
+            .collect();
+        let right = left.clone();
+        StereoSampleBuffer::from_channels(left, right, SR).unwrap()
+    }
+
+    #[test]
+    fn wrapped_window_plays_union() {
+        // start 0.75 / end 0.25 on 8 frames -> plays [6..8) ∪ [0..2). Markers
+        // are exact in f32 so the wrapped positions land on integer frames.
+        let mut ch = LoopChannel::new(SR);
+        ch.set_loop_start(0.75);
+        ch.set_loop_end(0.25);
+        ch.set_buffer(ramp_buffer(8));
+        ch.set_playing(true);
+        let expected = [6.0, 7.0, 0.0, 1.0];
+        for i in 0..16 {
+            let f = ch.tick(SR);
+            assert_eq!(f.l, expected[i % expected.len()], "tick {i}");
+        }
+    }
+
+    #[test]
+    fn non_wrapped_interior_window_exact_sequence_regression() {
+        // Byte-identical guard: the non-wrap playback path must be unchanged.
+        // 0.25/0.5 on 8 frames are exact in f32 -> window [2, 4), reads [2, 3].
+        let mut ch = LoopChannel::new(SR);
+        ch.set_loop_start(0.25);
+        ch.set_loop_end(0.5);
+        ch.set_buffer(ramp_buffer(8));
+        ch.set_playing(true);
+        let expected = [2.0, 3.0];
+        for i in 0..16 {
+            let f = ch.tick(SR);
+            assert_eq!(f.l, expected[i % expected.len()], "tick {i}");
+        }
+    }
+
+    #[test]
+    fn wrapped_window_reverse_stays_in_union() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_loop_start(0.7);
+        ch.set_loop_end(0.3);
+        ch.set_buffer(ramp_buffer(10));
+        ch.set_speed(-1.0);
+        ch.set_playing(true);
+        for _ in 0..200 {
+            ch.tick(SR);
+            let p = ch.position_normalized();
+            assert!(
+                !(0.3 + 1e-3..=0.7 - 1e-3).contains(&p),
+                "pos {p} left the wrapped union"
+            );
+        }
+    }
+
+    #[test]
+    fn set_position_folds_into_wrapped_window() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_loop_start(0.7);
+        ch.set_loop_end(0.3);
+        ch.set_buffer(ramp_buffer(10));
+        // Inside the union -> kept.
+        ch.set_position(0.1);
+        assert!((ch.position_normalized() - 0.1).abs() < 1e-6);
+        ch.set_position(0.9);
+        assert!((ch.position_normalized() - 0.9).abs() < 1e-6);
+        // In the gap [0.3, 0.7): snaps to the nearer edge.
+        ch.set_position(0.45); // nearer hi = 0.3
+        assert!((ch.position_normalized() - 0.3).abs() < 1e-6);
+        ch.set_position(0.55); // nearer lo = 0.7
+        assert!((ch.position_normalized() - 0.7).abs() < 1e-6);
+    }
+
+    #[test]
+    fn set_window_phase_maps_across_seam() {
+        // Exact f32 markers: window [6, 8) ∪ [0, 2) on 8 frames, span 4.
+        let mut ch = LoopChannel::new(SR);
+        ch.set_loop_start(0.75);
+        ch.set_loop_end(0.25);
+        ch.set_buffer(ramp_buffer(8));
+        ch.set_window_phase(0.0); // loop start -> frame 6 (0.75)
+        assert!((ch.position_normalized() - 0.75).abs() < 1e-6);
+        // Half the 4-frame span crosses the buffer seam to frame 0.
+        ch.set_window_phase(0.5);
+        assert!((ch.position_normalized() - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn degenerate_wrapped_window_is_clamped() {
+        // A wrap window whose raw span < 1 frame must stay finite and not hang.
+        let mut ch = LoopChannel::new(SR);
+        ch.set_loop_start(0.9);
+        ch.set_loop_end(0.1);
+        ch.set_buffer(ramp_buffer(4)); // lo=3.6, hi=0.4, span=0.8 -> clamped to 1.0
+        ch.set_playing(true);
+        for _ in 0..200 {
+            let f = ch.tick(SR);
+            assert!(f.l.is_finite() && f.r.is_finite());
+            assert!(ch.position_normalized().is_finite());
+        }
+    }
+
+    #[test]
+    fn queued_swap_lands_in_wrapped_window() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_loop_start(0.7);
+        ch.set_loop_end(0.3);
+        ch.set_buffer(ramp_buffer(10)); // span = 6 virtual frames
+        ch.set_playing(true);
+        ch.queue_swap(const_buffer(10, 1000.0), 1); // whole-phrase swap at the wrap
+        for _ in 0..5 {
+            ch.tick(SR);
+        }
+        assert_eq!(ch.swaps_completed(), 0);
+        // Cross the wrap -> swap lands.
+        for _ in 0..4 {
+            ch.tick(SR);
+        }
+        assert_eq!(ch.swaps_completed(), 1);
+        // New buffer plays from its loop start (const 1000).
+        let f = ch.tick(SR);
+        assert!(f.l > 500.0, "expected swapped buffer, got {}", f.l);
+    }
+
+    #[test]
+    fn preserve_pitch_wrapped_window_is_finite_and_bounded() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_loop_start(0.7);
+        ch.set_loop_end(0.3);
+        ch.set_buffer(sine_buffer(4000));
+        ch.set_pitch_mode(PitchMode::PreservePitch);
+        ch.set_playing(true);
+        for _ in 0..8000 {
+            let f = ch.tick(SR);
+            assert!(f.l.is_finite() && f.r.is_finite());
+            assert!(f.l.abs() < 4.0, "output blew up: {}", f.l);
+            let p = ch.position_normalized();
+            assert!(
+                !(0.3 + 0.05..=0.7 - 0.05).contains(&p),
+                "pos {p} left the wrapped union"
+            );
+        }
     }
 }

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -16,9 +16,9 @@ pub mod stereo_buffer;
 mod wsola;
 
 pub use clip_grid::{
-    ClipGrid, LaunchQuantization, CLIP_COLUMN_COUNT, CLIP_QUANTIZE_BAR, CLIP_QUANTIZE_QUARTER,
-    CLIP_QUANTIZE_SIXTEENTH, CLIP_ROW_COUNT, CLIP_STATE_LOADED, CLIP_STATE_PLAYING,
-    CLIP_STATE_QUEUED,
+    ClipGrid, LaunchQuantization, RetrimTiming, CLIP_COLUMN_COUNT, CLIP_QUANTIZE_BAR,
+    CLIP_QUANTIZE_IMMEDIATE, CLIP_QUANTIZE_QUARTER, CLIP_QUANTIZE_SIXTEENTH, CLIP_ROW_COUNT,
+    CLIP_STATE_LOADED, CLIP_STATE_PLAYING, CLIP_STATE_QUEUED,
 };
 pub use effect_chain::{ChannelEffect, EffectChain};
 pub use graph::MixerGraph;
@@ -318,6 +318,30 @@ impl Mixer {
 
     pub fn clip_scheduled_beat(&self, column: usize) -> Option<f64> {
         self.clip_grid.scheduled_beat(column)
+    }
+
+    /// Set a slot's loop trim. Unlike the legacy `set_loop_start/end` (which
+    /// evict the column from grid control via `detach_column`), this keeps the
+    /// slot owned by the grid — the trim is a per-slot property the grid
+    /// applies itself.
+    pub fn clip_set_trim(
+        &mut self,
+        column: usize,
+        row: usize,
+        start: f64,
+        end: f64,
+        timing: RetrimTiming,
+    ) -> bool {
+        self.clip_grid
+            .set_trim(column, row, start, end, timing, &mut self.channels)
+    }
+
+    pub fn clip_trim_start(&self, column: usize, row: usize) -> Option<f64> {
+        self.clip_grid.trim_start(column, row)
+    }
+
+    pub fn clip_trim_end(&self, column: usize, row: usize) -> Option<f64> {
+        self.clip_grid.trim_end(column, row)
     }
 
     pub fn transport_start(&mut self) {

--- a/src/mixer/stereo_buffer.rs
+++ b/src/mixer/stereo_buffer.rs
@@ -185,6 +185,12 @@ impl StereoSampleBuffer {
         channel[index.clamp(0, last) as usize]
     }
 
+    #[inline]
+    fn channel_wrapped(channel: &[f32], index: isize) -> f32 {
+        let len = channel.len() as isize;
+        channel[index.rem_euclid(len) as usize]
+    }
+
     /// Read a stereo frame at a fractional frame position using cubic
     /// interpolation. The position is clamped into the valid range; callers
     /// that loop are responsible for wrapping `position` before calling.
@@ -207,6 +213,42 @@ impl StereoSampleBuffer {
             let p1 = Self::channel_clamped(channel, index);
             let p2 = Self::channel_clamped(channel, index + 1);
             let p3 = Self::channel_clamped(channel, index + 2);
+            cubic_interpolate(p0, p1, p2, p3, frac)
+        };
+
+        StereoFrame {
+            l: read(&self.left),
+            r: read(&self.right),
+        }
+    }
+
+    /// Read a stereo frame like [`Self::read_interpolated`], but with the cubic
+    /// interpolation taps wrapping around the buffer ends
+    /// (`index.rem_euclid(len)`) instead of clamping. Used by
+    /// [`crate::mixer::loop_channel::LoopChannel`] only when the active loop
+    /// window wraps the buffer end, so the seam between the last and first
+    /// frames stays continuous.
+    #[inline]
+    pub fn read_wrapped(&self, position: f64) -> StereoFrame {
+        if self.left.len() == 1 {
+            return StereoFrame {
+                l: self.left[0],
+                r: self.right[0],
+            };
+        }
+
+        let len = self.left.len() as f64;
+        // Fold the read position into [0, len) so the integer index and each of
+        // its cubic neighbors resolve to a valid mod-len tap.
+        let position = position.rem_euclid(len);
+        let index = position.floor() as isize;
+        let frac = (position - index as f64) as f32;
+
+        let read = |channel: &[f32]| {
+            let p0 = Self::channel_wrapped(channel, index - 1);
+            let p1 = Self::channel_wrapped(channel, index);
+            let p2 = Self::channel_wrapped(channel, index + 1);
+            let p3 = Self::channel_wrapped(channel, index + 2);
             cubic_interpolate(p0, p1, p2, p3, frac)
         };
 

--- a/src/mixer/wsola.rs
+++ b/src/mixer/wsola.rs
@@ -22,6 +22,7 @@
 //! to call from `LoopChannel::tick()`.
 
 use crate::frame::StereoFrame;
+use crate::mixer::loop_channel::LoopWindow;
 use crate::mixer::stereo_buffer::StereoSampleBuffer;
 use crate::utils::raised_sine_window;
 
@@ -127,6 +128,24 @@ impl WsolaStretcher {
     pub(crate) fn synthesize_next_hop(
         &mut self,
         buffer: &StereoSampleBuffer,
+        window: &LoopWindow,
+        sr_ratio: f64,
+        speed: f64,
+        warp: f64,
+    ) -> f64 {
+        if window.wraps {
+            self.synthesize_next_hop_wrapped(buffer, window, sr_ratio, speed, warp)
+        } else {
+            self.synthesize_next_hop_linear(buffer, window.lo, window.hi, sr_ratio, speed, warp)
+        }
+    }
+
+    /// Non-wrap hop synthesis: physical-frame math, byte-identical to the
+    /// pre-wrap engine. See [`Self::synthesize_next_hop`] for the parameter
+    /// meanings (`loop_lo`/`loop_hi` are `window.lo`/`window.hi`).
+    fn synthesize_next_hop_linear(
+        &mut self,
+        buffer: &StereoSampleBuffer,
         loop_lo: f64,
         loop_hi: f64,
         sr_ratio: f64,
@@ -204,6 +223,158 @@ impl WsolaStretcher {
         self.drain_idx = 0;
         self.analysis_cursor = best_start;
         best_start
+    }
+
+    /// Wrap-window hop synthesis. Works entirely in the window's *virtual*
+    /// coordinates `[0, span)`: the analysis cursor is converted from physical
+    /// on entry, all bounds/search run in virtual space, and each source read
+    /// translates back with `window.to_physical` + [`StereoSampleBuffer::read_wrapped`]
+    /// so a grain that straddles the buffer seam (`len → 0`) stays continuous.
+    /// The *loop* seam (`span → 0`) keeps the linear path's behavior: a fresh,
+    /// non-crossfaded grain restart. The stored/returned cursor is physical.
+    fn synthesize_next_hop_wrapped(
+        &mut self,
+        buffer: &StereoSampleBuffer,
+        window: &LoopWindow,
+        sr_ratio: f64,
+        speed: f64,
+        warp: f64,
+    ) -> f64 {
+        let span = window.span;
+        let step = (sr_ratio * speed.max(0.0)).max(1e-6);
+        let hop_source_span = self.hop_len as f64 * step;
+        let grain_source_span = (self.window_len as f64 - 1.0) * step + 1.0;
+        // Latest virtual start that still fits a whole grain before the loop end.
+        let max_start = (span - grain_source_span).max(0.0);
+
+        let cursor_v = window.to_virtual(self.analysis_cursor);
+        let raw_target = cursor_v + hop_source_span * warp.max(0.0);
+        let (search_center, wrapped) = if raw_target > max_start || max_start <= 0.0 {
+            (0.0, true)
+        } else {
+            (raw_target.max(0.0), false)
+        };
+        if wrapped {
+            // Grain would read past the loop end (or the window is too small to
+            // fit one): restart from the loop start with a fresh grain rather
+            // than correlating across the seam (see linear path).
+            self.have_prev_tail = false;
+        }
+
+        let best_start = if self.have_prev_tail {
+            self.search_best_start_wrapped(buffer, window, search_center, step, max_start)
+        } else {
+            search_center
+        };
+
+        // Extract and window the new grain, reading each tap through the
+        // physical translation so the buffer seam wraps transparently.
+        for (i, slot) in self.grain_scratch.iter_mut().enumerate() {
+            let pos_v = (best_start + i as f64 * step).clamp(0.0, span);
+            let raw = buffer.read_wrapped(window.to_physical(pos_v));
+            let w = self.window[i];
+            *slot = StereoFrame {
+                l: raw.l * w,
+                r: raw.r * w,
+            };
+        }
+
+        // Overlap-add the new grain's first half against the carried tail
+        // (silence on a just-wrapped seam — a brief fade-in, not a hard onset).
+        for i in 0..self.hop_len {
+            let prev = if self.have_prev_tail {
+                self.prev_tail[i]
+            } else {
+                StereoFrame::default()
+            };
+            let new = self.grain_scratch[i];
+            self.out_scratch[i] = StereoFrame {
+                l: prev.l + new.l,
+                r: prev.r + new.r,
+            };
+        }
+
+        // Carry the new grain's second half forward as next hop's tail.
+        for i in 0..self.hop_len {
+            self.prev_tail[i] = self.grain_scratch[self.hop_len + i];
+            let f = self.prev_tail[i];
+            self.prev_tail_mono[i] = f.l + f.r;
+        }
+
+        self.have_prev_tail = true;
+        self.drain_idx = 0;
+        let phys_start = window.to_physical(best_start);
+        self.analysis_cursor = phys_start;
+        phys_start
+    }
+
+    /// Correlation search for [`Self::synthesize_next_hop_wrapped`], mirroring
+    /// [`Self::search_best_start`] but in the window's virtual coordinates and
+    /// reading candidates through `window.to_physical` + `read_wrapped`.
+    fn search_best_start_wrapped(
+        &self,
+        buffer: &StereoSampleBuffer,
+        window: &LoopWindow,
+        center: f64,
+        step: f64,
+        max_start: f64,
+    ) -> f64 {
+        let radius = ((SEARCH_MS as f64 / 1000.0) * buffer.sample_rate() as f64)
+            .round()
+            .max(1.0);
+        let lo_bound = (center - radius).max(0.0);
+        let hi_bound = (center + radius).min(max_start);
+        if hi_bound <= lo_bound {
+            return center.clamp(0.0, max_start);
+        }
+
+        let score_at = |start: f64| -> f32 {
+            let mut num = 0.0f32;
+            let mut ref_energy = 0.0f32;
+            let mut cand_energy = 0.0f32;
+            for (i, reference) in self.prev_tail_mono.iter().enumerate() {
+                let pos_v = (start + i as f64 * step).clamp(0.0, max_start + step);
+                let raw = buffer.read_wrapped(window.to_physical(pos_v));
+                let cand = raw.l + raw.r;
+                num += cand * reference;
+                ref_energy += reference * reference;
+                cand_energy += cand * cand;
+            }
+            if ref_energy <= f32::EPSILON || cand_energy <= f32::EPSILON {
+                0.0
+            } else {
+                num / (ref_energy.sqrt() * cand_energy.sqrt())
+            }
+        };
+
+        let span = hi_bound - lo_bound;
+        let coarse_stride = (span / COARSE_STEPS as f64).max(1.0);
+
+        let mut best = lo_bound;
+        let mut best_score = f32::MIN;
+        let mut c = lo_bound;
+        while c <= hi_bound {
+            let s = score_at(c);
+            if s > best_score {
+                best_score = s;
+                best = c;
+            }
+            c += coarse_stride;
+        }
+
+        let refine_lo = (best - coarse_stride).max(lo_bound);
+        let refine_hi = (best + coarse_stride).min(hi_bound);
+        let mut c = refine_lo;
+        while c <= refine_hi {
+            let s = score_at(c);
+            if s > best_score {
+                best_score = s;
+                best = c;
+            }
+            c += 1.0;
+        }
+
+        best
     }
 
     /// Coarse-to-fine normalized cross-correlation search for the source
@@ -285,6 +456,17 @@ mod tests {
 
     const SR: f32 = 48_000.0;
 
+    /// A full-buffer, non-wrapping loop window spanning `[0, len)`.
+    fn full_window(len: f64) -> LoopWindow {
+        LoopWindow {
+            lo: 0.0,
+            hi: len,
+            span: len,
+            wraps: false,
+            len,
+        }
+    }
+
     fn sine_buffer(seconds: f32, hz: f32, sample_rate: f32) -> StereoSampleBuffer {
         let frames = (sample_rate * seconds) as usize;
         let left: Vec<f32> = (0..frames)
@@ -315,9 +497,9 @@ mod tests {
     fn synthesize_produces_finite_output() {
         let buffer = sine_buffer(2.0, 220.0, SR);
         let mut s = WsolaStretcher::new(SR, 0.0);
-        let loop_hi = buffer.len() as f64;
+        let window = full_window(buffer.len() as f64);
         for _ in 0..50 {
-            s.synthesize_next_hop(&buffer, 0.0, loop_hi, 1.0, 1.0, 1.0);
+            s.synthesize_next_hop(&buffer, &window, 1.0, 1.0, 1.0);
             for frame in &s.out_scratch {
                 assert!(frame.l.is_finite() && frame.r.is_finite());
             }
@@ -327,13 +509,13 @@ mod tests {
     #[test]
     fn warp_ratio_advances_analysis_cursor_faster() {
         let buffer = sine_buffer(4.0, 220.0, SR);
-        let loop_hi = buffer.len() as f64;
+        let window = full_window(buffer.len() as f64);
 
         let mut slow = WsolaStretcher::new(SR, 0.0);
         let mut fast = WsolaStretcher::new(SR, 0.0);
         for _ in 0..20 {
-            slow.synthesize_next_hop(&buffer, 0.0, loop_hi, 1.0, 1.0, 1.0);
-            fast.synthesize_next_hop(&buffer, 0.0, loop_hi, 1.0, 1.0, 2.0);
+            slow.synthesize_next_hop(&buffer, &window, 1.0, 1.0, 1.0);
+            fast.synthesize_next_hop(&buffer, &window, 1.0, 1.0, 2.0);
         }
         assert!(
             fast.analysis_cursor > slow.analysis_cursor,

--- a/tests/clip_grid.rs
+++ b/tests/clip_grid.rs
@@ -389,6 +389,199 @@ fn different_source_tempos_hold_the_same_musical_phase() {
 }
 
 #[test]
+fn trim_validation_and_round_trip() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        let _samples = load(engine, 0, 0, 0.5, 1000, 60.0);
+
+        // Fresh slot defaults to the full [0, 1) buffer.
+        assert_eq!(gooey_engine_clip_get_trim_start(engine, 0, 0), 0.0);
+        assert_eq!(gooey_engine_clip_get_trim_end(engine, 0, 0), 1.0);
+
+        // Store and read back.
+        assert!(gooey_engine_clip_set_trim(
+            engine,
+            0,
+            0,
+            0.2,
+            0.8,
+            CLIP_QUANTIZE_IMMEDIATE
+        ));
+        assert_eq!(gooey_engine_clip_get_trim_start(engine, 0, 0), 0.2);
+        assert_eq!(gooey_engine_clip_get_trim_end(engine, 0, 0), 0.8);
+
+        // Rejections: out-of-range slot, start == end, out of [0,1], non-finite,
+        // unknown quantization.
+        assert!(!gooey_engine_clip_set_trim(
+            engine,
+            CLIP_COLUMN_COUNT,
+            0,
+            0.2,
+            0.8,
+            0
+        ));
+        assert!(!gooey_engine_clip_set_trim(engine, 0, 0, 0.5, 0.5, 0));
+        assert!(!gooey_engine_clip_set_trim(engine, 0, 0, -0.1, 0.8, 0));
+        assert!(!gooey_engine_clip_set_trim(engine, 0, 0, 0.2, f64::NAN, 0));
+        assert!(!gooey_engine_clip_set_trim(engine, 0, 0, 0.2, 0.8, 99));
+
+        // Empty slot -> -1.0 sentinel.
+        assert_eq!(gooey_engine_clip_get_trim_start(engine, 0, 1), -1.0);
+        assert_eq!(gooey_engine_clip_get_trim_end(engine, 0, 1), -1.0);
+
+        // Reloading a slot resets its trim to the full buffer.
+        let _reload = load(engine, 0, 0, 0.5, 1000, 60.0);
+        assert_eq!(gooey_engine_clip_get_trim_start(engine, 0, 0), 0.0);
+        assert_eq!(gooey_engine_clip_get_trim_end(engine, 0, 0), 1.0);
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn quantized_retrim_lands_on_boundary_without_detaching() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let _samples = load(engine, 0, 0, 0.5, 8000, 60.0); // 8 beats
+        gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.0);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 100); // beat 0.1; playhead early in the full loop
+
+        // Retrim to a window that does not contain the current playhead, on the
+        // next sixteenth (0.25 beat).
+        assert!(gooey_engine_clip_set_trim(
+            engine,
+            0,
+            0,
+            0.8,
+            0.95,
+            CLIP_QUANTIZE_SIXTEENTH
+        ));
+        let target = gooey_engine_clip_get_scheduled_beat(engine, 0);
+        assert_eq!(
+            target, -1.0,
+            "a retrim must not occupy the launch queue slot"
+        );
+
+        // Up to one frame before the boundary: still in the old (full) window.
+        let frames_to_boundary = ((0.25 - 0.1) * SR as f64) as usize;
+        let _ = render(engine, frames_to_boundary - 1);
+        assert!(gooey_engine_loop_get_position(engine, 0) < 0.8);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
+
+        // Cross the boundary: the playhead snaps into the new window and the
+        // column is still owned by the grid (active row unchanged -> no detach).
+        let _ = render(engine, 2);
+        assert!(gooey_engine_loop_get_position(engine, 0) >= 0.8);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
+        assert_eq!(
+            gooey_engine_clip_get_state(engine, 0, 0),
+            CLIP_STATE_LOADED | CLIP_STATE_PLAYING
+        );
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn immediate_retrim_applies_playing_and_stopped() {
+    unsafe {
+        // Playing: the retrim lands within the same call.
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let _samples = load(engine, 0, 0, 0.5, 8000, 60.0);
+        gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.0);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 200); // playhead early in the full loop (< 0.8)
+        assert!(gooey_engine_loop_get_position(engine, 0) < 0.8);
+        assert!(gooey_engine_clip_set_trim(
+            engine,
+            0,
+            0,
+            0.8,
+            0.95,
+            CLIP_QUANTIZE_IMMEDIATE
+        ));
+        assert!(gooey_engine_loop_get_position(engine, 0) >= 0.8);
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
+        gooey_engine_free(engine);
+
+        // Transport stopped but a clip is frozen active: immediate still applies.
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let _samples = load(engine, 0, 0, 0.5, 8000, 60.0);
+        gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.0);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 200);
+        gooey_engine_sequencer_stop(engine); // freeze; column stays active
+        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
+        let before = gooey_engine_loop_get_position(engine, 0);
+        assert!(before < 0.8);
+        assert!(gooey_engine_clip_set_trim(
+            engine,
+            0,
+            0,
+            0.8,
+            0.95,
+            CLIP_QUANTIZE_IMMEDIATE
+        ));
+        assert!(gooey_engine_loop_get_position(engine, 0) >= 0.8);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn wrapped_trim_plays_both_segments() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        // Two-valued buffer: first 200 frames = 0.3, last 200 = 0.9.
+        let mut samples = vec![0.3f32; 400];
+        for s in samples.iter_mut().skip(200) {
+            *s = 0.9;
+        }
+        assert!(gooey_engine_clip_load(
+            engine,
+            0,
+            0,
+            samples.as_ptr(),
+            400,
+            1,
+            SR,
+            60.0,
+        ));
+        // Wrap-around trim: [0.6, 1.0) ∪ [0.0, 0.4) spans the 0.9 tail and the
+        // 0.3 head, so both amplitudes must appear in the output.
+        assert!(gooey_engine_clip_set_trim(
+            engine,
+            0,
+            0,
+            0.6,
+            0.4,
+            CLIP_QUANTIZE_IMMEDIATE
+        ));
+        gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.0);
+        gooey_engine_sequencer_start(engine);
+
+        let out = render(engine, 2000);
+        // The mixer applies master gain, so compare amplitudes relative to the
+        // loudest sample. The 0.9 tail forms a cluster near the max; the 0.3
+        // head forms a distinct cluster at ~1/3 of it.
+        let max_abs = out.iter().fold(0.0f32, |m, &s| m.max(s.abs()));
+        assert!(max_abs > 0.0);
+        let saw_low = out
+            .iter()
+            .any(|&s| (0.15 * max_abs..0.6 * max_abs).contains(&s.abs()));
+        let saw_high = out.iter().any(|&s| s.abs() > 0.75 * max_abs);
+        assert!(saw_low, "0.3 segment never played");
+        assert!(saw_high, "0.9 segment never played");
+
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
 fn host_time_arm_starts_transport_and_due_clip_on_same_sample() {
     unsafe {
         let engine = gooey_engine_new(SR);


### PR DESCRIPTION
Makes loop trim a per-clip-slot property the grid applies itself, so `start`/`end` edits no longer route through `Mixer::set_loop_start/end` and evict the column from grid control. Introduces a wrap-around loop primitive (`LoopWindow`) that plays `[start, len) ∪ [0, end)` when `end < start`, with wrap-aware cubic (`StereoSampleBuffer::read_wrapped`) and WSOLA hop synthesis so the buffer seam stays continuous — the non-wrap paths keep their original float expressions byte-identically. Trim edits to the active clip land either immediately (live marker scrubbing) or scheduled on the transport grid via a separate `pending_retrim` slot that coexists with a queued launch. Exposes `gooey_engine_clip_set_trim` plus `_get_trim_start`/`_get_trim_end` and a `CLIP_QUANTIZE_IMMEDIATE` constant; the legacy `gooey_engine_loop_set_start/end` now wraps instead of silently swapping markers when `end < start` (documented). Adds 16 tests (loop_channel wrap + non-wrap regression guard, clip_grid retrim scheduling, and FFI integration); full lib + integration suites pass with clippy/fmt clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)