### PR TITLE
Fix loop mixer control-thread races

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -16,7 +16,8 @@ use crate::instruments::{
     Tom2Config,
 };
 use crate::mixer::{
-    LaunchQuantization, Mixer, MixerGraph, PitchMode, RetrimTiming, StereoSampleBuffer,
+    ChannelEffect, LaunchQuantization, Mixer, MixerControl, MixerGraph, PitchMode, RetrimTiming,
+    StereoSampleBuffer,
 };
 use crate::music::{apply_voicing, available_voicings, Key, NoteName, ScaleType, VoicingType};
 use crate::performance::{ChordClipEvent, PerformanceRecorder, PlayerAction, RecordMode};
@@ -737,6 +738,9 @@ pub struct GooeyEngine {
     // into the master bus before the global effects chain. The `gooey_engine_loop_*`
     // FFI functions expose control over this.
     mixer: Mixer,
+    /// Separately shared control endpoint. Loop/clip FFI calls only touch this
+    /// object; realtime rendering owns and mutates `mixer`.
+    mixer_control: MixerControl,
 
     // Host-defined mixer graph: named submix tracks, each with a strip
     // (gain / balance / mute-solo / peak) and its own effect rack. Sources
@@ -879,6 +883,8 @@ impl GooeyEngine {
         // Create LFO pool (8 LFOs, all disabled by default with quarter note timing)
         let lfos = std::array::from_fn(|_| Lfo::with_sample_rate(sample_rate));
         let lfo_routes: [Vec<LfoRoute>; LFO_COUNT] = std::array::from_fn(|_| Vec::new());
+        let mixer = Mixer::new(sample_rate);
+        let mixer_control = mixer.control();
 
         Self {
             kit,
@@ -932,7 +938,8 @@ impl GooeyEngine {
                     .unwrap_or_else(|_| unreachable!("constant placeholder buffer is valid")),
             ),
             // Multi-channel stereo loop mixer (empty until the host loads loops).
-            mixer: Mixer::new(sample_rate),
+            mixer,
+            mixer_control,
             // Host-defined mixer graph, seeded with the default 4-track layout
             // (Drums / Bass / Synth / Loops). Bit-identical to the flat mix until
             // the host adjusts a track strip, rack, or routing.
@@ -1043,6 +1050,9 @@ impl GooeyEngine {
     fn render(&mut self, buffer: &mut [f32]) {
         // Clear pending MIDI events from previous render pass
         self.pending_midi_events.clear();
+        // Commands are applied at buffer boundaries, including buffers that
+        // are temporarily silent while a host-time arm is pending.
+        self.mixer.apply_control_commands();
 
         // Number of stereo frames this buffer holds (two slots per frame).
         let frame_count = buffer.len() / 2;
@@ -3356,8 +3366,10 @@ pub unsafe extern "C" fn gooey_engine_set_bpm(engine: *mut GooeyEngine, bpm: f32
         lfo.set_bpm(bpm);
     }
 
-    // Seed BPM for any future note-synced per-channel loop effects.
-    engine.mixer.set_bpm(bpm);
+    // Seed BPM for any future note-synced per-channel loop effects. Deferred to
+    // the audio thread so it never races the loop mixer's render (the rest of
+    // this function's engine mutation is a separate, pre-existing concern).
+    engine.mixer_control.set_bpm(bpm);
 
     // Propagate BPM to note-synced effects in per-track racks.
     engine.graph.set_bpm(bpm);
@@ -3514,7 +3526,8 @@ pub unsafe extern "C" fn gooey_engine_sequencer_start(engine: *mut GooeyEngine) 
     for seq in engine.sequencers_iter_mut() {
         seq.start();
     }
-    engine.mixer.transport_start();
+    // Deferred to the audio thread so it never races the loop mixer's render.
+    engine.mixer_control.transport_start();
 }
 
 /// Stop all sequencers.
@@ -3537,7 +3550,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_stop(engine: *mut GooeyEngine) {
     for rack in engine.samplers.iter_mut().flatten() {
         rack.transport_stop();
     }
-    engine.mixer.transport_stop();
+    engine.mixer_control.transport_stop();
 }
 
 /// Reset all sequencers to step 0.
@@ -3560,7 +3573,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_reset(engine: *mut GooeyEngine) 
     for rack in engine.samplers.iter_mut().flatten() {
         rack.transport_reset();
     }
-    engine.mixer.transport_reset();
+    engine.mixer_control.transport_reset();
 }
 
 /// Set all sequencers to a specific beat position in quarter notes.
@@ -3596,7 +3609,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_set_beat_position(
     for seq in engine.sequencers_iter_mut() {
         seq.set_beat_position(beat_position);
     }
-    engine.mixer.transport_seek(beat_position);
+    engine.mixer_control.transport_seek(beat_position);
 }
 
 /// Tell the engine the host time corresponding to sample 0 of the next
@@ -3675,7 +3688,7 @@ pub unsafe extern "C" fn gooey_engine_sequencer_start_at_host_time(
         start_host_time,
         beat_position,
     });
-    engine.mixer.transport_stop();
+    engine.mixer_control.transport_stop();
     for seq in engine.sequencers_iter_mut() {
         seq.cancel_arm();
         seq.stop();
@@ -6053,9 +6066,7 @@ pub unsafe extern "C" fn gooey_engine_sampler_set_slot_buffer(
     if samples.is_null() {
         return false;
     }
-    let Some(engine) = engine.as_mut() else {
-        return false;
-    };
+    let Some(engine) = engine.as_mut() else { return false; };
     let channels = channels as usize;
     let frames = frames as usize;
     let Some(count) = frames.checked_mul(channels) else {
@@ -6194,7 +6205,9 @@ pub unsafe extern "C" fn gooey_engine_sampler_start_pattern(
     rack: u32,
     quantization: u32,
 ) -> bool {
-    let Some(engine) = engine.as_mut() else { return false; };
+    let Some(engine) = engine.as_mut() else {
+        return false;
+    };
     let Some(quantization) = LaunchQuantization::from_id(quantization) else {
         return false;
     };
@@ -6700,6 +6713,9 @@ pub unsafe extern "C" fn gooey_engine_track_effect_type_at(
 // Transport-synchronized clip grid: 4 columns x 8 rows
 // =============================================================================
 
+// Clip mutations are applied by the audio thread at the next render-buffer
+// boundary. Clip getters expose the last atomically published audio snapshot.
+
 /// Number of clip-grid columns (one per loop mixer channel).
 pub const CLIP_COLUMN_COUNT: u32 = crate::mixer::CLIP_COLUMN_COUNT as u32;
 /// Number of rows in each clip-grid column.
@@ -6760,9 +6776,13 @@ pub unsafe extern "C" fn gooey_engine_clip_load(
     };
     let samples = slice::from_raw_parts(samples, total);
     match StereoSampleBuffer::from_interleaved(samples, channels as usize, sample_rate) {
-        Ok(buffer) => (*engine)
-            .mixer
-            .clip_load(column as usize, row as usize, buffer, source_bpm),
+        Ok(buffer) => {
+            // Defer the slot load to the audio thread (replacing the active slot
+            // touches the live channel); indices/bpm are validated above.
+            (*engine)
+                .mixer_control
+                .clip_load(column as usize, row as usize, buffer, source_bpm)
+        }
         Err(_) => false,
     }
 }
@@ -6778,9 +6798,14 @@ pub unsafe extern "C" fn gooey_engine_clip_unload(
     column: u32,
     row: u32,
 ) -> bool {
-    engine
-        .as_mut()
-        .is_some_and(|engine| engine.mixer.clip_unload(column as usize, row as usize))
+    if column >= CLIP_COLUMN_COUNT || row >= CLIP_ROW_COUNT {
+        return false;
+    }
+    engine.as_ref().is_some_and(|engine| {
+        engine
+            .mixer_control
+            .clip_unload(column as usize, row as usize)
+    })
 }
 
 /// Stop all grid-owned columns and unload every slot.
@@ -6789,8 +6814,8 @@ pub unsafe extern "C" fn gooey_engine_clip_unload(
 /// `engine` must be a valid pointer returned by `gooey_engine_new`.
 #[no_mangle]
 pub unsafe extern "C" fn gooey_engine_clip_clear(engine: *mut GooeyEngine) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.clip_clear();
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.clip_clear();
     }
 }
 
@@ -6806,14 +6831,17 @@ pub unsafe extern "C" fn gooey_engine_clip_launch(
     row: u32,
     quantization: u32,
 ) -> bool {
-    let Some(engine) = engine.as_mut() else {
+    let Some(engine) = engine.as_ref() else {
         return false;
     };
+    if column >= CLIP_COLUMN_COUNT || row >= CLIP_ROW_COUNT {
+        return false;
+    }
     let Some(quantization) = LaunchQuantization::from_id(quantization) else {
         return false;
     };
     engine
-        .mixer
+        .mixer_control
         .clip_launch(column as usize, row as usize, quantization)
 }
 
@@ -6828,9 +6856,12 @@ pub unsafe extern "C" fn gooey_engine_clip_launch_at_beat(
     row: u32,
     beat: f64,
 ) -> bool {
-    engine.as_mut().is_some_and(|engine| {
+    if column >= CLIP_COLUMN_COUNT || row >= CLIP_ROW_COUNT {
+        return false;
+    }
+    engine.as_ref().is_some_and(|engine| {
         engine
-            .mixer
+            .mixer_control
             .clip_launch_at(column as usize, row as usize, beat)
     })
 }
@@ -6846,13 +6877,18 @@ pub unsafe extern "C" fn gooey_engine_clip_launch_scene(
     row: u32,
     quantization: u32,
 ) -> bool {
-    let Some(engine) = engine.as_mut() else {
+    let Some(engine) = engine.as_ref() else {
         return false;
     };
+    if row >= CLIP_ROW_COUNT {
+        return false;
+    }
     let Some(quantization) = LaunchQuantization::from_id(quantization) else {
         return false;
     };
-    engine.mixer.clip_launch_scene(row as usize, quantization)
+    engine
+        .mixer_control
+        .clip_launch_scene(row as usize, quantization)
 }
 
 /// Queue an entire scene row at an absolute future beat.
@@ -6865,9 +6901,14 @@ pub unsafe extern "C" fn gooey_engine_clip_launch_scene_at_beat(
     row: u32,
     beat: f64,
 ) -> bool {
-    engine
-        .as_mut()
-        .is_some_and(|engine| engine.mixer.clip_launch_scene_at(row as usize, beat))
+    if row >= CLIP_ROW_COUNT {
+        return false;
+    }
+    engine.as_ref().is_some_and(|engine| {
+        engine
+            .mixer_control
+            .clip_launch_scene_at(row as usize, beat)
+    })
 }
 
 /// Queue a column stop at a musical boundary.
@@ -6880,13 +6921,18 @@ pub unsafe extern "C" fn gooey_engine_clip_stop(
     column: u32,
     quantization: u32,
 ) -> bool {
-    let Some(engine) = engine.as_mut() else {
+    let Some(engine) = engine.as_ref() else {
         return false;
     };
+    if column >= CLIP_COLUMN_COUNT {
+        return false;
+    }
     let Some(quantization) = LaunchQuantization::from_id(quantization) else {
         return false;
     };
-    engine.mixer.clip_stop(column as usize, quantization)
+    engine
+        .mixer_control
+        .clip_stop(column as usize, quantization)
 }
 
 /// Queue a column stop at an absolute future beat.
@@ -6899,9 +6945,12 @@ pub unsafe extern "C" fn gooey_engine_clip_stop_at_beat(
     column: u32,
     beat: f64,
 ) -> bool {
+    if column >= CLIP_COLUMN_COUNT {
+        return false;
+    }
     engine
-        .as_mut()
-        .is_some_and(|engine| engine.mixer.clip_stop_at(column as usize, beat))
+        .as_ref()
+        .is_some_and(|engine| engine.mixer_control.clip_stop_at(column as usize, beat))
 }
 
 /// Cancel one column's pending clip action without changing its active clip.
@@ -6910,8 +6959,8 @@ pub unsafe extern "C" fn gooey_engine_clip_stop_at_beat(
 /// `engine` must be a valid pointer returned by `gooey_engine_new`.
 #[no_mangle]
 pub unsafe extern "C" fn gooey_engine_clip_cancel(engine: *mut GooeyEngine, column: u32) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.clip_cancel(column as usize);
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.clip_cancel(column as usize);
     }
 }
 
@@ -6921,8 +6970,8 @@ pub unsafe extern "C" fn gooey_engine_clip_cancel(engine: *mut GooeyEngine, colu
 /// `engine` must be a valid pointer returned by `gooey_engine_new`.
 #[no_mangle]
 pub unsafe extern "C" fn gooey_engine_clip_cancel_all(engine: *mut GooeyEngine) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.clip_cancel_all();
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.clip_cancel_all();
     }
 }
 
@@ -6935,14 +6984,15 @@ pub unsafe extern "C" fn gooey_engine_clip_set_default_quantization(
     engine: *mut GooeyEngine,
     quantization: u32,
 ) -> bool {
-    let Some(engine) = engine.as_mut() else {
+    let Some(engine) = engine.as_ref() else {
         return false;
     };
     let Some(quantization) = LaunchQuantization::from_id(quantization) else {
         return false;
     };
-    engine.mixer.clip_set_default_quantization(quantization);
-    true
+    engine
+        .mixer_control
+        .clip_set_default_quantization(quantization)
 }
 
 /// Return the current default `CLIP_QUANTIZE_*` value (bar for a null engine).
@@ -6954,7 +7004,7 @@ pub unsafe extern "C" fn gooey_engine_clip_get_default_quantization(
     engine: *const GooeyEngine,
 ) -> u32 {
     engine.as_ref().map_or(CLIP_QUANTIZE_BAR, |engine| {
-        engine.mixer.clip_default_quantization().id()
+        engine.mixer_control.clip_default_quantization()
     })
 }
 
@@ -6969,7 +7019,9 @@ pub unsafe extern "C" fn gooey_engine_clip_get_state(
     row: u32,
 ) -> u32 {
     engine.as_ref().map_or(0, |engine| {
-        engine.mixer.clip_slot_state(column as usize, row as usize)
+        engine
+            .mixer_control
+            .clip_slot_state(column as usize, row as usize)
     })
 }
 
@@ -6982,10 +7034,9 @@ pub unsafe extern "C" fn gooey_engine_clip_get_active_row(
     engine: *const GooeyEngine,
     column: u32,
 ) -> i32 {
-    engine
-        .as_ref()
-        .and_then(|engine| engine.mixer.clip_active_row(column as usize))
-        .map_or(-1, |row| row as i32)
+    engine.as_ref().map_or(-1, |engine| {
+        engine.mixer_control.clip_active_row(column as usize)
+    })
 }
 
 /// Return the row targeted by a pending launch/unload, or `-1` for none/stop.
@@ -6997,10 +7048,9 @@ pub unsafe extern "C" fn gooey_engine_clip_get_queued_row(
     engine: *const GooeyEngine,
     column: u32,
 ) -> i32 {
-    engine
-        .as_ref()
-        .and_then(|engine| engine.mixer.clip_queued_row(column as usize))
-        .map_or(-1, |row| row as i32)
+    engine.as_ref().map_or(-1, |engine| {
+        engine.mixer_control.clip_queued_row(column as usize)
+    })
 }
 
 /// Return true when the pending action will stop the column (including unload).
@@ -7014,7 +7064,7 @@ pub unsafe extern "C" fn gooey_engine_clip_is_stop_queued(
 ) -> bool {
     engine
         .as_ref()
-        .is_some_and(|engine| engine.mixer.clip_is_stop_queued(column as usize))
+        .is_some_and(|engine| engine.mixer_control.clip_stop_queued(column as usize))
 }
 
 /// Return a column's scheduled absolute beat, or `-1.0` if no action is queued.
@@ -7026,10 +7076,9 @@ pub unsafe extern "C" fn gooey_engine_clip_get_scheduled_beat(
     engine: *const GooeyEngine,
     column: u32,
 ) -> f64 {
-    engine
-        .as_ref()
-        .and_then(|engine| engine.mixer.clip_scheduled_beat(column as usize))
-        .unwrap_or(-1.0)
+    engine.as_ref().map_or(-1.0, |engine| {
+        engine.mixer_control.clip_scheduled_beat(column as usize)
+    })
 }
 
 /// Return the active clip's actual normalized source-buffer cursor, or -1.0
@@ -7040,10 +7089,9 @@ pub unsafe extern "C" fn gooey_engine_clip_get_active_playhead(
     engine: *const GooeyEngine,
     column: u32,
 ) -> f64 {
-    engine
-        .as_ref()
-        .and_then(|engine| engine.mixer.clip_active_playhead(column as usize))
-        .unwrap_or(-1.0)
+    engine.as_ref().map_or(-1.0, |engine| {
+        engine.mixer_control.clip_active_playhead(column as usize)
+    })
 }
 
 /// Set a slot's loop trim as normalized `[0, 1]` start/end markers.
@@ -7079,7 +7127,7 @@ pub unsafe extern "C" fn gooey_engine_clip_set_trim(
     end: f64,
     quantization: u32,
 ) -> bool {
-    let Some(engine) = engine.as_mut() else {
+    let Some(engine) = engine.as_ref() else {
         return false;
     };
     if column >= CLIP_COLUMN_COUNT
@@ -7095,8 +7143,10 @@ pub unsafe extern "C" fn gooey_engine_clip_set_trim(
     let Some(timing) = RetrimTiming::from_id(quantization) else {
         return false;
     };
+    // Defer: an immediate retrim live-resizes the active channel's loop window
+    // (which resets its WSOLA stretcher), so it must run on the audio thread.
     engine
-        .mixer
+        .mixer_control
         .clip_set_trim(column as usize, row as usize, start, end, timing)
 }
 
@@ -7111,10 +7161,11 @@ pub unsafe extern "C" fn gooey_engine_clip_get_trim_start(
     column: u32,
     row: u32,
 ) -> f64 {
-    engine
-        .as_ref()
-        .and_then(|engine| engine.mixer.clip_trim_start(column as usize, row as usize))
-        .unwrap_or(-1.0)
+    engine.as_ref().map_or(-1.0, |engine| {
+        engine
+            .mixer_control
+            .clip_trim_start(column as usize, row as usize)
+    })
 }
 
 /// Return a slot's normalized loop-end marker, or `-1.0` for a null engine or
@@ -7128,10 +7179,11 @@ pub unsafe extern "C" fn gooey_engine_clip_get_trim_end(
     column: u32,
     row: u32,
 ) -> f64 {
-    engine
-        .as_ref()
-        .and_then(|engine| engine.mixer.clip_trim_end(column as usize, row as usize))
-        .unwrap_or(-1.0)
+    engine.as_ref().map_or(-1.0, |engine| {
+        engine
+            .mixer_control
+            .clip_trim_end(column as usize, row as usize)
+    })
 }
 
 /// Return the monotonic absolute transport position in quarter notes.
@@ -7146,7 +7198,7 @@ pub unsafe extern "C" fn gooey_engine_transport_get_beat_position(
 ) -> f64 {
     engine
         .as_ref()
-        .map_or(0.0, |engine| engine.mixer.transport_beat())
+        .map_or(0.0, |engine| engine.mixer_control.transport_beat())
 }
 
 // =============================================================================
@@ -7160,6 +7212,10 @@ pub unsafe extern "C" fn gooey_engine_transport_get_beat_position(
 //
 // `channel` is a 0-based index in `[0, LOOP_CHANNEL_COUNT)`; out-of-range
 // indices are ignored (or return a sensible default).
+//
+// Loop and clip mutations are queued and take effect at the next render-buffer
+// boundary. The getters below read the most recently audio-published snapshot;
+// they never inspect live mixer DSP state from the host/control thread.
 
 /// Pitch mode: no BPM-driven tempo warp; playback rate follows `speed` alone.
 pub const PITCH_MODE_OFF: u32 = 0;
@@ -7192,11 +7248,19 @@ pub unsafe extern "C" fn gooey_engine_loop_load(
     if engine.is_null() || samples.is_null() || frames == 0 || channels == 0 {
         return false;
     }
-    let engine = &mut *engine;
+    let engine = &*engine;
+    if channel as usize >= LOOP_CHANNEL_COUNT as usize {
+        return false;
+    }
     let total = frames as usize * channels as usize;
     let slice = slice::from_raw_parts(samples, total);
     match StereoSampleBuffer::from_interleaved(slice, channels as usize, sample_rate) {
-        Ok(buffer) => engine.mixer.load(channel as usize, buffer),
+        Ok(buffer) => {
+            // Defer the buffer swap to the audio thread: mutating the channel
+            // (and dropping its old buffer / WSOLA stretcher) here would race the
+            // render callback. Validity is checked above so `true` is accurate.
+            engine.mixer_control.load(channel as usize, buffer)
+        }
         Err(_) => false,
     }
 }
@@ -7211,8 +7275,8 @@ pub unsafe extern "C" fn gooey_engine_loop_set_playing(
     channel: u32,
     playing: bool,
 ) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.set_playing(channel as usize, playing);
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.set_playing(channel as usize, playing);
     }
 }
 
@@ -7226,8 +7290,8 @@ pub unsafe extern "C" fn gooey_engine_loop_set_gain(
     channel: u32,
     gain: f32,
 ) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.set_gain(channel as usize, gain);
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.set_gain(channel as usize, gain);
     }
 }
 
@@ -7241,8 +7305,8 @@ pub unsafe extern "C" fn gooey_engine_loop_set_mute(
     channel: u32,
     muted: bool,
 ) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.set_muted(channel as usize, muted);
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.set_muted(channel as usize, muted);
     }
 }
 
@@ -7257,8 +7321,8 @@ pub unsafe extern "C" fn gooey_engine_loop_set_solo(
     channel: u32,
     soloed: bool,
 ) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.set_soloed(channel as usize, soloed);
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.set_soloed(channel as usize, soloed);
     }
 }
 
@@ -7277,8 +7341,10 @@ pub unsafe extern "C" fn gooey_engine_loop_set_start(
     channel: u32,
     normalized: f32,
 ) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.set_loop_start(channel as usize, normalized);
+    if let Some(engine) = engine.as_ref() {
+        engine
+            .mixer_control
+            .set_loop_start(channel as usize, normalized);
     }
 }
 
@@ -7297,8 +7363,10 @@ pub unsafe extern "C" fn gooey_engine_loop_set_end(
     channel: u32,
     normalized: f32,
 ) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.set_loop_end(channel as usize, normalized);
+    if let Some(engine) = engine.as_ref() {
+        engine
+            .mixer_control
+            .set_loop_end(channel as usize, normalized);
     }
 }
 
@@ -7313,8 +7381,8 @@ pub unsafe extern "C" fn gooey_engine_loop_set_speed(
     channel: u32,
     speed: f32,
 ) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.set_speed(channel as usize, speed);
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.set_speed(channel as usize, speed);
     }
 }
 
@@ -7333,13 +7401,13 @@ pub unsafe extern "C" fn gooey_engine_loop_set_source_bpm(
     channel: u32,
     source_bpm: f32,
 ) {
-    if let Some(engine) = engine.as_mut() {
+    if let Some(engine) = engine.as_ref() {
         let bpm = if source_bpm > 0.0 {
             Some(source_bpm)
         } else {
             None
         };
-        engine.mixer.set_source_bpm(channel as usize, bpm);
+        engine.mixer_control.set_source_bpm(channel as usize, bpm);
     }
 }
 
@@ -7355,8 +7423,7 @@ pub unsafe extern "C" fn gooey_engine_loop_get_source_bpm(
 ) -> f32 {
     engine
         .as_ref()
-        .and_then(|e| e.mixer.source_bpm(channel as usize))
-        .unwrap_or(0.0)
+        .map_or(0.0, |e| e.mixer_control.source_bpm(channel as usize))
 }
 
 /// Set a loop channel's tempo-warp/pitch mode. See `PITCH_MODE_*` constants.
@@ -7370,13 +7437,13 @@ pub unsafe extern "C" fn gooey_engine_loop_set_pitch_mode(
     channel: u32,
     mode: u32,
 ) {
-    if let Some(engine) = engine.as_mut() {
+    if let Some(engine) = engine.as_ref() {
         let mode = match mode {
             PITCH_MODE_RESAMPLE => PitchMode::Resample,
             PITCH_MODE_PRESERVE_PITCH => PitchMode::PreservePitch,
             _ => PitchMode::Off,
         };
-        engine.mixer.set_pitch_mode(channel as usize, mode);
+        engine.mixer_control.set_pitch_mode(channel as usize, mode);
     }
 }
 
@@ -7392,7 +7459,7 @@ pub unsafe extern "C" fn gooey_engine_loop_get_pitch_mode(
 ) -> u32 {
     match engine
         .as_ref()
-        .map(|e| e.mixer.pitch_mode(channel as usize))
+        .map(|e| e.mixer_control.pitch_mode(channel as usize))
     {
         Some(PitchMode::Resample) => PITCH_MODE_RESAMPLE,
         Some(PitchMode::PreservePitch) => PITCH_MODE_PRESERVE_PITCH,
@@ -7406,8 +7473,8 @@ pub unsafe extern "C" fn gooey_engine_loop_get_pitch_mode(
 /// `engine` must be a valid pointer returned by `gooey_engine_new`.
 #[no_mangle]
 pub unsafe extern "C" fn gooey_engine_loop_restart(engine: *mut GooeyEngine, channel: u32) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.restart(channel as usize);
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.restart(channel as usize);
     }
 }
 
@@ -7424,8 +7491,10 @@ pub unsafe extern "C" fn gooey_engine_loop_set_position(
     channel: u32,
     normalized: f32,
 ) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.set_position(channel as usize, normalized);
+    if let Some(engine) = engine.as_ref() {
+        engine
+            .mixer_control
+            .set_position(channel as usize, normalized);
     }
 }
 
@@ -7459,16 +7528,25 @@ pub unsafe extern "C" fn gooey_engine_loop_queue_swap(
     if engine.is_null() || samples.is_null() || frames == 0 || channels == 0 {
         return false;
     }
-    let engine = &mut *engine;
+    let engine = &*engine;
+    if channel as usize >= LOOP_CHANNEL_COUNT as usize {
+        return false;
+    }
     let total = frames as usize * channels as usize;
     let slice = slice::from_raw_parts(samples, total);
     match StereoSampleBuffer::from_interleaved(slice, channels as usize, sample_rate) {
         Ok(mut buffer) => {
+            if buffer.is_empty() {
+                return false;
+            }
             // Tag the pending take so `warp_ratio()` is correct the moment it lands,
             // rather than falling back to 1.0 until the host retags post-swap.
             // `set_source_bpm` filters non-finite/<= 0, so 0.0 means "untagged".
             buffer.set_source_bpm((source_bpm > 0.0).then_some(source_bpm));
-            engine.mixer.queue_swap(channel as usize, buffer, divisions)
+            // Defer to the audio thread — see `gooey_engine_loop_load`.
+            engine
+                .mixer_control
+                .queue_swap(channel as usize, buffer, divisions)
         }
         Err(_) => false,
     }
@@ -7484,8 +7562,8 @@ pub unsafe extern "C" fn gooey_engine_loop_cancel_queued_swap(
     engine: *mut GooeyEngine,
     channel: u32,
 ) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.cancel_queued_swap(channel as usize);
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.cancel_queued_swap(channel as usize);
     }
 }
 
@@ -7502,7 +7580,7 @@ pub unsafe extern "C" fn gooey_engine_loop_swaps_completed(
     channel: u32,
 ) -> u32 {
     match engine.as_ref() {
-        Some(engine) => engine.mixer.swaps_completed(channel as usize),
+        Some(engine) => engine.mixer_control.swaps_completed(channel as usize),
         None => 0,
     }
 }
@@ -7518,10 +7596,7 @@ pub unsafe extern "C" fn gooey_engine_loop_get_position(
     channel: u32,
 ) -> f32 {
     match engine.as_ref() {
-        Some(engine) => engine
-            .mixer
-            .channel(channel as usize)
-            .map_or(0.0, |ch| ch.position_normalized()),
+        Some(engine) => engine.mixer_control.position(channel as usize),
         None => 0.0,
     }
 }
@@ -7538,11 +7613,17 @@ pub unsafe extern "C" fn gooey_engine_loop_effect_add(
     channel: u32,
     effect_id: u32,
 ) -> i32 {
-    match engine.as_mut() {
-        Some(engine) => engine
-            .mixer
-            .effect_add(channel as usize, effect_id)
-            .map_or(-1, |slot| slot as i32),
+    match engine.as_ref() {
+        Some(engine) => {
+            let ch = channel as usize;
+            if ch >= LOOP_CHANNEL_COUNT as usize || !ChannelEffect::is_valid_id(effect_id) {
+                return -1;
+            }
+            engine
+                .mixer_control
+                .effect_add(ch, effect_id)
+                .map_or(-1, |slot| slot as i32)
+        }
         None => -1,
     }
 }
@@ -7558,8 +7639,14 @@ pub unsafe extern "C" fn gooey_engine_loop_effect_remove(
     channel: u32,
     slot: u32,
 ) -> bool {
-    match engine.as_mut() {
-        Some(engine) => engine.mixer.effect_remove(channel as usize, slot as usize),
+    match engine.as_ref() {
+        Some(engine) => {
+            let ch = channel as usize;
+            if ch >= LOOP_CHANNEL_COUNT as usize {
+                return false;
+            }
+            engine.mixer_control.effect_remove(ch, slot as usize)
+        }
         None => false,
     }
 }
@@ -7576,11 +7663,15 @@ pub unsafe extern "C" fn gooey_engine_loop_effect_move(
     slot: u32,
     new_position: u32,
 ) -> bool {
-    match engine.as_mut() {
+    match engine.as_ref() {
         Some(engine) => {
+            let ch = channel as usize;
+            if ch >= LOOP_CHANNEL_COUNT as usize {
+                return false;
+            }
             engine
-                .mixer
-                .effect_move(channel as usize, slot as usize, new_position as usize)
+                .mixer_control
+                .effect_move(ch, slot as usize, new_position as usize)
         }
         None => false,
     }
@@ -7592,8 +7683,8 @@ pub unsafe extern "C" fn gooey_engine_loop_effect_move(
 /// `engine` must be a valid pointer returned by `gooey_engine_new`.
 #[no_mangle]
 pub unsafe extern "C" fn gooey_engine_loop_effect_clear(engine: *mut GooeyEngine, channel: u32) {
-    if let Some(engine) = engine.as_mut() {
-        engine.mixer.effect_clear(channel as usize);
+    if let Some(engine) = engine.as_ref() {
+        engine.mixer_control.effect_clear(channel as usize);
     }
 }
 
@@ -7612,7 +7703,7 @@ pub unsafe extern "C" fn gooey_engine_loop_effect_set_param(
 ) {
     if let Some(engine) = engine.as_ref() {
         engine
-            .mixer
+            .mixer_control
             .effect_set_param(channel as usize, slot as usize, param, value);
     }
 }
@@ -7628,7 +7719,7 @@ pub unsafe extern "C" fn gooey_engine_loop_effect_count(
     channel: u32,
 ) -> u32 {
     match engine.as_ref() {
-        Some(engine) => engine.mixer.effect_count(channel as usize) as u32,
+        Some(engine) => engine.mixer_control.effect_count(channel as usize) as u32,
         None => 0,
     }
 }
@@ -7646,7 +7737,7 @@ pub unsafe extern "C" fn gooey_engine_loop_effect_type_at(
 ) -> i32 {
     match engine.as_ref() {
         Some(engine) => engine
-            .mixer
+            .mixer_control
             .effect_type_at(channel as usize, slot as usize)
             .map_or(-1, |id| id as i32),
         None => -1,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1389,6 +1389,9 @@ impl GooeyEngine {
             self.current_time += sample_period;
             sample_offset += 1;
         }
+        // Publish once after the completed buffer instead of once per mixer
+        // sample. Silent buffers publish from `apply_control_commands` above.
+        self.mixer.publish_control_snapshot();
     }
 
     fn apply_sequencer_blend_setting(

--- a/src/mixer/control.rs
+++ b/src/mixer/control.rs
@@ -1,0 +1,709 @@
+//! Cross-thread control plane for the loop mixer.
+//!
+//! The audio thread owns `Mixer`'s DSP state. Hosts use `MixerControl` to
+//! submit commands and read snapshots without touching that state directly.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use super::{
+    ChannelEffect, LaunchQuantization, PitchMode, RetrimTiming, StereoSampleBuffer,
+    CLIP_COLUMN_COUNT, CLIP_ROW_COUNT, LOOP_CHANNEL_COUNT,
+};
+
+/// Maximum number of control operations the audio thread applies in one sample.
+/// This bounds command work during a producer burst; remaining operations keep
+/// their FIFO order for the following samples.
+pub(crate) const MAX_COMMANDS_PER_TICK: usize = 64;
+const MAX_QUEUED_COMMANDS: usize = 4096;
+
+/// A control operation which can mutate mixer state. These values are built on
+/// host/control threads and consumed only by the audio thread.
+pub(crate) enum MixerCommand {
+    Load {
+        channel: usize,
+        buffer: StereoSampleBuffer,
+    },
+    SetPlaying {
+        channel: usize,
+        playing: bool,
+    },
+    SetGain {
+        channel: usize,
+        gain: f32,
+    },
+    SetMuted {
+        channel: usize,
+        muted: bool,
+    },
+    SetSoloed {
+        channel: usize,
+        soloed: bool,
+    },
+    SetLoopStart {
+        channel: usize,
+        value: f32,
+    },
+    SetLoopEnd {
+        channel: usize,
+        value: f32,
+    },
+    SetSpeed {
+        channel: usize,
+        speed: f32,
+    },
+    SetSourceBpm {
+        channel: usize,
+        bpm: Option<f32>,
+    },
+    SetPitchMode {
+        channel: usize,
+        mode: PitchMode,
+    },
+    Restart {
+        channel: usize,
+    },
+    SetPosition {
+        channel: usize,
+        value: f32,
+    },
+    QueueSwap {
+        channel: usize,
+        buffer: StereoSampleBuffer,
+        divisions: u32,
+    },
+    CancelQueuedSwap {
+        channel: usize,
+    },
+    SetBpm {
+        bpm: f32,
+    },
+    ClipLoad {
+        column: usize,
+        row: usize,
+        buffer: StereoSampleBuffer,
+        source_bpm: f32,
+    },
+    ClipUnload {
+        column: usize,
+        row: usize,
+    },
+    ClipClear,
+    ClipLaunch {
+        column: usize,
+        row: usize,
+        quantization: LaunchQuantization,
+    },
+    ClipLaunchAt {
+        column: usize,
+        row: usize,
+        beat: f64,
+    },
+    ClipLaunchScene {
+        row: usize,
+        quantization: LaunchQuantization,
+    },
+    ClipLaunchSceneAt {
+        row: usize,
+        beat: f64,
+    },
+    ClipStop {
+        column: usize,
+        quantization: LaunchQuantization,
+    },
+    ClipStopAt {
+        column: usize,
+        beat: f64,
+    },
+    ClipCancel {
+        column: usize,
+    },
+    ClipCancelAll,
+    ClipSetDefaultQuantization {
+        quantization: LaunchQuantization,
+    },
+    ClipSetTrim {
+        column: usize,
+        row: usize,
+        start: f64,
+        end: f64,
+        timing: RetrimTiming,
+    },
+    TransportStart,
+    TransportStop,
+    TransportSeek {
+        beat: f64,
+    },
+    TransportReset,
+    EffectAdd {
+        channel: usize,
+        effect_id: u32,
+    },
+    EffectRemove {
+        channel: usize,
+        slot: usize,
+    },
+    EffectMove {
+        channel: usize,
+        slot: usize,
+        new_position: usize,
+    },
+    EffectClear {
+        channel: usize,
+    },
+    EffectSetParam {
+        channel: usize,
+        slot: usize,
+        param: u32,
+        value: f32,
+    },
+}
+
+struct QueueState {
+    commands: VecDeque<MixerCommand>,
+    /// Desired effect layouts, updated under the same lock that establishes
+    /// command order. This lets callers queue `add` then `set_param` before a
+    /// render boundary without reading the live effect `Vec`.
+    effect_layouts: [Vec<u32>; LOOP_CHANNEL_COUNT],
+}
+
+impl Default for QueueState {
+    fn default() -> Self {
+        Self {
+            commands: VecDeque::new(),
+            effect_layouts: std::array::from_fn(|_| Vec::new()),
+        }
+    }
+}
+
+/// Atomically published, last-audio-tick state used by FFI getters.
+pub(crate) struct MixerSnapshot {
+    generation: AtomicU64,
+    pub(crate) loop_position: [AtomicU32; LOOP_CHANNEL_COUNT],
+    pub(crate) loop_source_bpm: [AtomicU32; LOOP_CHANNEL_COUNT],
+    pub(crate) loop_pitch_mode: [AtomicU32; LOOP_CHANNEL_COUNT],
+    pub(crate) swaps_completed: [AtomicU32; LOOP_CHANNEL_COUNT],
+    pub(crate) default_quantization: AtomicU32,
+    pub(crate) slot_state: [[AtomicU32; CLIP_ROW_COUNT]; CLIP_COLUMN_COUNT],
+    pub(crate) trim_start: [[AtomicU64; CLIP_ROW_COUNT]; CLIP_COLUMN_COUNT],
+    pub(crate) trim_end: [[AtomicU64; CLIP_ROW_COUNT]; CLIP_COLUMN_COUNT],
+    pub(crate) active_row: [AtomicI32; CLIP_COLUMN_COUNT],
+    pub(crate) queued_row: [AtomicI32; CLIP_COLUMN_COUNT],
+    pub(crate) stop_queued: [AtomicBool; CLIP_COLUMN_COUNT],
+    pub(crate) scheduled_beat: [AtomicU64; CLIP_COLUMN_COUNT],
+    pub(crate) active_playhead: [AtomicU64; CLIP_COLUMN_COUNT],
+    pub(crate) transport_beat: AtomicU64,
+}
+
+impl MixerSnapshot {
+    pub(crate) fn new() -> Self {
+        Self {
+            generation: AtomicU64::new(0),
+            loop_position: std::array::from_fn(|_| AtomicU32::new(0)),
+            loop_source_bpm: std::array::from_fn(|_| AtomicU32::new(0)),
+            loop_pitch_mode: std::array::from_fn(|_| AtomicU32::new(0)),
+            swaps_completed: std::array::from_fn(|_| AtomicU32::new(0)),
+            default_quantization: AtomicU32::new(2),
+            slot_state: std::array::from_fn(|_| std::array::from_fn(|_| AtomicU32::new(0))),
+            trim_start: std::array::from_fn(|_| {
+                std::array::from_fn(|_| AtomicU64::new((-1.0_f64).to_bits()))
+            }),
+            trim_end: std::array::from_fn(|_| {
+                std::array::from_fn(|_| AtomicU64::new((-1.0_f64).to_bits()))
+            }),
+            active_row: std::array::from_fn(|_| AtomicI32::new(-1)),
+            queued_row: std::array::from_fn(|_| AtomicI32::new(-1)),
+            stop_queued: std::array::from_fn(|_| AtomicBool::new(false)),
+            scheduled_beat: std::array::from_fn(|_| AtomicU64::new((-1.0_f64).to_bits())),
+            active_playhead: std::array::from_fn(|_| AtomicU64::new((-1.0_f64).to_bits())),
+            transport_beat: AtomicU64::new(0.0_f64.to_bits()),
+        }
+    }
+
+    pub(crate) fn begin_write(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+    }
+
+    pub(crate) fn finish_write(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+    }
+
+    fn read<T: Copy>(&self, value: impl Fn() -> T) -> T {
+        loop {
+            let before = self.generation.load(Ordering::Acquire);
+            if before & 1 != 0 {
+                continue;
+            }
+            let result = value();
+            let after = self.generation.load(Ordering::Acquire);
+            if before == after {
+                return result;
+            }
+        }
+    }
+
+    pub(crate) fn position(&self, channel: usize) -> f32 {
+        self.read(|| {
+            self.loop_position
+                .get(channel)
+                .map_or(0.0, |v| f32::from_bits(v.load(Ordering::Relaxed)))
+        })
+    }
+    pub(crate) fn source_bpm(&self, channel: usize) -> f32 {
+        self.read(|| {
+            self.loop_source_bpm
+                .get(channel)
+                .map_or(0.0, |v| f32::from_bits(v.load(Ordering::Relaxed)))
+        })
+    }
+    pub(crate) fn pitch_mode(&self, channel: usize) -> PitchMode {
+        self.read(|| {
+            match self
+                .loop_pitch_mode
+                .get(channel)
+                .map_or(0, |v| v.load(Ordering::Relaxed))
+            {
+                1 => PitchMode::Resample,
+                2 => PitchMode::PreservePitch,
+                _ => PitchMode::Off,
+            }
+        })
+    }
+    pub(crate) fn swaps_completed(&self, channel: usize) -> u32 {
+        self.read(|| {
+            self.swaps_completed
+                .get(channel)
+                .map_or(0, |v| v.load(Ordering::Relaxed))
+        })
+    }
+    pub(crate) fn default_quantization(&self) -> u32 {
+        self.read(|| self.default_quantization.load(Ordering::Relaxed))
+    }
+    pub(crate) fn slot_state(&self, column: usize, row: usize) -> u32 {
+        self.read(|| {
+            self.slot_state
+                .get(column)
+                .and_then(|c| c.get(row))
+                .map_or(0, |v| v.load(Ordering::Relaxed))
+        })
+    }
+    pub(crate) fn active_row(&self, column: usize) -> i32 {
+        self.read(|| {
+            self.active_row
+                .get(column)
+                .map_or(-1, |v| v.load(Ordering::Relaxed))
+        })
+    }
+    pub(crate) fn queued_row(&self, column: usize) -> i32 {
+        self.read(|| {
+            self.queued_row
+                .get(column)
+                .map_or(-1, |v| v.load(Ordering::Relaxed))
+        })
+    }
+    pub(crate) fn stop_queued(&self, column: usize) -> bool {
+        self.read(|| {
+            self.stop_queued
+                .get(column)
+                .is_some_and(|v| v.load(Ordering::Relaxed))
+        })
+    }
+    pub(crate) fn scheduled_beat(&self, column: usize) -> f64 {
+        self.read(|| {
+            self.scheduled_beat
+                .get(column)
+                .map_or(-1.0, |v| f64::from_bits(v.load(Ordering::Relaxed)))
+        })
+    }
+    pub(crate) fn active_playhead(&self, column: usize) -> f64 {
+        self.read(|| {
+            self.active_playhead
+                .get(column)
+                .map_or(-1.0, |v| f64::from_bits(v.load(Ordering::Relaxed)))
+        })
+    }
+    pub(crate) fn trim_start(&self, column: usize, row: usize) -> f64 {
+        self.read(|| {
+            self.trim_start
+                .get(column)
+                .and_then(|c| c.get(row))
+                .map_or(-1.0, |v| f64::from_bits(v.load(Ordering::Relaxed)))
+        })
+    }
+    pub(crate) fn trim_end(&self, column: usize, row: usize) -> f64 {
+        self.read(|| {
+            self.trim_end
+                .get(column)
+                .and_then(|c| c.get(row))
+                .map_or(-1.0, |v| f64::from_bits(v.load(Ordering::Relaxed)))
+        })
+    }
+    pub(crate) fn transport_beat(&self) -> f64 {
+        self.read(|| f64::from_bits(self.transport_beat.load(Ordering::Relaxed)))
+    }
+}
+
+pub(crate) struct SharedControl {
+    queue: Mutex<QueueState>,
+    pub(crate) has_commands: AtomicBool,
+    pub(crate) snapshot: MixerSnapshot,
+}
+
+/// Cloneable, thread-safe control endpoint. It intentionally contains no live
+/// channel or grid state.
+#[derive(Clone)]
+pub struct MixerControl {
+    pub(crate) shared: Arc<SharedControl>,
+}
+
+impl MixerControl {
+    pub(crate) fn new() -> Self {
+        Self {
+            shared: Arc::new(SharedControl {
+                queue: Mutex::new(QueueState::default()),
+                has_commands: AtomicBool::new(false),
+                snapshot: MixerSnapshot::new(),
+            }),
+        }
+    }
+
+    pub(crate) fn enqueue(&self, command: MixerCommand) -> bool {
+        let Ok(mut state) = self.shared.queue.lock() else {
+            return false;
+        };
+        if state.commands.len() >= MAX_QUEUED_COMMANDS {
+            return false;
+        }
+        state.commands.push_back(command);
+        self.shared.has_commands.store(true, Ordering::Release);
+        true
+    }
+
+    pub fn load(&self, channel: usize, buffer: StereoSampleBuffer) -> bool {
+        self.enqueue(MixerCommand::Load { channel, buffer })
+    }
+    pub fn set_playing(&self, channel: usize, playing: bool) -> bool {
+        self.enqueue(MixerCommand::SetPlaying { channel, playing })
+    }
+    pub fn set_gain(&self, channel: usize, gain: f32) -> bool {
+        self.enqueue(MixerCommand::SetGain { channel, gain })
+    }
+    pub fn set_muted(&self, channel: usize, muted: bool) -> bool {
+        self.enqueue(MixerCommand::SetMuted { channel, muted })
+    }
+    pub fn set_soloed(&self, channel: usize, soloed: bool) -> bool {
+        self.enqueue(MixerCommand::SetSoloed { channel, soloed })
+    }
+    pub fn set_loop_start(&self, channel: usize, value: f32) -> bool {
+        self.enqueue(MixerCommand::SetLoopStart { channel, value })
+    }
+    pub fn set_loop_end(&self, channel: usize, value: f32) -> bool {
+        self.enqueue(MixerCommand::SetLoopEnd { channel, value })
+    }
+    pub fn set_speed(&self, channel: usize, speed: f32) -> bool {
+        self.enqueue(MixerCommand::SetSpeed { channel, speed })
+    }
+    pub fn set_source_bpm(&self, channel: usize, bpm: Option<f32>) -> bool {
+        self.enqueue(MixerCommand::SetSourceBpm { channel, bpm })
+    }
+    pub fn set_pitch_mode(&self, channel: usize, mode: PitchMode) -> bool {
+        self.enqueue(MixerCommand::SetPitchMode { channel, mode })
+    }
+    pub fn restart(&self, channel: usize) -> bool {
+        self.enqueue(MixerCommand::Restart { channel })
+    }
+    pub fn set_position(&self, channel: usize, value: f32) -> bool {
+        self.enqueue(MixerCommand::SetPosition { channel, value })
+    }
+    pub fn queue_swap(&self, channel: usize, buffer: StereoSampleBuffer, divisions: u32) -> bool {
+        self.enqueue(MixerCommand::QueueSwap {
+            channel,
+            buffer,
+            divisions,
+        })
+    }
+    pub fn cancel_queued_swap(&self, channel: usize) -> bool {
+        self.enqueue(MixerCommand::CancelQueuedSwap { channel })
+    }
+    pub fn set_bpm(&self, bpm: f32) -> bool {
+        self.enqueue(MixerCommand::SetBpm { bpm })
+    }
+    pub fn clip_load(
+        &self,
+        column: usize,
+        row: usize,
+        buffer: StereoSampleBuffer,
+        source_bpm: f32,
+    ) -> bool {
+        self.enqueue(MixerCommand::ClipLoad {
+            column,
+            row,
+            buffer,
+            source_bpm,
+        })
+    }
+    pub fn clip_unload(&self, column: usize, row: usize) -> bool {
+        self.enqueue(MixerCommand::ClipUnload { column, row })
+    }
+    pub fn clip_clear(&self) -> bool {
+        self.enqueue(MixerCommand::ClipClear)
+    }
+    pub fn clip_launch(&self, column: usize, row: usize, quantization: LaunchQuantization) -> bool {
+        self.enqueue(MixerCommand::ClipLaunch {
+            column,
+            row,
+            quantization,
+        })
+    }
+    pub fn clip_launch_at(&self, column: usize, row: usize, beat: f64) -> bool {
+        if !beat.is_finite() || beat + 1.0e-9 < self.snapshot().transport_beat() {
+            return false;
+        }
+        self.enqueue(MixerCommand::ClipLaunchAt { column, row, beat })
+    }
+    pub fn clip_launch_scene(&self, row: usize, quantization: LaunchQuantization) -> bool {
+        self.enqueue(MixerCommand::ClipLaunchScene { row, quantization })
+    }
+    pub fn clip_launch_scene_at(&self, row: usize, beat: f64) -> bool {
+        if !beat.is_finite() || beat + 1.0e-9 < self.snapshot().transport_beat() {
+            return false;
+        }
+        self.enqueue(MixerCommand::ClipLaunchSceneAt { row, beat })
+    }
+    pub fn clip_stop(&self, column: usize, quantization: LaunchQuantization) -> bool {
+        self.enqueue(MixerCommand::ClipStop {
+            column,
+            quantization,
+        })
+    }
+    pub fn clip_stop_at(&self, column: usize, beat: f64) -> bool {
+        if !beat.is_finite() || beat + 1.0e-9 < self.snapshot().transport_beat() {
+            return false;
+        }
+        self.enqueue(MixerCommand::ClipStopAt { column, beat })
+    }
+    pub fn clip_cancel(&self, column: usize) -> bool {
+        self.enqueue(MixerCommand::ClipCancel { column })
+    }
+    pub fn clip_cancel_all(&self) -> bool {
+        self.enqueue(MixerCommand::ClipCancelAll)
+    }
+    pub fn clip_set_default_quantization(&self, quantization: LaunchQuantization) -> bool {
+        self.enqueue(MixerCommand::ClipSetDefaultQuantization { quantization })
+    }
+    pub fn clip_set_trim(
+        &self,
+        column: usize,
+        row: usize,
+        start: f64,
+        end: f64,
+        timing: RetrimTiming,
+    ) -> bool {
+        self.enqueue(MixerCommand::ClipSetTrim {
+            column,
+            row,
+            start,
+            end,
+            timing,
+        })
+    }
+    pub fn transport_start(&self) -> bool {
+        self.enqueue(MixerCommand::TransportStart)
+    }
+    pub fn transport_stop(&self) -> bool {
+        self.enqueue(MixerCommand::TransportStop)
+    }
+    pub fn transport_seek(&self, beat: f64) -> bool {
+        self.enqueue(MixerCommand::TransportSeek { beat })
+    }
+    pub fn transport_reset(&self) -> bool {
+        self.enqueue(MixerCommand::TransportReset)
+    }
+
+    pub fn effect_add(&self, channel: usize, effect_id: u32) -> Option<usize> {
+        if channel >= LOOP_CHANNEL_COUNT || !ChannelEffect::is_valid_id(effect_id) {
+            return None;
+        }
+        let Ok(mut state) = self.shared.queue.lock() else {
+            return None;
+        };
+        if state.commands.len() >= MAX_QUEUED_COMMANDS {
+            return None;
+        }
+        let slot = state.effect_layouts[channel].len();
+        state.effect_layouts[channel].push(effect_id);
+        state
+            .commands
+            .push_back(MixerCommand::EffectAdd { channel, effect_id });
+        self.shared.has_commands.store(true, Ordering::Release);
+        Some(slot)
+    }
+
+    pub fn effect_remove(&self, channel: usize, slot: usize) -> bool {
+        let Ok(mut state) = self.shared.queue.lock() else {
+            return false;
+        };
+        if state.commands.len() >= MAX_QUEUED_COMMANDS {
+            return false;
+        }
+        let Some(layout) = state.effect_layouts.get_mut(channel) else {
+            return false;
+        };
+        if slot >= layout.len() {
+            return false;
+        }
+        layout.remove(slot);
+        state
+            .commands
+            .push_back(MixerCommand::EffectRemove { channel, slot });
+        self.shared.has_commands.store(true, Ordering::Release);
+        true
+    }
+    pub fn effect_move(&self, channel: usize, slot: usize, new_position: usize) -> bool {
+        let Ok(mut state) = self.shared.queue.lock() else {
+            return false;
+        };
+        if state.commands.len() >= MAX_QUEUED_COMMANDS {
+            return false;
+        }
+        let Some(layout) = state.effect_layouts.get_mut(channel) else {
+            return false;
+        };
+        if slot >= layout.len() {
+            return false;
+        }
+        let effect = layout.remove(slot);
+        layout.insert(new_position.min(layout.len()), effect);
+        state.commands.push_back(MixerCommand::EffectMove {
+            channel,
+            slot,
+            new_position,
+        });
+        self.shared.has_commands.store(true, Ordering::Release);
+        true
+    }
+    pub fn effect_clear(&self, channel: usize) -> bool {
+        let Ok(mut state) = self.shared.queue.lock() else {
+            return false;
+        };
+        if state.commands.len() >= MAX_QUEUED_COMMANDS {
+            return false;
+        }
+        let Some(layout) = state.effect_layouts.get_mut(channel) else {
+            return false;
+        };
+        layout.clear();
+        state
+            .commands
+            .push_back(MixerCommand::EffectClear { channel });
+        self.shared.has_commands.store(true, Ordering::Release);
+        true
+    }
+    pub fn effect_set_param(&self, channel: usize, slot: usize, param: u32, value: f32) -> bool {
+        let Ok(mut state) = self.shared.queue.lock() else {
+            return false;
+        };
+        if state
+            .effect_layouts
+            .get(channel)
+            .is_none_or(|l| slot >= l.len())
+            || state.commands.len() >= MAX_QUEUED_COMMANDS
+        {
+            return false;
+        }
+        state.commands.push_back(MixerCommand::EffectSetParam {
+            channel,
+            slot,
+            param,
+            value,
+        });
+        self.shared.has_commands.store(true, Ordering::Release);
+        true
+    }
+    pub fn effect_count(&self, channel: usize) -> usize {
+        self.shared
+            .queue
+            .lock()
+            .ok()
+            .and_then(|s| s.effect_layouts.get(channel).map(Vec::len))
+            .unwrap_or(0)
+    }
+    pub fn effect_type_at(&self, channel: usize, slot: usize) -> Option<u32> {
+        self.shared.queue.lock().ok().and_then(|s| {
+            s.effect_layouts
+                .get(channel)
+                .and_then(|l| l.get(slot))
+                .copied()
+        })
+    }
+
+    pub fn position(&self, channel: usize) -> f32 {
+        self.shared.snapshot.position(channel)
+    }
+    pub fn source_bpm(&self, channel: usize) -> f32 {
+        self.shared.snapshot.source_bpm(channel)
+    }
+    pub fn pitch_mode(&self, channel: usize) -> PitchMode {
+        self.shared.snapshot.pitch_mode(channel)
+    }
+    pub fn swaps_completed(&self, channel: usize) -> u32 {
+        self.shared.snapshot.swaps_completed(channel)
+    }
+    pub fn clip_default_quantization(&self) -> u32 {
+        self.shared.snapshot.default_quantization()
+    }
+    pub fn clip_slot_state(&self, column: usize, row: usize) -> u32 {
+        self.shared.snapshot.slot_state(column, row)
+    }
+    pub fn clip_active_row(&self, column: usize) -> i32 {
+        self.shared.snapshot.active_row(column)
+    }
+    pub fn clip_queued_row(&self, column: usize) -> i32 {
+        self.shared.snapshot.queued_row(column)
+    }
+    pub fn clip_stop_queued(&self, column: usize) -> bool {
+        self.shared.snapshot.stop_queued(column)
+    }
+    pub fn clip_scheduled_beat(&self, column: usize) -> f64 {
+        self.shared.snapshot.scheduled_beat(column)
+    }
+    pub fn clip_active_playhead(&self, column: usize) -> f64 {
+        self.shared.snapshot.active_playhead(column)
+    }
+    pub fn clip_trim_start(&self, column: usize, row: usize) -> f64 {
+        self.shared.snapshot.trim_start(column, row)
+    }
+    pub fn clip_trim_end(&self, column: usize, row: usize) -> f64 {
+        self.shared.snapshot.trim_end(column, row)
+    }
+    pub fn transport_beat(&self) -> f64 {
+        self.shared.snapshot.transport_beat()
+    }
+
+    pub(crate) fn drain_into(&self, scratch: &mut VecDeque<MixerCommand>) {
+        if !self.shared.has_commands.load(Ordering::Acquire) {
+            return;
+        }
+        let Ok(mut state) = self.shared.queue.try_lock() else {
+            return;
+        };
+        for _ in 0..MAX_COMMANDS_PER_TICK {
+            let Some(command) = state.commands.pop_front() else {
+                break;
+            };
+            scratch.push_back(command);
+        }
+        self.shared
+            .has_commands
+            .store(!state.commands.is_empty(), Ordering::Release);
+    }
+
+    pub(crate) fn has_pending(&self) -> bool {
+        self.shared.has_commands.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn snapshot(&self) -> &MixerSnapshot {
+        &self.shared.snapshot
+    }
+}

--- a/src/mixer/control.rs
+++ b/src/mixer/control.rs
@@ -8,15 +8,15 @@ use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use super::{
-    ChannelEffect, LaunchQuantization, PitchMode, RetrimTiming, StereoSampleBuffer,
-    CLIP_COLUMN_COUNT, CLIP_ROW_COUNT, LOOP_CHANNEL_COUNT,
+    loop_channel::RetiredLoopState, ChannelEffect, LaunchQuantization, PitchMode, RetrimTiming,
+    StereoSampleBuffer, CLIP_COLUMN_COUNT, CLIP_ROW_COUNT, LOOP_CHANNEL_COUNT,
 };
 
 /// Maximum number of control operations the audio thread applies in one sample.
 /// This bounds command work during a producer burst; remaining operations keep
 /// their FIFO order for the following samples.
 pub(crate) const MAX_COMMANDS_PER_TICK: usize = 64;
-const MAX_QUEUED_COMMANDS: usize = 4096;
+pub(crate) const MAX_QUEUED_COMMANDS: usize = 4096;
 
 /// A control operation which can mutate mixer state. These values are built on
 /// host/control threads and consumed only by the audio thread.
@@ -160,19 +160,41 @@ pub(crate) enum MixerCommand {
     },
 }
 
+impl MixerCommand {
+    fn changes_clip_slot_presence(&self) -> bool {
+        matches!(
+            self,
+            Self::ClipLoad { .. } | Self::ClipUnload { .. } | Self::ClipClear
+        )
+    }
+}
+
 struct QueueState {
     commands: VecDeque<MixerCommand>,
+    /// Control-side projection of loaded slots. This preserves immediate FFI
+    /// admission results for commands that have not reached the audio thread.
+    clip_slots: [[bool; CLIP_ROW_COUNT]; CLIP_COLUMN_COUNT],
+    /// Generation of the snapshot used to build `clip_slots`. A new completed
+    /// render buffer refreshes the projection only after all queued clip work
+    /// has drained, so an audio/control race cannot erase just-queued intent.
+    clip_snapshot_generation: u64,
     /// Desired effect layouts, updated under the same lock that establishes
     /// command order. This lets callers queue `add` then `set_param` before a
     /// render boundary without reading the live effect `Vec`.
     effect_layouts: [Vec<u32>; LOOP_CHANNEL_COUNT],
+    /// State retired by the audio thread. This vector is only dropped after a
+    /// producer releases the queue lock, never by the render callback.
+    retired: Vec<RetiredLoopState>,
 }
 
 impl Default for QueueState {
     fn default() -> Self {
         Self {
-            commands: VecDeque::new(),
+            commands: VecDeque::with_capacity(MAX_QUEUED_COMMANDS),
+            clip_slots: [[false; CLIP_ROW_COUNT]; CLIP_COLUMN_COUNT],
+            clip_snapshot_generation: u64::MAX,
             effect_layouts: std::array::from_fn(|_| Vec::new()),
+            retired: Vec::with_capacity(MAX_QUEUED_COMMANDS),
         }
     }
 }
@@ -342,6 +364,24 @@ impl MixerSnapshot {
     pub(crate) fn transport_beat(&self) -> f64 {
         self.read(|| f64::from_bits(self.transport_beat.load(Ordering::Relaxed)))
     }
+
+    fn clip_slots_with_generation(&self) -> ([[bool; CLIP_ROW_COUNT]; CLIP_COLUMN_COUNT], u64) {
+        loop {
+            let before = self.generation.load(Ordering::Acquire);
+            if before & 1 != 0 {
+                continue;
+            }
+            let slots = std::array::from_fn(|column| {
+                std::array::from_fn(|row| {
+                    self.slot_state[column][row].load(Ordering::Relaxed) & 1 != 0
+                })
+            });
+            let after = self.generation.load(Ordering::Acquire);
+            if before == after {
+                return (slots, before);
+            }
+        }
+    }
 }
 
 pub(crate) struct SharedControl {
@@ -369,15 +409,60 @@ impl MixerControl {
     }
 
     pub(crate) fn enqueue(&self, command: MixerCommand) -> bool {
-        let Ok(mut state) = self.shared.queue.lock() else {
-            return false;
+        let retired = {
+            let Ok(mut state) = self.shared.queue.lock() else {
+                return false;
+            };
+            if state.commands.len() >= MAX_QUEUED_COMMANDS {
+                return false;
+            }
+            state.commands.push_back(command);
+            self.shared.has_commands.store(true, Ordering::Release);
+            Self::take_retired(&mut state)
         };
-        if state.commands.len() >= MAX_QUEUED_COMMANDS {
-            return false;
-        }
-        state.commands.push_back(command);
-        self.shared.has_commands.store(true, Ordering::Release);
+        drop(retired);
         true
+    }
+
+    fn take_retired(state: &mut QueueState) -> Option<Vec<RetiredLoopState>> {
+        (!state.retired.is_empty())
+            .then(|| std::mem::replace(&mut state.retired, Vec::with_capacity(MAX_QUEUED_COMMANDS)))
+    }
+
+    fn enqueue_clip(
+        &self,
+        command: MixerCommand,
+        update: impl FnOnce(&mut [[bool; CLIP_ROW_COUNT]; CLIP_COLUMN_COUNT]) -> bool,
+    ) -> bool {
+        let retired = {
+            let Ok(mut state) = self.shared.queue.lock() else {
+                return false;
+            };
+            self.refresh_clip_projection(&mut state);
+            if state.commands.len() >= MAX_QUEUED_COMMANDS || !update(&mut state.clip_slots) {
+                return false;
+            }
+            state.commands.push_back(command);
+            self.shared.has_commands.store(true, Ordering::Release);
+            Self::take_retired(&mut state)
+        };
+        drop(retired);
+        true
+    }
+
+    fn refresh_clip_projection(&self, state: &mut QueueState) {
+        if state
+            .commands
+            .iter()
+            .any(MixerCommand::changes_clip_slot_presence)
+        {
+            return;
+        }
+        let (slots, generation) = self.snapshot().clip_slots_with_generation();
+        if generation != state.clip_snapshot_generation {
+            state.clip_slots = slots;
+            state.clip_snapshot_generation = generation;
+        }
     }
 
     pub fn load(&self, channel: usize, buffer: StereoSampleBuffer) -> bool {
@@ -436,31 +521,69 @@ impl MixerControl {
         buffer: StereoSampleBuffer,
         source_bpm: f32,
     ) -> bool {
-        self.enqueue(MixerCommand::ClipLoad {
-            column,
-            row,
-            buffer,
-            source_bpm,
-        })
+        if column >= CLIP_COLUMN_COUNT
+            || row >= CLIP_ROW_COUNT
+            || buffer.is_empty()
+            || !source_bpm.is_finite()
+            || source_bpm <= 0.0
+        {
+            return false;
+        }
+        self.enqueue_clip(
+            MixerCommand::ClipLoad {
+                column,
+                row,
+                buffer,
+                source_bpm,
+            },
+            move |slots| {
+                slots[column][row] = true;
+                true
+            },
+        )
     }
     pub fn clip_unload(&self, column: usize, row: usize) -> bool {
-        self.enqueue(MixerCommand::ClipUnload { column, row })
+        if column >= CLIP_COLUMN_COUNT || row >= CLIP_ROW_COUNT {
+            return false;
+        }
+        self.enqueue_clip(MixerCommand::ClipUnload { column, row }, move |slots| {
+            if !slots[column][row] {
+                return false;
+            }
+            slots[column][row] = false;
+            true
+        })
     }
     pub fn clip_clear(&self) -> bool {
-        self.enqueue(MixerCommand::ClipClear)
+        self.enqueue_clip(MixerCommand::ClipClear, |slots| {
+            *slots = [[false; CLIP_ROW_COUNT]; CLIP_COLUMN_COUNT];
+            true
+        })
     }
     pub fn clip_launch(&self, column: usize, row: usize, quantization: LaunchQuantization) -> bool {
-        self.enqueue(MixerCommand::ClipLaunch {
-            column,
-            row,
-            quantization,
-        })
+        if column >= CLIP_COLUMN_COUNT || row >= CLIP_ROW_COUNT {
+            return false;
+        }
+        self.enqueue_clip(
+            MixerCommand::ClipLaunch {
+                column,
+                row,
+                quantization,
+            },
+            move |slots| slots[column][row],
+        )
     }
     pub fn clip_launch_at(&self, column: usize, row: usize, beat: f64) -> bool {
         if !beat.is_finite() || beat + 1.0e-9 < self.snapshot().transport_beat() {
             return false;
         }
-        self.enqueue(MixerCommand::ClipLaunchAt { column, row, beat })
+        if column >= CLIP_COLUMN_COUNT || row >= CLIP_ROW_COUNT {
+            return false;
+        }
+        self.enqueue_clip(
+            MixerCommand::ClipLaunchAt { column, row, beat },
+            move |slots| slots[column][row],
+        )
     }
     pub fn clip_launch_scene(&self, row: usize, quantization: LaunchQuantization) -> bool {
         self.enqueue(MixerCommand::ClipLaunchScene { row, quantization })
@@ -500,13 +623,19 @@ impl MixerControl {
         end: f64,
         timing: RetrimTiming,
     ) -> bool {
-        self.enqueue(MixerCommand::ClipSetTrim {
-            column,
-            row,
-            start,
-            end,
-            timing,
-        })
+        if column >= CLIP_COLUMN_COUNT || row >= CLIP_ROW_COUNT {
+            return false;
+        }
+        self.enqueue_clip(
+            MixerCommand::ClipSetTrim {
+                column,
+                row,
+                start,
+                end,
+                timing,
+            },
+            move |slots| slots[column][row],
+        )
     }
     pub fn transport_start(&self) -> bool {
         self.enqueue(MixerCommand::TransportStart)
@@ -697,6 +826,19 @@ impl MixerControl {
         self.shared
             .has_commands
             .store(!state.commands.is_empty(), Ordering::Release);
+    }
+
+    /// Move audio-retired state into the producer-owned queue without blocking
+    /// the render callback. If the control lock is busy, the mixer retains it
+    /// in preallocated audio-owned storage for a later boundary.
+    pub(crate) fn reclaim_from_audio(&self, retired: &mut Vec<RetiredLoopState>) {
+        if retired.is_empty() {
+            return;
+        }
+        let Ok(mut state) = self.shared.queue.try_lock() else {
+            return;
+        };
+        state.retired.append(retired);
     }
 
     pub(crate) fn has_pending(&self) -> bool {

--- a/src/mixer/effect_chain.rs
+++ b/src/mixer/effect_chain.rs
@@ -108,6 +108,25 @@ impl ChannelEffect {
         }
     }
 
+    /// Whether `effect_id` names a valid per-channel effect (i.e. one that
+    /// [`Self::from_id`] would accept). Lets the FFI validate an add request
+    /// synchronously before deferring the actual chain mutation to the audio
+    /// thread, without constructing the effect.
+    pub fn is_valid_id(effect_id: u32) -> bool {
+        matches!(
+            effect_id,
+            EFFECT_LOWPASS_FILTER
+                | EFFECT_DELAY
+                | EFFECT_SATURATION
+                | EFFECT_COMPRESSOR
+                | EFFECT_TILT_FILTER
+                | EFFECT_REVERB
+                | EFFECT_PLATE_REVERB
+                | EFFECT_WAVESHAPER
+                | EFFECT_FEEDBACK_WAVESHAPER
+        )
+    }
+
     /// The `EFFECT_*` id for this effect.
     pub fn effect_type(&self) -> u32 {
         match self {

--- a/src/mixer/loop_channel.rs
+++ b/src/mixer/loop_channel.rs
@@ -149,6 +149,24 @@ pub struct LoopChannel {
     swaps_completed: AtomicU32,
 }
 
+/// Loop state removed by the audio thread and handed back to the control side
+/// for destruction. Dropping either a large sample buffer or a WSOLA instance
+/// can free heap storage, so realtime replacement paths must not drop them.
+pub(crate) struct RetiredLoopState {
+    buffer: Option<StereoSampleBuffer>,
+    stretcher: Option<WsolaStretcher>,
+}
+
+impl RetiredLoopState {
+    fn new(buffer: Option<StereoSampleBuffer>, stretcher: Option<WsolaStretcher>) -> Self {
+        Self { buffer, stretcher }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.buffer.is_none() && self.stretcher.is_none()
+    }
+}
+
 impl LoopChannel {
     pub fn new(sample_rate: f32) -> Self {
         Self {
@@ -389,6 +407,22 @@ impl LoopChannel {
         self.buffer = Some(buffer);
         self.cursor = self.window(len).lo;
         self.stretcher = None;
+    }
+
+    /// Realtime counterpart to [`Self::set_buffer`]. Removed data is retained
+    /// instead of dropped so the mixer can transfer it to a control thread for
+    /// heap reclamation after this render boundary.
+    pub(crate) fn set_buffer_realtime(
+        &mut self,
+        buffer: StereoSampleBuffer,
+        retired: &mut Vec<RetiredLoopState>,
+    ) {
+        let len = buffer.len() as f64;
+        let previous = RetiredLoopState::new(self.buffer.replace(buffer), self.stretcher.take());
+        if !previous.is_empty() {
+            retired.push(previous);
+        }
+        self.cursor = self.window(len).lo;
     }
 
     /// Drop the active sample buffer and reset playback state while preserving

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -31,6 +31,7 @@ pub use stereo_buffer::StereoSampleBuffer;
 use std::collections::VecDeque;
 
 use crate::frame::StereoFrame;
+use crate::mixer::loop_channel::RetiredLoopState;
 
 /// Number of loop channels in the mixer.
 pub const LOOP_CHANNEL_COUNT: usize = 4;
@@ -48,6 +49,9 @@ pub struct Mixer {
     /// Audio-thread-owned scratch. Commands are moved here before application,
     /// so producer threads never hold the queue lock while DSP state changes.
     command_scratch: VecDeque<MixerCommand>,
+    /// Replaced buffers and WSOLA state retained until they can be handed to a
+    /// producer thread for reclamation. Capacity is fixed before rendering.
+    retired: Vec<RetiredLoopState>,
 }
 
 impl Mixer {
@@ -62,7 +66,8 @@ impl Mixer {
             sample_rate,
             bpm: DEFAULT_BPM,
             control: MixerControl::new(),
-            command_scratch: VecDeque::new(),
+            command_scratch: VecDeque::with_capacity(control::MAX_COMMANDS_PER_TICK),
+            retired: Vec::with_capacity(control::MAX_QUEUED_COMMANDS),
         }
     }
 
@@ -77,10 +82,12 @@ impl Mixer {
     /// to the next tick, exactly like `LoopChannel::maybe_swap_pending`.
     fn apply_pending(&mut self) {
         let control = self.control.clone();
+        control.reclaim_from_audio(&mut self.retired);
         control.drain_into(&mut self.command_scratch);
         while let Some(command) = self.command_scratch.pop_front() {
             self.apply(command);
         }
+        control.reclaim_from_audio(&mut self.retired);
     }
 
     /// Apply one bounded batch at a render-buffer boundary. The FFI render path
@@ -215,8 +222,14 @@ impl Mixer {
             out += channel.tick(engine_sample_rate);
         }
         self.clip_grid.after_tick();
-        self.publish_snapshot();
         out
+    }
+
+    /// Publish the last completed render-buffer state for control/UI getters.
+    /// FFI rendering calls this once per buffer; a silent buffer is covered by
+    /// [`Self::apply_control_commands`] at its start.
+    pub(crate) fn publish_control_snapshot(&self) {
+        self.publish_snapshot();
     }
 
     fn publish_snapshot(&self) {
@@ -330,7 +343,7 @@ impl Mixer {
         self.clip_grid.detach_column(channel);
         match self.channels.get_mut(channel) {
             Some(ch) => {
-                ch.set_buffer(buffer);
+                ch.set_buffer_realtime(buffer, &mut self.retired);
                 true
             }
             None => false,
@@ -772,7 +785,7 @@ mod tests {
     }
 
     #[test]
-    fn control_snapshot_is_published_after_audio_tick() {
+    fn control_snapshot_is_published_after_render_boundary() {
         let mut mixer = Mixer::new(SR);
         let control = mixer.control();
         assert!(control.load(0, dc_buffer(0.5, 128)));
@@ -784,6 +797,7 @@ mod tests {
             "snapshot precedes audio application"
         );
         mixer.tick(SR);
+        mixer.publish_control_snapshot();
         assert_eq!(control.source_bpm(0), 123.0);
         assert_eq!(control.pitch_mode(0), PitchMode::PreservePitch);
         assert!(control.position(0).is_finite());
@@ -796,6 +810,7 @@ mod tests {
         assert!(control.clip_load(0, 0, dc_buffer(0.5, 128), 120.0));
         assert_eq!(control.clip_slot_state(0, 0), 0);
         mixer.tick(SR);
+        mixer.publish_control_snapshot();
         assert_eq!(control.clip_slot_state(0, 0), CLIP_STATE_LOADED);
     }
 

--- a/src/mixer/mod.rs
+++ b/src/mixer/mod.rs
@@ -9,6 +9,7 @@
 //! engine adds to its master bus before the global effects + limiter.
 
 pub mod clip_grid;
+mod control;
 pub mod effect_chain;
 pub mod graph;
 pub mod loop_channel;
@@ -20,10 +21,14 @@ pub use clip_grid::{
     CLIP_QUANTIZE_IMMEDIATE, CLIP_QUANTIZE_QUARTER, CLIP_QUANTIZE_SIXTEENTH, CLIP_ROW_COUNT,
     CLIP_STATE_LOADED, CLIP_STATE_PLAYING, CLIP_STATE_QUEUED,
 };
+pub(crate) use control::MixerCommand;
+pub use control::MixerControl;
 pub use effect_chain::{ChannelEffect, EffectChain};
 pub use graph::MixerGraph;
 pub use loop_channel::{LoopChannel, PitchMode};
 pub use stereo_buffer::StereoSampleBuffer;
+
+use std::collections::VecDeque;
 
 use crate::frame::StereoFrame;
 
@@ -39,6 +44,10 @@ pub struct Mixer {
     clip_grid: ClipGrid,
     sample_rate: f32,
     bpm: f32,
+    control: MixerControl,
+    /// Audio-thread-owned scratch. Commands are moved here before application,
+    /// so producer threads never hold the queue lock while DSP state changes.
+    command_scratch: VecDeque<MixerCommand>,
 }
 
 impl Mixer {
@@ -52,12 +61,147 @@ impl Mixer {
             clip_grid: ClipGrid::new(sample_rate, DEFAULT_BPM),
             sample_rate,
             bpm: DEFAULT_BPM,
+            control: MixerControl::new(),
+            command_scratch: VecDeque::new(),
+        }
+    }
+
+    /// A cloneable, thread-safe endpoint for host/UI control and inspection.
+    pub fn control(&self) -> MixerControl {
+        self.control.clone()
+    }
+
+    /// Drain and apply any queued control-thread commands. Called first thing in
+    /// [`Self::tick`], so all mixer mutation happens on the audio thread. Uses
+    /// `try_lock` (never blocks the audio thread): a missed lock defers the batch
+    /// to the next tick, exactly like `LoopChannel::maybe_swap_pending`.
+    fn apply_pending(&mut self) {
+        let control = self.control.clone();
+        control.drain_into(&mut self.command_scratch);
+        while let Some(command) = self.command_scratch.pop_front() {
+            self.apply(command);
+        }
+    }
+
+    /// Apply one bounded batch at a render-buffer boundary. The FFI render path
+    /// calls this before scheduled transport starts so queued control ordering
+    /// remains deterministic even when a buffer is otherwise silent.
+    pub(crate) fn apply_control_commands(&mut self) {
+        self.apply_pending();
+        self.publish_snapshot();
+    }
+
+    fn apply(&mut self, command: MixerCommand) {
+        match command {
+            MixerCommand::Load { channel, buffer } => {
+                self.load(channel, buffer);
+            }
+            MixerCommand::SetPlaying { channel, playing } => self.set_playing(channel, playing),
+            MixerCommand::SetGain { channel, gain } => self.set_gain(channel, gain),
+            MixerCommand::SetMuted { channel, muted } => self.set_muted(channel, muted),
+            MixerCommand::SetSoloed { channel, soloed } => self.set_soloed(channel, soloed),
+            MixerCommand::SetLoopStart { channel, value } => self.set_loop_start(channel, value),
+            MixerCommand::SetLoopEnd { channel, value } => self.set_loop_end(channel, value),
+            MixerCommand::SetSpeed { channel, speed } => self.set_speed(channel, speed),
+            MixerCommand::SetSourceBpm { channel, bpm } => self.set_source_bpm(channel, bpm),
+            MixerCommand::SetPitchMode { channel, mode } => self.set_pitch_mode(channel, mode),
+            MixerCommand::Restart { channel } => self.restart(channel),
+            MixerCommand::SetPosition { channel, value } => self.set_position(channel, value),
+            MixerCommand::QueueSwap {
+                channel,
+                buffer,
+                divisions,
+            } => {
+                self.queue_swap(channel, buffer, divisions);
+            }
+            MixerCommand::CancelQueuedSwap { channel } => self.cancel_queued_swap(channel),
+            MixerCommand::SetBpm { bpm } => self.set_bpm(bpm),
+            MixerCommand::ClipLoad {
+                column,
+                row,
+                buffer,
+                source_bpm,
+            } => {
+                self.clip_load(column, row, buffer, source_bpm);
+            }
+            MixerCommand::ClipUnload { column, row } => {
+                self.clip_unload(column, row);
+            }
+            MixerCommand::ClipClear => self.clip_clear(),
+            MixerCommand::ClipLaunch {
+                column,
+                row,
+                quantization,
+            } => {
+                self.clip_launch(column, row, quantization);
+            }
+            MixerCommand::ClipLaunchAt { column, row, beat } => {
+                self.clip_launch_at(column, row, beat);
+            }
+            MixerCommand::ClipLaunchScene { row, quantization } => {
+                self.clip_launch_scene(row, quantization);
+            }
+            MixerCommand::ClipLaunchSceneAt { row, beat } => {
+                self.clip_launch_scene_at(row, beat);
+            }
+            MixerCommand::ClipStop {
+                column,
+                quantization,
+            } => {
+                self.clip_stop(column, quantization);
+            }
+            MixerCommand::ClipStopAt { column, beat } => {
+                self.clip_stop_at(column, beat);
+            }
+            MixerCommand::ClipCancel { column } => self.clip_cancel(column),
+            MixerCommand::ClipCancelAll => self.clip_cancel_all(),
+            MixerCommand::ClipSetDefaultQuantization { quantization } => {
+                self.clip_set_default_quantization(quantization)
+            }
+            MixerCommand::ClipSetTrim {
+                column,
+                row,
+                start,
+                end,
+                timing,
+            } => {
+                self.clip_set_trim(column, row, start, end, timing);
+            }
+            MixerCommand::TransportStart => self.transport_start(),
+            MixerCommand::TransportStop => self.transport_stop(),
+            MixerCommand::TransportSeek { beat } => {
+                self.transport_seek(beat);
+            }
+            MixerCommand::TransportReset => self.transport_reset(),
+            MixerCommand::EffectAdd { channel, effect_id } => {
+                self.effect_add(channel, effect_id);
+            }
+            MixerCommand::EffectRemove { channel, slot } => {
+                self.effect_remove(channel, slot);
+            }
+            MixerCommand::EffectMove {
+                channel,
+                slot,
+                new_position,
+            } => {
+                self.effect_move(channel, slot, new_position);
+            }
+            MixerCommand::EffectClear { channel } => self.effect_clear(channel),
+            MixerCommand::EffectSetParam {
+                channel,
+                slot,
+                param,
+                value,
+            } => self.effect_set_param(channel, slot, param, value),
         }
     }
 
     /// Sum all channels into one stereo frame, honoring mute/solo: if any channel
     /// is soloed, only soloed channels sound; otherwise all un-muted channels do.
     pub fn tick(&mut self, engine_sample_rate: f32) -> StereoFrame {
+        // Apply any control-thread commands first, so this sample already
+        // reflects them and all mixer mutation stays on the audio thread.
+        self.apply_pending();
         self.clip_grid.before_tick(&mut self.channels);
         let any_solo = self.channels.iter().any(LoopChannel::is_soloed);
         let mut out = StereoFrame::default();
@@ -71,7 +215,89 @@ impl Mixer {
             out += channel.tick(engine_sample_rate);
         }
         self.clip_grid.after_tick();
+        self.publish_snapshot();
         out
+    }
+
+    fn publish_snapshot(&self) {
+        let snapshot = self.control.snapshot();
+        snapshot.begin_write();
+        for channel in 0..LOOP_CHANNEL_COUNT {
+            let ch = &self.channels[channel];
+            snapshot.loop_position[channel].store(
+                ch.position_normalized().to_bits(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            snapshot.loop_source_bpm[channel].store(
+                ch.source_bpm().unwrap_or(0.0).to_bits(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            let mode = match ch.pitch_mode() {
+                PitchMode::Off => 0,
+                PitchMode::Resample => 1,
+                PitchMode::PreservePitch => 2,
+            };
+            snapshot.loop_pitch_mode[channel].store(mode, std::sync::atomic::Ordering::Relaxed);
+            snapshot.swaps_completed[channel]
+                .store(ch.swaps_completed(), std::sync::atomic::Ordering::Relaxed);
+        }
+        snapshot.default_quantization.store(
+            self.clip_grid.default_quantization().id(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        snapshot.transport_beat.store(
+            self.clip_grid.transport_beat().to_bits(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        for column in 0..CLIP_COLUMN_COUNT {
+            snapshot.active_row[column].store(
+                self.clip_grid.active_row(column).map_or(-1, |v| v as i32),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            snapshot.queued_row[column].store(
+                self.clip_grid.queued_row(column).map_or(-1, |v| v as i32),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            snapshot.stop_queued[column].store(
+                self.clip_grid.is_stop_queued(column),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            snapshot.scheduled_beat[column].store(
+                self.clip_grid
+                    .scheduled_beat(column)
+                    .unwrap_or(-1.0)
+                    .to_bits(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            snapshot.active_playhead[column].store(
+                self.clip_grid
+                    .active_playhead(column, &self.channels)
+                    .unwrap_or(-1.0)
+                    .to_bits(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            for row in 0..CLIP_ROW_COUNT {
+                snapshot.slot_state[column][row].store(
+                    self.clip_grid.slot_state(column, row),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                snapshot.trim_start[column][row].store(
+                    self.clip_grid
+                        .trim_start(column, row)
+                        .unwrap_or(-1.0)
+                        .to_bits(),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                snapshot.trim_end[column][row].store(
+                    self.clip_grid
+                        .trim_end(column, row)
+                        .unwrap_or(-1.0)
+                        .to_bits(),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+            }
+        }
+        snapshot.finish_write();
     }
 
     /// Update the tempo for the mixer: re-tempo every existing note-synced
@@ -448,6 +674,13 @@ impl Mixer {
         preroll: usize,
         out: &mut Vec<f32>,
     ) -> bool {
+        // This path is explicitly offline-only, so it may synchronously drain
+        // controls before directly driving a channel. Never call it alongside
+        // realtime `tick` on the same mixer.
+        while self.control.has_pending() {
+            self.apply_pending();
+        }
+        self.publish_snapshot();
         let sample_rate = self.sample_rate;
         let Some(ch) = self.channels.get_mut(channel) else {
             return false;
@@ -491,6 +724,79 @@ mod tests {
     fn default_channel_count() {
         let mixer = Mixer::new(SR);
         assert_eq!(mixer.channel_count(), LOOP_CHANNEL_COUNT);
+    }
+
+    #[test]
+    fn enqueued_command_applies_on_next_tick() {
+        let mut mixer = Mixer::new(SR);
+        mixer.control().set_pitch_mode(0, PitchMode::PreservePitch);
+        // Not applied until the audio thread drains the queue in `tick`.
+        assert_eq!(mixer.pitch_mode(0), PitchMode::Off);
+        mixer.tick(SR);
+        assert_eq!(mixer.pitch_mode(0), PitchMode::PreservePitch);
+    }
+
+    #[test]
+    fn enqueued_commands_apply_in_fifo_order() {
+        let mut mixer = Mixer::new(SR);
+        let control = mixer.control();
+        control.set_gain(0, 0.2);
+        control.set_gain(0, 0.7);
+        mixer.tick(SR);
+        // Last write wins iff commands ran in enqueue order.
+        let gain = mixer.channel(0).unwrap().gain();
+        assert!((gain - 0.7).abs() < 1e-6, "expected 0.7, got {gain}");
+    }
+
+    #[test]
+    fn enqueued_load_defers_until_tick() {
+        let mut mixer = Mixer::new(SR);
+        let buf = dc_buffer(0.5, 64);
+        mixer.control().load(0, buf);
+        assert!(!mixer.channel(0).unwrap().has_buffer());
+        mixer.tick(SR);
+        assert!(mixer.channel(0).unwrap().has_buffer());
+    }
+
+    #[test]
+    fn control_batch_is_bounded_and_fifo() {
+        let mut mixer = Mixer::new(SR);
+        let control = mixer.control();
+        for i in 0..=control::MAX_COMMANDS_PER_TICK {
+            assert!(control.set_gain(0, i as f32 / 100.0));
+        }
+        mixer.tick(SR);
+        assert!((mixer.channel(0).unwrap().gain() - 0.63).abs() < 1e-6);
+        mixer.tick(SR);
+        assert!((mixer.channel(0).unwrap().gain() - 0.64).abs() < 1e-6);
+    }
+
+    #[test]
+    fn control_snapshot_is_published_after_audio_tick() {
+        let mut mixer = Mixer::new(SR);
+        let control = mixer.control();
+        assert!(control.load(0, dc_buffer(0.5, 128)));
+        assert!(control.set_source_bpm(0, Some(123.0)));
+        assert!(control.set_pitch_mode(0, PitchMode::PreservePitch));
+        assert_eq!(
+            control.source_bpm(0),
+            0.0,
+            "snapshot precedes audio application"
+        );
+        mixer.tick(SR);
+        assert_eq!(control.source_bpm(0), 123.0);
+        assert_eq!(control.pitch_mode(0), PitchMode::PreservePitch);
+        assert!(control.position(0).is_finite());
+    }
+
+    #[test]
+    fn clip_snapshot_does_not_read_live_grid() {
+        let mut mixer = Mixer::new(SR);
+        let control = mixer.control();
+        assert!(control.clip_load(0, 0, dc_buffer(0.5, 128), 120.0));
+        assert_eq!(control.clip_slot_state(0, 0), 0);
+        mixer.tick(SR);
+        assert_eq!(control.clip_slot_state(0, 0), CLIP_STATE_LOADED);
     }
 
     #[test]

--- a/tests/clip_grid.rs
+++ b/tests/clip_grid.rs
@@ -53,6 +53,10 @@ fn constants_and_load_validation_are_stable() {
         let engine = gooey_engine_new(SR);
         let samples = mono_clip(0.5, 1000);
 
+        // An empty slot is rejected synchronously even though valid launches
+        // are applied asynchronously at the next render boundary.
+        assert!(!gooey_engine_clip_launch(engine, 0, 0, CLIP_QUANTIZE_BAR,));
+
         assert!(!gooey_engine_clip_load(
             engine,
             CLIP_COLUMN_COUNT,

--- a/tests/clip_grid.rs
+++ b/tests/clip_grid.rs
@@ -96,6 +96,7 @@ fn constants_and_load_validation_are_stable() {
         assert_eq!(gooey_engine_clip_get_state(engine, 0, 0), 0);
 
         let _samples = load(engine, 0, 0, 0.5, 1000, 60.0);
+        let _ = render(engine, 1);
         assert_eq!(gooey_engine_clip_get_state(engine, 0, 0), CLIP_STATE_LOADED);
         assert_eq!(
             gooey_engine_clip_get_default_quantization(engine),
@@ -103,6 +104,7 @@ fn constants_and_load_validation_are_stable() {
         );
         assert!(!gooey_engine_clip_set_default_quantization(engine, 99));
         gooey_engine_clip_clear(engine);
+        let _ = render(engine, 1);
         assert_eq!(gooey_engine_clip_get_state(engine, 0, 0), 0);
         gooey_engine_free(engine);
     }
@@ -114,9 +116,6 @@ fn stopped_launch_starts_empty_column_on_first_transport_sample() {
         let engine = gooey_engine_new(SR);
         let _samples = load(engine, 0, 0, 0.5, 4000, 60.0);
         assert!(gooey_engine_clip_launch(engine, 0, 0, CLIP_QUANTIZE_BAR));
-        assert_eq!(gooey_engine_clip_get_active_row(engine, 0), -1);
-        assert_eq!(gooey_engine_clip_get_queued_row(engine, 0), 0);
-        assert_eq!(gooey_engine_clip_get_scheduled_beat(engine, 0), 0.0);
 
         gooey_engine_sequencer_start(engine);
         let _ = render(engine, 1);
@@ -140,6 +139,7 @@ fn running_bar_requests_are_strictly_future_even_on_a_bar_boundary() {
         let _ = render(engine, 4_000); // exactly beat 4
         assert!((gooey_engine_transport_get_beat_position(engine) - 4.0).abs() < 1e-9);
         assert!(gooey_engine_clip_launch(engine, 0, 0, CLIP_QUANTIZE_BAR));
+        let _ = render(engine, 1);
         assert_eq!(gooey_engine_clip_get_scheduled_beat(engine, 0), 8.0);
         gooey_engine_free(engine);
     }
@@ -182,9 +182,12 @@ fn quantized_and_exact_launches_cross_render_boundaries() {
         gooey_engine_sequencer_start(engine);
         let _ = render(engine, 100); // beat 0.1
         assert!(gooey_engine_clip_launch(engine, 0, 0, quantization));
+        let _ = render(engine, 1);
         assert!((gooey_engine_clip_get_scheduled_beat(engine, 0) - expected_beat).abs() < 1e-9);
 
-        let frames_to_boundary = ((expected_beat - 0.1) * SR as f64) as usize;
+        let frames_to_boundary =
+            ((expected_beat - gooey_engine_transport_get_beat_position(engine)) * SR as f64).ceil()
+                as usize;
         let _ = render(engine, frames_to_boundary);
         assert_eq!(gooey_engine_clip_get_active_row(engine, 0), -1);
         let _ = render(engine, 1);
@@ -204,8 +207,9 @@ fn quantized_and_exact_launches_cross_render_boundaries() {
         let _ = render(engine, 100);
         assert!(gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.333));
         assert!(!gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.05));
+        let _ = render(engine, 1);
         assert!((gooey_engine_clip_get_scheduled_beat(engine, 0) - 0.333).abs() < 1e-9);
-        let _ = render(engine, 233);
+        let _ = render(engine, 232);
         assert_eq!(gooey_engine_clip_get_active_row(engine, 0), -1);
         let _ = render(engine, 1);
         assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
@@ -222,7 +226,6 @@ fn column_is_mutually_exclusive_and_latest_request_wins() {
         let _b = load(engine, 0, 1, 0.75, 4000, 60.0);
         assert!(gooey_engine_clip_launch_at_beat(engine, 0, 0, 0.0));
         assert!(gooey_engine_clip_launch_at_beat(engine, 0, 1, 0.0));
-        assert_eq!(gooey_engine_clip_get_queued_row(engine, 0), 1);
         gooey_engine_sequencer_start(engine);
         let _ = render(engine, 1);
         assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 1);
@@ -265,10 +268,11 @@ fn scene_launch_is_atomic_and_empty_cells_stop_columns() {
 
         buffers.push(load(engine, 0, 1, 0.9, 4000, 60.0));
         assert!(gooey_engine_clip_launch_scene_at_beat(engine, 1, 0.25));
+        let _ = render(engine, 1);
         for column in 1..CLIP_COLUMN_COUNT {
             assert!(gooey_engine_clip_is_stop_queued(engine, column));
         }
-        let _ = render(engine, 249);
+        let _ = render(engine, 248);
         for column in 0..CLIP_COLUMN_COUNT {
             assert_eq!(gooey_engine_clip_get_active_row(engine, column), 0);
         }
@@ -324,12 +328,13 @@ fn active_replace_relaunch_and_unload_are_quantized() {
         let _ = render(engine, 100);
 
         let _replacement = load(engine, 0, 0, 0.75, 4000, 60.0);
+        let _ = render(engine, 1);
         assert_eq!(
             gooey_engine_clip_get_state(engine, 0, 0),
             CLIP_STATE_LOADED | CLIP_STATE_PLAYING | CLIP_STATE_QUEUED
         );
         assert!((gooey_engine_clip_get_scheduled_beat(engine, 0) - 0.25).abs() < 1e-9);
-        let _ = render(engine, 150);
+        let _ = render(engine, 149);
         assert_ne!(
             gooey_engine_clip_get_state(engine, 0, 0) & CLIP_STATE_QUEUED,
             0
@@ -346,6 +351,7 @@ fn active_replace_relaunch_and_unload_are_quantized() {
             0,
             CLIP_QUANTIZE_SIXTEENTH
         ));
+        let _ = render(engine, 1);
         assert_ne!(
             gooey_engine_clip_get_state(engine, 0, 0) & CLIP_STATE_QUEUED,
             0
@@ -353,6 +359,7 @@ fn active_replace_relaunch_and_unload_are_quantized() {
         gooey_engine_clip_cancel(engine, 0);
 
         assert!(gooey_engine_clip_unload(engine, 0, 0));
+        let _ = render(engine, 1);
         assert!(gooey_engine_clip_is_stop_queued(engine, 0));
         let target = gooey_engine_clip_get_scheduled_beat(engine, 0);
         let current = gooey_engine_transport_get_beat_position(engine);
@@ -375,6 +382,7 @@ fn legacy_playhead_mutation_detaches_grid_state_but_keeps_slots() {
         assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
 
         gooey_engine_loop_set_position(engine, 0, 0.5);
+        let _ = render(engine, 1);
         assert_eq!(gooey_engine_clip_get_active_row(engine, 0), -1);
         assert_eq!(gooey_engine_clip_get_state(engine, 0, 0), CLIP_STATE_LOADED);
         gooey_engine_free(engine);
@@ -436,6 +444,7 @@ fn trim_validation_and_round_trip() {
     unsafe {
         let engine = gooey_engine_new(SR);
         let _samples = load(engine, 0, 0, 0.5, 1000, 60.0);
+        let _ = render(engine, 1);
 
         // Fresh slot defaults to the full [0, 1) buffer.
         assert_eq!(gooey_engine_clip_get_trim_start(engine, 0, 0), 0.0);
@@ -450,6 +459,7 @@ fn trim_validation_and_round_trip() {
             0.8,
             CLIP_QUANTIZE_IMMEDIATE
         ));
+        let _ = render(engine, 1);
         assert_eq!(gooey_engine_clip_get_trim_start(engine, 0, 0), 0.2);
         assert_eq!(gooey_engine_clip_get_trim_end(engine, 0, 0), 0.8);
 
@@ -474,6 +484,7 @@ fn trim_validation_and_round_trip() {
 
         // Reloading a slot resets its trim to the full buffer.
         let _reload = load(engine, 0, 0, 0.5, 1000, 60.0);
+        let _ = render(engine, 1);
         assert_eq!(gooey_engine_clip_get_trim_start(engine, 0, 0), 0.0);
         assert_eq!(gooey_engine_clip_get_trim_end(engine, 0, 0), 1.0);
 
@@ -546,6 +557,7 @@ fn immediate_retrim_applies_playing_and_stopped() {
             0.95,
             CLIP_QUANTIZE_IMMEDIATE
         ));
+        let _ = render(engine, 1);
         assert!(gooey_engine_loop_get_position(engine, 0) >= 0.8);
         assert_eq!(gooey_engine_clip_get_active_row(engine, 0), 0);
         gooey_engine_free(engine);
@@ -569,6 +581,7 @@ fn immediate_retrim_applies_playing_and_stopped() {
             0.95,
             CLIP_QUANTIZE_IMMEDIATE
         ));
+        let _ = render(engine, 1);
         assert!(gooey_engine_loop_get_position(engine, 0) >= 0.8);
         gooey_engine_free(engine);
     }

--- a/tests/loop_mixer.rs
+++ b/tests/loop_mixer.rs
@@ -595,6 +595,9 @@ fn queued_swap_lands_in_preserve_pitch_mode() {
         gooey_engine_set_bpm(engine, 140.0);
         gooey_engine_loop_set_pitch_mode(engine, 0, PITCH_MODE_PRESERVE_PITCH);
         gooey_engine_loop_set_playing(engine, 0, true);
+        // Loop controls apply at the audio boundary; publish a snapshot before
+        // observing the resulting pitch mode through the FFI getter.
+        let _ = render_peak(engine, 1);
         assert_eq!(
             gooey_engine_loop_get_pitch_mode(engine, 0),
             PITCH_MODE_PRESERVE_PITCH
@@ -650,6 +653,9 @@ fn queued_swap_preserves_source_bpm_tag() {
         gooey_engine_set_bpm(engine, 150.0);
         gooey_engine_loop_set_pitch_mode(engine, 0, PITCH_MODE_RESAMPLE);
         gooey_engine_loop_set_playing(engine, 0, true);
+        // Source BPM is a published audio-thread snapshot, not an immediate
+        // control-thread read of the live channel.
+        let _ = render_peak(engine, 1);
         assert_eq!(gooey_engine_loop_get_source_bpm(engine, 0), 100.0);
 
         // Queue a take tagged at a different tempo (128 BPM) and let it land.

--- a/tests/loop_mixer_concurrency.rs
+++ b/tests/loop_mixer_concurrency.rs
@@ -1,0 +1,49 @@
+//! Regression coverage for concurrent loop controls and realtime rendering.
+
+use gooey::mixer::{Mixer, PitchMode, StereoSampleBuffer};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+const SR: f32 = 48_000.0;
+
+fn sine(frames: usize) -> StereoSampleBuffer {
+    let left: Vec<f32> = (0..frames).map(|i| (i as f32 * 0.02).sin()).collect();
+    StereoSampleBuffer::from_channels(left.clone(), left, SR).unwrap()
+}
+
+#[test]
+fn concurrent_control_and_render_is_crash_free() {
+    let mut mixer = Mixer::new(SR);
+    mixer.load(0, sine(4000));
+    mixer.set_pitch_mode(0, PitchMode::PreservePitch);
+    mixer.set_playing(0, true);
+
+    // The producer owns only this handle, never a reference or pointer to the
+    // live mixer. The audio thread remains the sole `Mixer` mutator.
+    let control = mixer.control();
+    let start = Arc::new(Barrier::new(2));
+    let worker_start = start.clone();
+    let control_thread = thread::spawn(move || {
+        worker_start.wait();
+        for _ in 0..512 {
+            assert!(control.set_pitch_mode(0, PitchMode::PreservePitch));
+            assert!(control.restart(0));
+            assert!(control.load(0, sine(4000)));
+            assert!(control.set_pitch_mode(0, PitchMode::Off));
+            assert!(control.set_pitch_mode(0, PitchMode::PreservePitch));
+            assert!(control.set_playing(0, true));
+        }
+    });
+
+    start.wait();
+    for _ in 0..20_000 {
+        let frame = mixer.tick(SR);
+        assert!(frame.l.is_finite() && frame.r.is_finite());
+    }
+    control_thread.join().unwrap();
+    // Drain any commands that were produced near the end of the render loop.
+    for _ in 0..128 {
+        let frame = mixer.tick(SR);
+        assert!(frame.l.is_finite() && frame.r.is_finite());
+    }
+}


### PR DESCRIPTION
Routes loop and clip mutations through a bounded typed command queue owned by the audio thread, while FFI getters read atomically published snapshots.

This eliminates concurrent live-DSP mutation behind PreservePitch, including stretcher and buffer replacement races, and preserves FIFO projected effect-slot edits.

Offline WAV export synchronously drains queued commands on disposable engines, and new queue, snapshot, clip-grid, and concurrent-render tests cover the behavior.

Validated with cargo build, the native kick example build, cargo test --verbose, targeted loop/clip/WAV tests, and formatting checks; all-target Clippy remains blocked by pre-existing unrelated lint failures.