### PR TITLE
Add gooey_engine_loop_render_to_wav offline stem export

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -7978,3 +7978,71 @@ pub unsafe extern "C" fn gooey_engine_bounce_to_wav(
 
     writer.finalize().is_ok()
 }
+
+/// Render a single loop channel offline to a stereo WAV file.
+///
+/// Renders only `channel`, **after** its gain fader and effect chain but
+/// **ignoring mute/solo**, into a 44.1 kHz-agnostic (engine sample rate)
+/// stereo 32-bit float WAV. The channel's cursor and effect DSP are reset,
+/// `preroll_frame_count` frames are rendered and discarded to warm the effects
+/// (delay/reverb feedback), the loop cursor is then restarted while the warmed
+/// effect state is preserved, and exactly `frame_count` stereo frames are
+/// written with no appended tail — so a shorter selected loop region tiles
+/// seamlessly and the file ends on the bar-aligned boundary.
+///
+/// Returns `true` on success. Returns `false` for a null engine/path, an empty
+/// path, `frame_count == 0`, an out-of-range `channel`, a channel with no
+/// loaded buffer, or any file-write error.
+///
+/// This drives the channel directly and is **not** real-time safe: it must not
+/// run concurrently against the same engine's realtime render callback. Callers
+/// (e.g. Whirlpool) invoke it on a disposable offline engine.
+///
+/// # Safety
+/// - `engine` must be a valid pointer returned by `gooey_engine_new`.
+/// - `path` must be a valid null-terminated UTF-8 string.
+#[cfg(feature = "bounce")]
+#[no_mangle]
+pub unsafe extern "C" fn gooey_engine_loop_render_to_wav(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    frame_count: u32,
+    preroll_frame_count: u32,
+    path: *const std::os::raw::c_char,
+) -> bool {
+    if engine.is_null() || path.is_null() || frame_count == 0 {
+        return false;
+    }
+    let engine = &mut *engine;
+    let path_str = match std::ffi::CStr::from_ptr(path).to_str() {
+        Ok(s) if !s.is_empty() => s,
+        _ => return false,
+    };
+
+    let mut interleaved: Vec<f32> = Vec::new();
+    if !engine.mixer.render_channel_to_interleaved(
+        channel as usize,
+        frame_count as usize,
+        preroll_frame_count as usize,
+        &mut interleaved,
+    ) {
+        return false;
+    }
+
+    let spec = hound::WavSpec {
+        channels: 2,
+        sample_rate: engine.sample_rate as u32,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
+    let mut writer = match hound::WavWriter::create(path_str, spec) {
+        Ok(w) => w,
+        Err(_) => return false,
+    };
+    for &sample in &interleaved {
+        if writer.write_sample(sample).is_err() {
+            return false;
+        }
+    }
+    writer.finalize().is_ok()
+}

--- a/src/mixer/effect_chain.rs
+++ b/src/mixer/effect_chain.rs
@@ -333,6 +333,15 @@ impl EffectChain {
         self.effects.clear();
     }
 
+    /// Clear every effect's internal DSP state (delay lines, reverb tails,
+    /// filter memory) without removing the effects from the chain. Used to
+    /// start an offline render from a clean, un-warmed state.
+    pub fn reset(&self) {
+        for effect in &self.effects {
+            effect.reset();
+        }
+    }
+
     /// Set a parameter on the effect at `slot`.
     pub fn set_param(&self, slot: usize, param: u32, value: f32) {
         if let Some(effect) = self.effects.get(slot) {

--- a/src/mixer/loop_channel.rs
+++ b/src/mixer/loop_channel.rs
@@ -545,6 +545,21 @@ impl LoopChannel {
         self.active_gain.set_target(if audible { 1.0 } else { 0.0 });
     }
 
+    /// Prepare this channel for an offline single-channel render: force it
+    /// playing and fully audible (ignoring mute/solo), snap the gain and gate
+    /// smoothers to their targets so the capture has stable gain from the first
+    /// sample, clear any warmed effect DSP state, and reset the cursor to the
+    /// loop start. The caller then discards a preroll (to warm the effects) and
+    /// [`Self::restart`]s the cursor before capturing.
+    pub(crate) fn prepare_offline_render(&mut self) {
+        self.playing = true;
+        self.gain.snap();
+        self.active_gain.set_target(1.0);
+        self.active_gain.snap();
+        self.effects.reset();
+        self.restart();
+    }
+
     // --- Getters ----------------------------------------------------------
 
     pub fn has_buffer(&self) -> bool {

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -423,6 +423,57 @@ impl Mixer {
             .get(channel)
             .and_then(|ch| ch.effects().effect_type_at(slot))
     }
+
+    // --- Offline single-channel render ------------------------------------
+
+    /// Render a single loop channel offline into `out` as interleaved stereo
+    /// `f32` frames (`[l, r]` per frame), **post channel gain and effects but
+    /// ignoring mute/solo**. The channel's cursor and effect DSP state are
+    /// reset, `preroll` frames are rendered and discarded to warm the effects
+    /// (delay/reverb feedback), the loop cursor is then restarted while the
+    /// warmed effect state is preserved, and exactly `frames` stereo frames are
+    /// written with no appended tail. `out` is cleared first and, on success,
+    /// holds `frames * 2` values.
+    ///
+    /// Returns `false` (leaving `out` untouched) for an out-of-range channel or
+    /// a channel with no loaded buffer.
+    ///
+    /// Not real-time safe: this drives the channel directly and must not run
+    /// concurrently with [`Mixer::tick`] on the same mixer. It is intended for
+    /// a disposable offline engine, never the live realtime engine.
+    pub fn render_channel_to_interleaved(
+        &mut self,
+        channel: usize,
+        frames: usize,
+        preroll: usize,
+        out: &mut Vec<f32>,
+    ) -> bool {
+        let sample_rate = self.sample_rate;
+        let Some(ch) = self.channels.get_mut(channel) else {
+            return false;
+        };
+        if !ch.has_buffer() {
+            return false;
+        }
+
+        // Clean slate: cursor at the loop start, effect DSP cleared, gain snapped.
+        ch.prepare_offline_render();
+        // Warm the effects with one discarded preroll.
+        for _ in 0..preroll {
+            ch.tick(sample_rate);
+        }
+        // Restart the loop cursor at the top, keeping the warmed effect state.
+        ch.restart();
+
+        out.clear();
+        out.reserve(frames * 2);
+        for _ in 0..frames {
+            let frame = ch.tick(sample_rate);
+            out.push(frame.l);
+            out.push(frame.r);
+        }
+        true
+    }
 }
 
 #[cfg(test)]
@@ -490,5 +541,115 @@ mod tests {
         assert_eq!(mixer.effect_count(0), 1);
         assert_eq!(mixer.effect_count(1), 0);
         assert!(mixer.effect_add(99, EFFECT_DELAY).is_none());
+    }
+
+    /// A ramp loop whose left channel is the frame index, useful for detecting
+    /// loop-region periodicity in offline renders.
+    fn ramp_buffer(frames: usize) -> StereoSampleBuffer {
+        let left: Vec<f32> = (0..frames).map(|i| i as f32).collect();
+        let right = left.clone();
+        StereoSampleBuffer::from_channels(left, right, SR).unwrap()
+    }
+
+    #[test]
+    fn render_channel_writes_exact_frame_count() {
+        let mut mixer = Mixer::new(SR);
+        mixer.load(0, dc_buffer(0.5, 4096));
+        let mut out = Vec::new();
+        assert!(mixer.render_channel_to_interleaved(0, 1000, 512, &mut out));
+        assert_eq!(out.len(), 1000 * 2, "interleaved stereo, no tail");
+    }
+
+    #[test]
+    fn render_channel_rejects_bad_channel_or_empty() {
+        let mut mixer = Mixer::new(SR);
+        let mut out = vec![1.0, 2.0, 3.0];
+        // Out-of-range channel.
+        assert!(!mixer.render_channel_to_interleaved(99, 100, 0, &mut out));
+        // Channel with no buffer loaded.
+        assert!(!mixer.render_channel_to_interleaved(0, 100, 0, &mut out));
+        // Left untouched on failure.
+        assert_eq!(out, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn render_channel_repeats_selected_region() {
+        // Region = first quarter of a 400-frame buffer -> 100-frame period.
+        let mut mixer = Mixer::new(SR);
+        mixer.load(0, ramp_buffer(400));
+        mixer.set_loop_start(0, 0.0);
+        mixer.set_loop_end(0, 0.25);
+        let mut out = Vec::new();
+        assert!(mixer.render_channel_to_interleaved(0, 350, 0, &mut out));
+        // Source SR == engine SR and speed 1.0 -> sample-accurate integer steps,
+        // so the left channel tiles the region [0, 100) exactly.
+        for i in 0..350 {
+            let expected = (i % 100) as f32;
+            assert!(
+                (out[i * 2] - expected).abs() < 1e-3,
+                "frame {i}: got {}, want {expected}",
+                out[i * 2]
+            );
+        }
+    }
+
+    #[test]
+    fn render_channel_applies_gain() {
+        let mut mixer = Mixer::new(SR);
+        mixer.load(0, dc_buffer(0.5, 4096));
+        mixer.set_gain(0, 0.5);
+        let mut out = Vec::new();
+        assert!(mixer.render_channel_to_interleaved(0, 256, 128, &mut out));
+        // 0.5 buffer * 0.5 gain = 0.25, from the first sample (gain is snapped).
+        assert!(
+            (out[0] - 0.25).abs() < 1e-3,
+            "gain not baked in from sample 0: {}",
+            out[0]
+        );
+    }
+
+    #[test]
+    fn render_channel_ignores_mute_solo_and_other_channels() {
+        let mut mixer = Mixer::new(SR);
+        mixer.load(0, dc_buffer(0.5, 4096));
+        mixer.load(1, dc_buffer(-0.9, 4096));
+        // Hostile mute/solo state: target channel muted, a different one soloed.
+        mixer.set_muted(0, true);
+        mixer.set_soloed(1, true);
+        let mut out = Vec::new();
+        assert!(mixer.render_channel_to_interleaved(0, 256, 128, &mut out));
+        // Still renders channel 0 at full level, with no bleed from channel 1.
+        assert!(
+            (out[0] - 0.5).abs() < 1e-3,
+            "mute/solo leaked into render: {}",
+            out[0]
+        );
+    }
+
+    #[test]
+    fn render_channel_preroll_warms_effects() {
+        // With a feedback delay, a warmed render differs from a cold one: the
+        // captured region opens with delay repeats already in flight.
+        use crate::ffi::{DELAY_PARAM_FEEDBACK, DELAY_PARAM_MIX};
+        let make = |preroll: usize| {
+            let mut mixer = Mixer::new(SR);
+            mixer.load(0, ramp_buffer(400));
+            mixer.set_loop_end(0, 0.25);
+            let slot = mixer.effect_add(0, EFFECT_DELAY).unwrap();
+            // Audible wet path with feedback so warm-up state is observable.
+            mixer.effect_set_param(0, slot, DELAY_PARAM_FEEDBACK, 0.7);
+            mixer.effect_set_param(0, slot, DELAY_PARAM_MIX, 0.5);
+            let mut out = Vec::new();
+            assert!(mixer.render_channel_to_interleaved(0, 2000, preroll, &mut out));
+            out
+        };
+        let cold = make(0);
+        let warm = make(20_000);
+        let diff: f32 = cold
+            .iter()
+            .zip(&warm)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0, f32::max);
+        assert!(diff > 1e-3, "preroll did not warm the effect state");
     }
 }

--- a/tests/loop_render_wav.rs
+++ b/tests/loop_render_wav.rs
@@ -1,0 +1,226 @@
+//! End-to-end tests for `gooey_engine_loop_render_to_wav` — the offline
+//! single-channel stem export used by Whirlpool's Render view. These exercise
+//! the FFI exactly as the host does (create engine → load a loop → gain/effects
+//! → render to a temp WAV) and then read the WAV back to assert its format and
+//! content. Gated behind the `bounce` feature (which pulls in `hound`), the same
+//! feature that gates the FFI function itself.
+#![cfg(feature = "bounce")]
+
+use gooey::ffi::*;
+use std::ffi::CString;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+const SAMPLE_RATE: f32 = 44_100.0;
+
+/// A process-unique temp path so parallel tests never collide.
+fn temp_wav() -> PathBuf {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "gooey_loop_render_{}_{}.wav",
+        std::process::id(),
+        n
+    ))
+}
+
+/// Interleaved stereo buffer, both channels set to `value`.
+fn dc_stereo(value: f32, frames: usize) -> Vec<f32> {
+    vec![value; frames * 2]
+}
+
+/// Interleaved stereo ramp: left = right = frame index (for periodicity checks).
+fn ramp_stereo(frames: usize) -> Vec<f32> {
+    let mut out = Vec::with_capacity(frames * 2);
+    for i in 0..frames {
+        out.push(i as f32);
+        out.push(i as f32);
+    }
+    out
+}
+
+unsafe fn load(engine: *mut GooeyEngine, channel: u32, samples: &[f32]) {
+    let frames = samples.len() / 2;
+    assert!(gooey_engine_loop_load(
+        engine,
+        channel,
+        samples.as_ptr(),
+        frames as u32,
+        2,
+        SAMPLE_RATE,
+    ));
+}
+
+unsafe fn render(
+    engine: *mut GooeyEngine,
+    channel: u32,
+    frames: u32,
+    preroll: u32,
+    path: &PathBuf,
+) -> bool {
+    let c = CString::new(path.to_str().unwrap()).unwrap();
+    gooey_engine_loop_render_to_wav(engine, channel, frames, preroll, c.as_ptr())
+}
+
+/// Read a WAV back as (spec, interleaved f32 samples).
+fn read_wav(path: &PathBuf) -> (hound::WavSpec, Vec<f32>) {
+    let reader = hound::WavReader::open(path).expect("wav should exist");
+    let spec = reader.spec();
+    let samples: Vec<f32> = hound::WavReader::open(path)
+        .unwrap()
+        .into_samples::<f32>()
+        .map(|s| s.unwrap())
+        .collect();
+    (spec, samples)
+}
+
+#[test]
+fn writes_stereo_32bit_float_with_exact_frame_count() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        load(engine, 0, &dc_stereo(0.5, 4096));
+        let path = temp_wav();
+        assert!(render(engine, 0, 1000, 512, &path));
+
+        let (spec, samples) = read_wav(&path);
+        assert_eq!(spec.channels, 2, "stereo");
+        assert_eq!(spec.bits_per_sample, 32);
+        assert_eq!(spec.sample_format, hound::SampleFormat::Float);
+        assert_eq!(spec.sample_rate, 44_100);
+        assert_eq!(samples.len(), 1000 * 2, "exact frame count, no tail");
+
+        gooey_engine_free(engine);
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+#[test]
+fn bakes_in_channel_gain() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        load(engine, 0, &dc_stereo(0.5, 4096));
+        gooey_engine_loop_set_gain(engine, 0, 0.5);
+        let path = temp_wav();
+        assert!(render(engine, 0, 256, 256, &path));
+
+        let (_, samples) = read_wav(&path);
+        // 0.5 buffer * 0.5 gain = 0.25, present from the very first sample.
+        assert!(
+            (samples[0] - 0.25).abs() < 1e-3,
+            "gain not baked in: {}",
+            samples[0]
+        );
+        gooey_engine_free(engine);
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+#[test]
+fn repeats_selected_loop_region_to_fill_length() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        load(engine, 0, &ramp_stereo(400));
+        // Region = first quarter -> 100-frame period.
+        gooey_engine_loop_set_start(engine, 0, 0.0);
+        gooey_engine_loop_set_end(engine, 0, 0.25);
+        let path = temp_wav();
+        assert!(render(engine, 0, 350, 0, &path));
+
+        let (_, samples) = read_wav(&path);
+        for i in 0..350 {
+            let expected = (i % 100) as f32;
+            assert!(
+                (samples[i * 2] - expected).abs() < 1e-3,
+                "frame {i}: got {}, want {expected}",
+                samples[i * 2]
+            );
+        }
+        gooey_engine_free(engine);
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+#[test]
+fn ignores_mute_solo_and_other_channels() {
+    unsafe {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        load(engine, 0, &dc_stereo(0.5, 4096));
+        load(engine, 1, &dc_stereo(-0.9, 4096));
+        // Hostile transport state: target muted, another channel soloed.
+        gooey_engine_loop_set_mute(engine, 0, true);
+        gooey_engine_loop_set_solo(engine, 1, true);
+        let path = temp_wav();
+        assert!(render(engine, 0, 256, 256, &path));
+
+        let (_, samples) = read_wav(&path);
+        assert!(
+            (samples[0] - 0.5).abs() < 1e-3,
+            "render honored mute/solo or leaked another channel: {}",
+            samples[0]
+        );
+        gooey_engine_free(engine);
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+#[test]
+fn effects_are_baked_and_warmed_by_preroll() {
+    unsafe fn render_to_vec(preroll: u32) -> Vec<f32> {
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        load(engine, 0, &ramp_stereo(400));
+        gooey_engine_loop_set_end(engine, 0, 0.25);
+        let slot = gooey_engine_loop_effect_add(engine, 0, EFFECT_DELAY);
+        assert!(slot >= 0);
+        gooey_engine_loop_effect_set_param(engine, 0, slot as u32, DELAY_PARAM_FEEDBACK, 0.7);
+        gooey_engine_loop_effect_set_param(engine, 0, slot as u32, DELAY_PARAM_MIX, 0.5);
+        let path = temp_wav();
+        assert!(render(engine, 0, 2000, preroll, &path));
+        let (_, samples) = read_wav(&path);
+        gooey_engine_free(engine);
+        let _ = std::fs::remove_file(&path);
+        samples
+    }
+    unsafe {
+        let cold = render_to_vec(0);
+        let warm = render_to_vec(20_000);
+        let diff = cold
+            .iter()
+            .zip(&warm)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0_f32, f32::max);
+        assert!(diff > 1e-3, "preroll did not warm the delay tail");
+    }
+}
+
+#[test]
+fn rejects_invalid_arguments() {
+    unsafe {
+        let path = temp_wav();
+        let c = CString::new(path.to_str().unwrap()).unwrap();
+        // Null engine.
+        assert!(!gooey_engine_loop_render_to_wav(
+            std::ptr::null_mut(),
+            0,
+            100,
+            0,
+            c.as_ptr()
+        ));
+
+        let engine = gooey_engine_new(SAMPLE_RATE);
+        load(engine, 0, &dc_stereo(0.5, 1024));
+        // Null path.
+        assert!(!gooey_engine_loop_render_to_wav(engine, 0, 100, 0, std::ptr::null()));
+        // Empty path.
+        let empty = CString::new("").unwrap();
+        assert!(!gooey_engine_loop_render_to_wav(engine, 0, 100, 0, empty.as_ptr()));
+        // Zero frame count.
+        assert!(!render(engine, 0, 0, 0, &path));
+        // Out-of-range channel.
+        assert!(!render(engine, 99, 100, 0, &path));
+        // Channel with no buffer loaded.
+        assert!(!render(engine, 1, 100, 0, &path));
+
+        gooey_engine_free(engine);
+        let _ = std::fs::remove_file(&path);
+    }
+}


### PR DESCRIPTION
Render a single loop channel offline to a stereo 32-bit float WAV, post channel gain and effects but ignoring mute/solo. Resets the cursor and effect DSP, discards a preroll to warm delay/reverb feedback, restarts the loop cursor while preserving the warmed effect state, and writes exactly frame_count stereo frames with no appended tail so a short selected region tiles seamlessly and ends bar-aligned.

Backs Whirlpool's macOS Render view, which runs it on a disposable offline engine (the binding is not real-time safe against a live render callback).