### PR TITLE
Preserve phase on queued loop swaps

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -7505,7 +7505,8 @@ pub unsafe extern "C" fn gooey_engine_loop_set_position(
 /// boundary. `divisions` splits the loop region into equal segments (pass the
 /// loop's bar count for bar-quantized swaps; 1 for whole-phrase). When the playing
 /// cursor next crosses a segment boundary, the queued buffer becomes active and its
-/// playhead resets to the loop start (restart from the top on the downbeat).
+/// playhead enters at the corresponding phase of its loop window. A whole-phrase
+/// swap therefore still enters at the loop start when the cursor wraps.
 /// Replaces any previously-queued buffer on the channel. Returns false on a null
 /// engine, bad channel, or empty buffer. Samples are interleaved, `channels` deep.
 ///

--- a/src/mixer/loop_channel.rs
+++ b/src/mixer/loop_channel.rs
@@ -261,14 +261,15 @@ impl LoopChannel {
         // this for the resample/off paths; the WSOLA path bypasses `advance`, so we
         // check here too — otherwise a queued swap could never land while a channel
         // is in PreservePitch mode. `maybe_swap_pending` resets the stretcher on a
-        // swap so the next tick re-seeds on the new buffer at its loop start.
+        // swap so the next tick re-seeds on the new buffer at the matching phrase
+        // phase.
         //
         // Note: `self.cursor` only advances on hop refills (~`wsola::HOP_MS`), so in
         // this mode the boundary check is at hop granularity — a queued swap can land
         // up to one hop after the exact grid sample, whereas the resample/off paths
-        // are sample-accurate. This is accepted: the swap restarts the phrase from the
-        // loop start (already a deliberate discontinuity), and sub-hop precision would
-        // require splitting an overlap-add hop for no meaningful audible gain.
+        // are sample-accurate. This is accepted: preserving the current phrase phase
+        // avoids a forced restart, and sub-hop precision would require splitting an
+        // overlap-add hop for no meaningful audible gain.
         let span = window.span.max(1.0);
         // Feed `maybe_swap_pending` virtual offsets. The non-wrap branch passes
         // `prev - lo` / `cursor - lo`, byte-identical to the previous internal
@@ -331,9 +332,9 @@ impl LoopChannel {
     }
 
     /// If a queued buffer is waiting and this sample crossed a bar-grid boundary
-    /// (or wrapped the loop), swap it in and restart the phrase from the loop
-    /// start — the sample-accurate, click-free downbeat swap. Gated by an atomic
-    /// flag so the nothing-queued path never locks.
+    /// (or wrapped the loop), swap it in at the corresponding phrase phase — the
+    /// sample-accurate, click-free downbeat swap. Gated by an atomic flag so the
+    /// nothing-queued path never locks.
     fn maybe_swap_pending(&mut self, prev_v: f64, cur_v: f64, span: f64, wrapped: bool) {
         if !self.has_pending.load(Ordering::Acquire) {
             return;
@@ -349,9 +350,14 @@ impl LoopChannel {
         // boundary; a missed lock just defers the swap to the next boundary.
         if let Ok(mut pending) = self.pending.try_lock() {
             if let Some(buffer) = pending.take() {
-                let new_lo = self.window(buffer.len() as f64).lo;
+                // `cur_v` is already in virtual loop-window coordinates. This is
+                // `(cursor - lo) / span` for ordinary windows, and continues to
+                // express the same musical phase through a wrapped buffer seam.
+                let phase = (cur_v / span).clamp(0.0, 1.0);
+                let new_window = self.window(buffer.len() as f64);
+                let new_span = new_window.span.max(1.0);
                 self.buffer = Some(buffer);
-                self.cursor = new_lo;
+                self.cursor = new_window.to_physical(phase * new_span);
                 // The buffer/cursor moved externally; drop any WSOLA stretcher so
                 // the PreservePitch path re-seeds on the new buffer (mirrors
                 // `set_buffer`/`restart`/`set_position`). No-op for other modes.
@@ -762,6 +768,25 @@ mod tests {
             (24..=27).contains(&idx),
             "swapped at frame {idx}, expected ~25"
         );
+    }
+
+    #[test]
+    fn queued_swap_preserves_phrase_phase() {
+        let mut ch = LoopChannel::new(SR);
+        ch.set_buffer(ramp_buffer(100));
+        ch.set_playing(true);
+        // The first four-division boundary is frame 25. Queue another ramp so
+        // the incoming sample directly exposes the cursor selected at the swap.
+        ch.queue_swap(ramp_buffer(100), 4);
+
+        // Tick 24 reads the outgoing frame 24, then advances across frame 25
+        // and performs the swap. The following tick must read incoming frame 25,
+        // not restart at incoming frame 0.
+        for _ in 0..25 {
+            ch.tick(SR);
+        }
+        assert_eq!(ch.swaps_completed(), 1);
+        assert_eq!(ch.tick(SR).l, 25.0);
     }
 
     #[test]

--- a/src/mixer/loop_channel.rs
+++ b/src/mixer/loop_channel.rs
@@ -353,7 +353,10 @@ impl LoopChannel {
                 // `cur_v` is already in virtual loop-window coordinates. This is
                 // `(cursor - lo) / span` for ordinary windows, and continues to
                 // express the same musical phase through a wrapped buffer seam.
-                let phase = (cur_v / span).clamp(0.0, 1.0);
+                // `rem_euclid` also maps the exclusive end (`phase == 1.0`),
+                // which reverse playback can produce on an exact wrap, back to
+                // the loop start.
+                let phase = (cur_v / span).rem_euclid(1.0);
                 let new_window = self.window(buffer.len() as f64);
                 let new_span = new_window.span.max(1.0);
                 self.buffer = Some(buffer);
@@ -787,6 +790,25 @@ mod tests {
         }
         assert_eq!(ch.swaps_completed(), 1);
         assert_eq!(ch.tick(SR).l, 25.0);
+    }
+
+    #[test]
+    fn queued_swap_reverse_wrap_normalizes_to_loop_start() {
+        let mut ch = LoopChannel::new(SR);
+        // Exact markers make the active window [2, 4). Starting at frame 2 and
+        // advancing in reverse by two frames wraps to the exclusive end, frame 4.
+        ch.set_loop_start(0.25);
+        ch.set_loop_end(0.5);
+        ch.set_buffer(ramp_buffer(8));
+        ch.set_speed(-2.0);
+        ch.set_playing(true);
+        ch.queue_swap(ramp_buffer(8), 1);
+
+        ch.tick(SR); // reads outgoing frame 2, then swaps on the reverse wrap
+        assert_eq!(ch.swaps_completed(), 1);
+        // Phase 1 is the exclusive loop end, so the incoming phrase restarts at
+        // its loop start rather than reading frame 4 outside the window.
+        assert_eq!(ch.tick(SR).l, 2.0);
     }
 
     #[test]


### PR DESCRIPTION
Queued loop-buffer swaps now preserve the active loop-window phase at bar-grid boundaries, including wrapped windows. This avoids restarting transformed takes at frame zero while retaining whole-phrase swaps at phase zero on wrap. A ramp-buffer regression test verifies the first incoming sample is the expected phase rather than frame zero. Validated with `cargo test --lib mixer::loop_channel::tests -- --nocapture` (19 tests).