### PR TITLE
Fix clip and sampler bar scheduling

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1136,6 +1136,16 @@ impl GooeyEngine {
                 arm_fires_at = None;
             }
 
+            // A rack start is owned by the render clock, not by the host UI
+            // timer. Applying it before sequencer ticks makes step zero fire on
+            // the same sample as a clip launch at this shared bar boundary.
+            if self.mixer.transport_running() {
+                let beat = self.mixer.transport_beat();
+                for rack in self.samplers.iter_mut().flatten() {
+                    rack.activate_start_if_due(beat);
+                }
+            }
+
             // Tick ALL sequencers first to ensure sample-accurate synchronization
             let mut seq_triggers: [Option<(f32, Option<SequencerBlendSetting>, Option<u8>)>;
                 NUM_INSTRUMENTS] = [None; NUM_INSTRUMENTS];
@@ -3334,6 +3344,9 @@ pub unsafe extern "C" fn gooey_engine_set_bpm(engine: *mut GooeyEngine, bpm: f32
     for seq in engine.sequencers_iter_mut() {
         seq.set_bpm(bpm);
     }
+    for rack in engine.samplers.iter_mut().flatten() {
+        rack.sequencer_mut().set_bpm(bpm);
+    }
 
     // Update delay BPM for clocked timing
     engine.delay.set_bpm(bpm);
@@ -3521,6 +3534,9 @@ pub unsafe extern "C" fn gooey_engine_sequencer_stop(engine: *mut GooeyEngine) {
     for seq in engine.sequencers_iter_mut() {
         seq.stop();
     }
+    for rack in engine.samplers.iter_mut().flatten() {
+        rack.transport_stop();
+    }
     engine.mixer.transport_stop();
 }
 
@@ -3540,6 +3556,9 @@ pub unsafe extern "C" fn gooey_engine_sequencer_reset(engine: *mut GooeyEngine) 
     engine.pending_arm_host_time = None;
     for seq in engine.sequencers_iter_mut() {
         seq.reset();
+    }
+    for rack in engine.samplers.iter_mut().flatten() {
+        rack.transport_reset();
     }
     engine.mixer.transport_reset();
 }
@@ -6166,6 +6185,82 @@ pub unsafe extern "C" fn gooey_engine_sampler_set_step(
         .is_some_and(|sampler| sampler.set_step(step as usize, enabled, slot as usize, velocity))
 }
 
+/// Queue a sampler pattern to start at the next selected shared-transport
+/// boundary. A stopped transport targets beat 0; a running transport always
+/// chooses the strictly future boundary, including when called exactly on one.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_sampler_start_pattern(
+    engine: *mut GooeyEngine,
+    rack: u32,
+    quantization: u32,
+) -> bool {
+    let Some(engine) = engine.as_mut() else { return false; };
+    let Some(quantization) = LaunchQuantization::from_id(quantization) else {
+        return false;
+    };
+    let target = engine.mixer.quantized_target(quantization);
+    engine
+        .samplers
+        .get_mut(rack as usize)
+        .and_then(Option::as_mut)
+        .is_some_and(|rack| rack.schedule_start(target))
+}
+
+/// Stop a sampler pattern immediately and cancel a queued pattern start.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_sampler_stop_pattern(
+    engine: *mut GooeyEngine,
+    rack: u32,
+) -> bool {
+    engine
+        .as_mut()
+        .and_then(|engine| engine.samplers.get_mut(rack as usize))
+        .and_then(Option::as_mut)
+        .map(|rack| { rack.stop_pattern(); true })
+        .unwrap_or(false)
+}
+
+/// Cancel a queued sampler-pattern start without stopping an already running rack.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_sampler_cancel_pattern_start(
+    engine: *mut GooeyEngine,
+    rack: u32,
+) -> bool {
+    engine
+        .as_mut()
+        .and_then(|engine| engine.samplers.get_mut(rack as usize))
+        .and_then(Option::as_mut)
+        .map(|rack| { rack.cancel_pending_start(); true })
+        .unwrap_or(false)
+}
+
+/// Return a rack's pending start beat, or -1.0 when it is invalid or not queued.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_sampler_get_pending_start_beat(
+    engine: *const GooeyEngine,
+    rack: u32,
+) -> f64 {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.samplers.get(rack as usize))
+        .and_then(Option::as_ref)
+        .and_then(SamplerRack::pending_start_beat)
+        .unwrap_or(-1.0)
+}
+
+/// Return whether a rack's pattern is currently running.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_sampler_is_pattern_running(
+    engine: *const GooeyEngine,
+    rack: u32,
+) -> bool {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.samplers.get(rack as usize))
+        .and_then(Option::as_ref)
+        .is_some_and(SamplerRack::pattern_running)
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn gooey_engine_sampler_get_step(
     engine: *const GooeyEngine,
@@ -6934,6 +7029,20 @@ pub unsafe extern "C" fn gooey_engine_clip_get_scheduled_beat(
     engine
         .as_ref()
         .and_then(|engine| engine.mixer.clip_scheduled_beat(column as usize))
+        .unwrap_or(-1.0)
+}
+
+/// Return the active clip's actual normalized source-buffer cursor, or -1.0
+/// when the column is inactive. Unlike a beat-derived estimate this reports the
+/// real loop-channel position, including trimmed and wrapped windows.
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_clip_get_active_playhead(
+    engine: *const GooeyEngine,
+    column: u32,
+) -> f64 {
+    engine
+        .as_ref()
+        .and_then(|engine| engine.mixer.clip_active_playhead(column as usize))
         .unwrap_or(-1.0)
 }
 

--- a/src/instruments/sampler.rs
+++ b/src/instruments/sampler.rs
@@ -148,6 +148,11 @@ pub struct SamplerRack {
     voices: [SampleVoice; SAMPLER_VOICE_COUNT],
     next_age: u64,
     sequencer: Sequencer,
+    /// Pattern dispatch is opt-in. A registered rack must remain silent until
+    /// the host explicitly starts it on the shared transport.
+    pattern_running: bool,
+    /// Absolute shared-transport beat at which a requested start lands.
+    pending_start_beat: Option<f64>,
 }
 
 impl SamplerRack {
@@ -163,6 +168,8 @@ impl SamplerRack {
                 vec![false; SAMPLER_SLOT_COUNT],
                 name,
             ),
+            pattern_running: false,
+            pending_start_beat: None,
         }
     }
 
@@ -236,6 +243,9 @@ impl SamplerRack {
     }
 
     pub fn tick_sequencer(&mut self) -> Option<(usize, f32)> {
+        if !self.pattern_running {
+            return None;
+        }
         self.sequencer
             .tick_with_settings()
             .map(|trigger| (trigger.note.unwrap_or(0) as usize, trigger.velocity))
@@ -245,6 +255,67 @@ impl SamplerRack {
     }
     pub fn sequencer(&self) -> &Sequencer {
         &self.sequencer
+    }
+
+    pub fn schedule_start(&mut self, beat: f64) -> bool {
+        if !beat.is_finite() || beat < 0.0 {
+            return false;
+        }
+        self.pattern_running = false;
+        self.sequencer.stop();
+        self.pending_start_beat = Some(beat);
+        true
+    }
+
+    /// Called from the render thread before the sequencer is ticked.
+    pub fn activate_start_if_due(&mut self, transport_beat: f64) {
+        let Some(target) = self.pending_start_beat else { return };
+        if transport_beat + 1.0e-8 < target {
+            return;
+        }
+        self.pending_start_beat = None;
+        self.sequencer.set_beat_position(target);
+        self.sequencer.start();
+        self.pattern_running = true;
+    }
+
+    pub fn stop_pattern(&mut self) {
+        self.pending_start_beat = None;
+        self.pattern_running = false;
+        self.sequencer.stop();
+        self.stop_all();
+    }
+
+    pub fn cancel_pending_start(&mut self) {
+        self.pending_start_beat = None;
+    }
+
+    pub fn pending_start_beat(&self) -> Option<f64> {
+        self.pending_start_beat
+    }
+
+    pub fn pattern_running(&self) -> bool {
+        self.pattern_running
+    }
+
+    pub fn transport_stop(&mut self) {
+        self.pending_start_beat = None;
+        self.pattern_running = false;
+        self.sequencer.stop();
+        self.stop_all();
+    }
+
+    pub fn transport_reset(&mut self) {
+        self.pending_start_beat = None;
+        self.pattern_running = false;
+        self.sequencer.reset();
+        self.stop_all();
+    }
+
+    fn stop_all(&mut self) {
+        for voice in &mut self.voices {
+            voice.buffer = None;
+        }
     }
 
     fn stop_slot(&mut self, slot: usize) {

--- a/src/mixer/clip_grid.rs
+++ b/src/mixer/clip_grid.rs
@@ -168,16 +168,26 @@ impl ClipGrid {
         self.bpm.max(0.0) as f64 / (60.0 * self.sample_rate.max(1.0) as f64)
     }
 
-    fn quantized_target(&self, quantization: LaunchQuantization) -> f64 {
+    /// Return the sole scheduling target used by clip-grid actions. A stopped
+    /// transport always accepts the responsive beat-zero launch; once running,
+    /// even a request made exactly on a boundary waits for the *next* boundary.
+    pub fn quantized_target(&self, quantization: LaunchQuantization) -> f64 {
+        if !self.transport_running {
+            return 0.0;
+        }
         let interval = quantization.beats();
         let scaled = self.transport_beat / interval;
+        // The render clock accumulates f64 sample increments, so an exact musical
+        // boundary can be represented as 0.9999999999999999. Treat that small
+        // numerical residue as aligned; "strictly future" then means one whole
+        // additional interval rather than accidentally scheduling the same bar.
         let nearest = scaled.round();
-        let aligned = (scaled - nearest).abs() <= 1.0e-9;
-        if !self.transport_running && aligned {
-            nearest * interval
+        let base = if (scaled - nearest).abs() <= 1.0e-9 {
+            nearest
         } else {
-            (scaled.floor() + 1.0) * interval
-        }
+            scaled.floor()
+        };
+        (base + 1.0) * interval
     }
 
     fn valid_exact_target(&self, beat: f64) -> bool {
@@ -376,6 +386,22 @@ impl ClipGrid {
 
     pub fn active_row(&self, column: usize) -> Option<usize> {
         self.columns.get(column).and_then(|state| state.active_row)
+    }
+
+    /// The actual source-buffer cursor of an active clip. This deliberately
+    /// reads the loop channel instead of deriving a phase from transport beat:
+    /// a launch at beat 4 and a cropped/wrapped window still begin at their
+    /// physical first audible frame.
+    pub fn active_playhead(
+        &self,
+        column: usize,
+        channels: &[LoopChannel],
+    ) -> Option<f64> {
+        self.active_row(column)?;
+        channels
+            .get(column)
+            .filter(|channel| channel.has_buffer())
+            .map(|channel| channel.position_normalized() as f64)
     }
 
     pub fn queued_row(&self, column: usize) -> Option<usize> {

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -308,6 +308,10 @@ impl Mixer {
         self.clip_grid.active_row(column)
     }
 
+    pub fn clip_active_playhead(&self, column: usize) -> Option<f64> {
+        self.clip_grid.active_playhead(column, &self.channels)
+    }
+
     pub fn clip_queued_row(&self, column: usize) -> Option<usize> {
         self.clip_grid.queued_row(column)
     }
@@ -318,6 +322,10 @@ impl Mixer {
 
     pub fn clip_scheduled_beat(&self, column: usize) -> Option<f64> {
         self.clip_grid.scheduled_beat(column)
+    }
+
+    pub fn quantized_target(&self, quantization: LaunchQuantization) -> f64 {
+        self.clip_grid.quantized_target(quantization)
     }
 
     /// Set a slot's loop trim. Unlike the legacy `set_loop_start/end` (which

--- a/tests/clip_grid.rs
+++ b/tests/clip_grid.rs
@@ -131,6 +131,49 @@ fn stopped_launch_starts_empty_column_on_first_transport_sample() {
 }
 
 #[test]
+fn running_bar_requests_are_strictly_future_even_on_a_bar_boundary() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let _samples = load(engine, 0, 0, 0.5, 8_000, 60.0);
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 4_000); // exactly beat 4
+        assert!((gooey_engine_transport_get_beat_position(engine) - 4.0).abs() < 1e-9);
+        assert!(gooey_engine_clip_launch(engine, 0, 0, CLIP_QUANTIZE_BAR));
+        assert_eq!(gooey_engine_clip_get_scheduled_beat(engine, 0), 8.0);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn active_playhead_reports_the_real_trimmed_source_cursor() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        assert_eq!(gooey_engine_clip_get_active_playhead(engine, 0), -1.0);
+        let _samples = load(engine, 0, 0, 0.5, 44_100, 60.0);
+        // A wrapped window begins at 75% of the full source buffer.
+        assert!(gooey_engine_clip_set_trim(
+            engine,
+            0,
+            0,
+            0.75,
+            0.25,
+            CLIP_QUANTIZE_IMMEDIATE
+        ));
+        assert!(gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.0));
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, 1);
+        let playhead = gooey_engine_clip_get_active_playhead(engine, 0);
+        assert!(
+            (0.75..0.752).contains(&playhead),
+            "expected trim-start cursor, got {playhead}"
+        );
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
 fn quantized_and_exact_launches_cross_render_boundaries() {
     unsafe fn assert_launch(quantization: u32, expected_beat: f64) {
         let engine = gooey_engine_new(SR);

--- a/tests/sampler_rack.rs
+++ b/tests/sampler_rack.rs
@@ -209,12 +209,62 @@ fn sampler_sequence_starts_when_host_time_arm_fires() {
             SR
         ));
         assert!(gooey_engine_sampler_set_step(engine, rack, 0, true, 0, 1.0));
+        assert!(gooey_engine_sampler_start_pattern(
+            engine,
+            rack,
+            CLIP_QUANTIZE_BAR
+        ));
         let host_now = 1_000u64;
         gooey_engine_set_render_host_time(engine, host_now, 1.0);
         gooey_engine_sequencer_start_at_host_time(engine, host_now + 100, 0.0);
         let output = render(engine, 256);
         assert!(output[..100 * 2].iter().all(|sample| *sample == 0.0));
         assert!(peak(&output[100 * 2..]) > 0.001);
+        gooey_engine_free(engine);
+    }
+}
+
+#[test]
+fn pattern_start_is_bar_quantized_and_never_seeks_the_clip_transport() {
+    unsafe {
+        let engine = gooey_engine_new(SR);
+        gooey_engine_set_bpm(engine, 60.0);
+        let rack = gooey_engine_sampler_register(engine) as u32;
+        let source = gooey_engine_sampler_get_source_id(engine, rack);
+        assert!(gooey_engine_mixer_route_source(engine, source, 3));
+        let pcm = vec![0.5_f32; 4096];
+        assert!(gooey_engine_sampler_set_slot_buffer(
+            engine, rack, 0, pcm.as_ptr(), pcm.len() as u32, 1, SR
+        ));
+        assert!(gooey_engine_sampler_set_step(engine, rack, 0, true, 0, 1.0));
+
+        gooey_engine_sequencer_start(engine);
+        let _ = render(engine, (SR / 10.0) as usize); // beat 0.1
+        assert!(gooey_engine_sampler_start_pattern(
+            engine, rack, CLIP_QUANTIZE_BAR
+        ));
+        assert_eq!(gooey_engine_sampler_get_pending_start_beat(engine, rack), 4.0);
+        assert!(!gooey_engine_sampler_is_pattern_running(engine, rack));
+
+        let _ = render(engine, ((4.0 - 0.1) * SR as f64) as usize);
+        assert!(!gooey_engine_sampler_is_pattern_running(engine, rack));
+        let before = gooey_engine_transport_get_beat_position(engine);
+        let _ = render(engine, 1);
+        assert!(gooey_engine_sampler_is_pattern_running(engine, rack));
+        assert!(
+            peak(&render(engine, 64)) > 0.001,
+            "step zero should fire on the boundary"
+        );
+        assert!(gooey_engine_transport_get_beat_position(engine) > before);
+
+        assert!(gooey_engine_sampler_stop_pattern(engine, rack));
+        assert!(!gooey_engine_sampler_is_pattern_running(engine, rack));
+        assert!(gooey_engine_sampler_start_pattern(
+            engine, rack, CLIP_QUANTIZE_BAR
+        ));
+        assert_eq!(gooey_engine_sampler_get_pending_start_beat(engine, rack), 8.0);
+        assert!(gooey_engine_sampler_cancel_pattern_start(engine, rack));
+        assert_eq!(gooey_engine_sampler_get_pending_start_beat(engine, rack), -1.0);
         gooey_engine_free(engine);
     }
 }


### PR DESCRIPTION
Make the engine clock the single scheduling authority for clip actions and sampler patterns.

Add render-thread, strictly-future quantized sampler starts with stop/cancel/pending-state APIs, plus actual active-clip playhead reporting.

The change preserves immediate beat-zero launches while stopped and adds boundary, rack, and trimmed-playhead coverage.

Validated with the full `cargo test` suite.